### PR TITLE
Add startup module and refactor workspace module

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -9,6 +9,7 @@
     ./windows.nix
     ./workspace.nix
     ./kwin.nix
+    ./startup.nix
   ];
 
   options.programs.plasma.enable = lib.mkEnableOption ''

--- a/modules/startup.nix
+++ b/modules/startup.nix
@@ -1,0 +1,60 @@
+# Allows to run commands/scripts at startup (this is used by some of the other
+# modules, which may need to do this, but can also be used on its own)
+{ config, lib, ... }:
+let
+  cfg = config.programs.plasma;
+  topScriptName = "run_all.sh";
+in
+{
+  options.programs.plasma.startup = {
+    autoStartScript = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = "Commands/scripts to be run at startup.";
+    };
+    scriptsDir = lib.mkOption {
+      type = lib.types.str;
+      default = "scripts";
+      description = "The name of the subdirectory where the scripts should be.";
+    };
+  };
+
+  config = lib.mkIf
+    (cfg.enable && builtins.length (builtins.attrNames cfg.startup) != 0)
+    {
+      xdg.dataFile = lib.mkMerge [
+        (lib.mkMerge
+          (lib.mapAttrsToList
+            (name: content: {
+              "plasma-manager/${cfg.startup.scriptsDir}/${name}.sh" = {
+                text = ''
+                  #!/bin/sh
+                  ${content}
+                '';
+                executable = true;
+              };
+            })
+            cfg.startup.autoStartScript)
+        )
+        {
+          "plasma-manager/${topScriptName}" = {
+            text = ''
+              #!/bin/sh
+              for script in ${config.xdg.dataHome}/plasma-manager/${cfg.startup.scriptsDir}/*.sh; do
+                  [ -x "$script" ] && $script
+              done
+            '';
+            executable = true;
+          };
+        }
+      ];
+
+      xdg.configFile."autostart/plasma-manager-apply-themes.desktop".text = ''
+        [Desktop Entry]
+        Type=Application
+        Name=Plasma Manager theme application
+        Exec=${config.xdg.dataHome}/plasma-manager/${topScriptName}
+        X-KDE-autostart-condition=ksmserver
+      '';
+    };
+}

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -68,7 +68,6 @@ in
       '';
     };
 
-
     wallpaper = lib.mkOption {
       type = lib.types.nullOr lib.types.path;
       default = null;
@@ -103,37 +102,24 @@ in
         # kde tools. We then run this using an autostart script, where this is
         # run only on the first login, granted all the commands succeed (until
         # we change the settings again).
-        xdg.dataFile."plasma-manager/apply_themes.sh" = {
-          text = ''
-            #!/bin/sh
-            last_update=$(stat -c %Y ${config.xdg.dataHome}/plasma-manager/apply_themes.sh)
-            last_update_file=${config.xdg.dataHome}/plasma-manager/last_update
-            stored_last_update=0
-            if [ -f "$last_update_file" ]; then
-                stored_last_update=$(cat "$last_update_file")
-            fi
+        programs.plasma.startup.autoStartScript."apply_themes" = ''
+          last_update=$(stat -c %Y ${config.xdg.dataHome}/plasma-manager/${cfg.startup.scriptsDir}/apply_themes.sh)
+          last_update_file=${config.xdg.dataHome}/plasma-manager/last_update
+          stored_last_update=0
+          if [ -f "$last_update_file" ]; then
+              stored_last_update=$(cat "$last_update_file")
+          fi
 
-            if [ $last_update -gt $stored_last_update ]; then
-                success=1
-                ${if cfg.workspace.lookAndFeel != null then "plasma-apply-lookandfeel -a ${cfg.workspace.lookAndFeel} || success=0" else ""}
-                ${if cfg.workspace.theme != null then "plasma-apply-desktoptheme ${cfg.workspace.theme} || success=0" else ""}
-                ${if cfg.workspace.cursorTheme != null then "plasma-apply-cursortheme ${cfg.workspace.cursorTheme} || success=0" else ""}
-                ${if cfg.workspace.colorScheme != null then "plasma-apply-colorscheme ${cfg.workspace.colorScheme} || success=0" else ""}
-                ${if cfg.workspace.iconTheme != null then "${pkgs.libsForQt5.plasma-workspace}/libexec/plasma-changeicons ${cfg.workspace.iconTheme} || success=0" else ""}
-                ${if cfg.workspace.wallpaper != null then "plasma-apply-wallpaperimage ${cfg.workspace.wallpaper} || success=0" else ""}
-                [ $success = 1 ] && echo "$last_update" > "$last_update_file"
-            fi
-          '';
-          executable = true;
-        };
-        # Here comes the autostart-script for kde, which just runs the script
-        # above on startup.
-        xdg.configFile."autostart/plasma-manager-apply-themes.desktop".text = ''
-          [Desktop Entry]
-          Type=Application
-          Name=Plasma Manager theme application
-          Exec=${config.xdg.dataHome}/plasma-manager/apply_themes.sh
-          X-KDE-autostart-condition=ksmserver
+          if [ $last_update -gt $stored_last_update ]; then
+              success=1
+              ${if cfg.workspace.lookAndFeel != null then "plasma-apply-lookandfeel -a ${cfg.workspace.lookAndFeel} || success=0" else ""}
+              ${if cfg.workspace.theme != null then "plasma-apply-desktoptheme ${cfg.workspace.theme} || success=0" else ""}
+              ${if cfg.workspace.cursorTheme != null then "plasma-apply-cursortheme ${cfg.workspace.cursorTheme} || success=0" else ""}
+              ${if cfg.workspace.colorScheme != null then "plasma-apply-colorscheme ${cfg.workspace.colorScheme} || success=0" else ""}
+              ${if cfg.workspace.iconTheme != null then "${pkgs.libsForQt5.plasma-workspace}/libexec/plasma-changeicons ${cfg.workspace.iconTheme} || success=0" else ""}
+              ${if cfg.workspace.wallpaper != null then "plasma-apply-wallpaperimage ${cfg.workspace.wallpaper} || success=0" else ""}
+              [ $success = 1 ] && echo "$last_update" > "$last_update_file"
+          fi
         '';
       })
   ];


### PR DESCRIPTION
Adds a module which lets us add scripts/commands to be executed after logging in to kde plasma. This can be useful for for example running custom theme commands or something similar before the kde session is fully up and running. It will also come in handy when trying to create a module for configuring panels. I also refactored the workspace module to use this, as that makes more sense, and makes the code more clean.