### PR TITLE
Add overrideConfig option for only adding configuration through plasma-manager

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -116,12 +116,11 @@ in
     (lib.mkRenamedOptionModule [ "programs" "plasma" "files" ] [ "programs" "plasma" "configFile" ])
   ];
 
-  config = {
-    home.activation.configure-plasma = lib.mkIf (builtins.length (builtins.attrNames cfg) > 0)
-      (lib.hm.dag.entryAfter [ "writeBoundary" ]
-        ''
-          $DRY_RUN_CMD ${if config.programs.plasma.overrideConfig then resetScript else ""}
-          $DRY_RUN_CMD ${script}
-        '');
+  config = lib.mkIf (plasmaCfg.enable && (builtins.length (builtins.attrNames cfg) > 0)) {
+    home.activation.configure-plasma = (lib.hm.dag.entryAfter [ "writeBoundary" ]
+      ''
+        $DRY_RUN_CMD ${if config.programs.plasma.overrideConfig then resetScript else ""}
+        $DRY_RUN_CMD ${script}
+      '');
   };
 }

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -101,13 +101,13 @@ in
         represent configuration groups and settings inside those groups.
       '';
     };
-    declarative = lib.mkOption {
+    overrideConfig = lib.mkOption {
       type = lib.types.bool;
       default = false;
       description = ''
-        Wether to. If enabled only the explicitly set attributes will be applied,
-        while everything else will lean back on the default. This should give more
-        declarative.
+        Wether to discard changes made outside plasma-manager. If enabled all
+        settings not specified explicitly in plasma-manager will be set to the
+        default on next login.
       '';
     };
   };
@@ -120,7 +120,7 @@ in
     home.activation.configure-plasma = lib.mkIf (builtins.length (builtins.attrNames cfg) > 0)
       (lib.hm.dag.entryAfter [ "writeBoundary" ]
         ''
-          $DRY_RUN_CMD ${if config.programs.plasma.declarative then resetScript else ""}
+          $DRY_RUN_CMD ${if config.programs.plasma.overrideConfig then resetScript else ""}
           $DRY_RUN_CMD ${script}
         '');
   };


### PR DESCRIPTION
Addresses #32. I have tested it out and as far as I can tell it works fine. A little unsure about exactly which files should be reset and whatnot though. The setting is disabled by default (at the moment anyway)