### PR TITLE
Add better theming support all around

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Configuration is broken down into three layers:
            clickItemTo = "select";
            tooltipDelay = 5;
            theme = "breeze-dark";
-           colorscheme = "BreezeDark";
+           colorScheme = "BreezeDark";
+           wallpaper = "${pkgs.libsForQt5.plasma-workspace-wallpapers}/share/wallpapers/Kay/contents/images/1080x1920.png";
          };
 
          kwin.titlebarButtons = {


### PR DESCRIPTION
This pr adds some considerable changes to the workspace module, where we before simply wrote some changes to some config-files. This worked OK for desktop theme, and partially colorscheme, but for other settings like cursortheme, look and feel, icons and more there is no simple way to configure these using config-files only (that I have found at least). I have therefore replaced these methods by creating a script in `~/.local/share/plasma-manager/apply_themes.sh` which is run on the next login (and never again after that) after the configuration is applied, using an autostart script. This script takes use of plasma cli tools like `plasma-apply-colorscheme`, `plasma-apply-cursortheme` and so on, which is a less hacky way of configuring the themes I reckon. At the moment you need to re-login for these changes to take effect, but probably in a later pr I will make it so that this script is ran immediately, granted that plasma is running (these tools only work when plasma is running, hence the use of autostart scripts here).

This solution seems to work very well, and I have tested all the options. In general this allows for much more advanced configuration, and as far as I have seen, it also appears to be less buggy :) 