### PR TITLE
module: add options for configs in HOME, XDG_CONFIG_HOME, XDG_DATA_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Configuration is broken down into three layers:
      ```nix
      {
        programs.plasma = {
-         files."baloofilerc"."Basic Settings"."Indexing-Enabled" = false;
+         configFile."baloofilerc"."Basic Settings"."Indexing-Enabled" = false;
        };
      }
      ```

--- a/example/home.nix
+++ b/example/home.nix
@@ -27,6 +27,6 @@
     };
 
     # A low-level setting:
-    files."baloofilerc"."Basic Settings"."Indexing-Enabled" = false;
+    configFile."baloofilerc"."Basic Settings"."Indexing-Enabled" = false;
   };
 }

--- a/lib/kwriteconfig.nix
+++ b/lib/kwriteconfig.nix
@@ -34,7 +34,7 @@ let
     lib.concatStringsSep "\n" (lib.mapAttrsToList
       (key: value: ''
         ${pkgs.libsForQt5.kconfig}/bin/kwriteconfig5 \
-          --file ''${XDG_CONFIG_HOME:-$HOME/.config}/${lib.escapeShellArg file} \
+          --file ${lib.escapeShellArg file} \
           ${lib.concatMapStringsSep " " (g: "--group " + lib.escapeShellArg g) groups} \
           --key ${lib.escapeShellArg key} \
           ${toKdeValue value}

--- a/modules/hotkeys.nix
+++ b/modules/hotkeys.nix
@@ -105,6 +105,6 @@ in
   config = lib.mkIf
     (cfg.enable && builtins.length (builtins.attrNames cfg.hotkeys.commands) != 0)
     {
-      programs.plasma.files.khotkeysrc = hotkeys;
+      programs.plasma.configFile.khotkeysrc = hotkeys;
     };
 }

--- a/modules/shortcuts.nix
+++ b/modules/shortcuts.nix
@@ -43,7 +43,7 @@ in
   };
 
   config = lib.mkIf (cfg.enable && builtins.attrNames cfg.shortcuts != 0) {
-    programs.plasma.files."kglobalshortcutsrc" =
+    programs.plasma.configFile."kglobalshortcutsrc" =
       shortcutsToSettings cfg.shortcuts;
   };
 }

--- a/modules/windows.nix
+++ b/modules/windows.nix
@@ -17,7 +17,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    programs.plasma.files = {
+    programs.plasma.configFile = {
       kdeglobals = {
         General.AllowKDEAppsToRememberWindowPositions =
           lib.mkDefault cfg.windows.allowWindowsToRememberPositions;

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -16,7 +16,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    programs.plasma.files.kdeglobals = {
+    programs.plasma.configFile.kdeglobals = {
       KDE.SingleClick = lib.mkDefault (cfg.workspace.clickItemTo == "open");
     };
   };

--- a/script/rc2nix.rb
+++ b/script/rc2nix.rb
@@ -189,7 +189,7 @@ module Rc2Nix
       puts("    shortcuts = {")
       pp_shortcuts(settings["kglobalshortcutsrc"], 6)
       puts("    };")
-      puts("    files = {")
+      puts("    configFile = {")
       pp_settings(settings, 6)
       puts("    };")
       puts("  };")


### PR DESCRIPTION
Certain applications, such as konsole, store some configuration in XDG_DATA_HOME (`~/.local/share/konsole`).
Currently, plasma-manger can only define config files in XDG_CONFIG_HOME.

This PR adds 2 new options for defining configurations
- `plasma.dataFile` for configuration files residing in XDG_DATA_HOME.
- `plasma.file` for any configuration files relative to HOME, to handle edge cases where applications put their data somewhere not covered by the other options.

I renamed the original `plasma.files` option to `plasma.configFile` (using `mkRenamedOptionModule`) to be more consistent with the new options and with the home-manager equivalent (`xdg.configFile`), but I can revert that if you do not want the option name to change.

I couldn't get the check script to run even before my changes, but some manual testing suggests that  the changes are working correctly.