### PR TITLE
example: add example with escaped dots

### DIFF
--- a/example/home.nix
+++ b/example/home.nix
@@ -27,6 +27,10 @@
     };
 
     # A low-level setting:
-    configFile."baloofilerc"."Basic Settings"."Indexing-Enabled" = false;
+    configFile = {
+      "baloofilerc"."Basic Settings"."Indexing-Enabled" = false;
+      # If a group name has dots you need to escape them
+      "kwinrc"."org\\.kde\\.kdecoration2"."ButtonsOnLeft" = "SF";
+    };
   };
 }


### PR DESCRIPTION
We recently added a way to use group names that have dots, but we don't mention that anywhere in our documentation.
This fixes that