### PR TITLE
allow escaping .

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -25,7 +25,12 @@ let
     options = {
       configGroupNesting = lib.mkOption {
         type = lib.types.nonEmptyListOf lib.types.str;
-        default = (lib.splitString "." name);
+        default = (map 
+                    (e: builtins.replaceStrings ["\\u002E"] ["."] e) 
+                    (lib.splitString "." 
+                      (builtins.replaceStrings ["\\."] ["\\u002E"] name)
+                    )
+                  );
         description = "Group name, and sub-group names.";
       };
     };

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -25,6 +25,7 @@ let
     options = {
       configGroupNesting = lib.mkOption {
         type = lib.types.nonEmptyListOf lib.types.str;
+        # We allow escaping periods using \\.
         default = (map 
                     (e: builtins.replaceStrings ["\\u002E"] ["."] e) 
                     (lib.splitString "." 


### PR DESCRIPTION
As explained in #33, there are plenty of categories which contains dot in the name.
That's why I modified the files.nix to be able to escape dots if we like.