### PR TITLE
Add per-widget customization options

### DIFF
--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -103,17 +103,6 @@ let
     };
   };
 
-  # Creates lines for changing the config of a widget in a layout.js. Here
-  # panel is the panel of the widget we are configuring for, widget is the full
-  # name of the widget, configGroup is the value of currentConfigGroup for the
-  # widget, while configKey and value are the key and value we want to set.
-  panelModifyConfig = panel: widget: configGroup: configKey: value:
-    if builtins.elem widget panel.widgets then ''
-      var w = panelWidgets["${widget}"]
-      w.currentConfigGroup = ${configGroup}
-      w.writeConfig("${configKey}", ${value})
-    '' else "";
-
   #
   # Functions to generate layout.js configurations from the widgetType
   #

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -4,6 +4,26 @@ with lib;
 
 let
   cfg = config.programs.plasma;
+
+  # Widget types
+  widgetType = lib.types.submodule {
+    options = {
+      name = lib.mkOption {
+        type = lib.types.str;
+        example = "org.kde.plasma.kickoff";
+        description = "The name of the widget to add.";
+      };
+      config = lib.mkOption {
+        type = with lib.types; nullOr (attrsOf (attrsOf (either str (listOf str))));
+        default = null;
+        example = {
+          General.icon = "nix-snowflake-white";
+        };
+        description = "Extra configuration-options for the widget.";
+      };
+    };
+  };
+
   panelType = lib.types.submodule {
     options = {
       height = lib.mkOption {
@@ -48,7 +68,7 @@ let
         description = "The hiding mode of the panel.";
       };
       widgets = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
+        type = with lib.types; listOf (either str widgetType);
         default = [
           "org.kde.plasma.kickoff"
           "org.kde.plasma.pager"
@@ -72,19 +92,6 @@ let
           plasma-workspace.
         '';
       };
-      iconTasksLaunchers = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        default = [ ];
-        example = [
-          "org.kde.dolphin.desktop"
-          "firefox.desktop"
-        ];
-        description = ''
-          The desktop-files to pin to the icontasks task-manager. For this to
-          have any effect, org.kde.plasma.icontasks must be included in the
-          widgets option.
-        '';
-      };
       extraSettings = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
         default = null;
@@ -95,12 +102,6 @@ let
       };
     };
   };
-
-  # The value of the config for the org.kde.plasma.icontasks plasmoid must be a
-  # list on the form applications:{{name of application 1}}.desktop,
-  # applications:{{name of application 2}}.desktop,..., hence we just transform
-  # it this way here.
-  iconTasksLaunchersStr = iconTasksLaunchers: "[${lib.concatStringsSep "," (map (p: "\"applications:${p}\"") iconTasksLaunchers)}]";
 
   # Creates lines for changing the config of a widget in a layout.js. Here
   # panel is the panel of the widget we are configuring for, widget is the full
@@ -113,8 +114,41 @@ let
       w.writeConfig("${configKey}", ${value})
     '' else "";
 
+  #
+  # Functions to generate layout.js configurations from the widgetType
+  #
+  # Configgroups must be javascript lists.
+  widgetConfigGroupFormat = group: ''[${lib.concatStringsSep ", " (map (s: "\"${s}\"") (lib.splitString "." group))}]'';
+  # If the specified value is a string then add in extra quotes. If we have a
+  # list, convert this to a javascript list.
+  widgetConfigValueFormat = value: if (builtins.isString value) then "\"${value}\"" else ''[${(lib.concatStringsSep ", " (map (s: "\"${s}\"") value))}]'';
+  # Generate writeConfig calls to include for a widget with additional
+  # configurations.
+  genWidgetConfigStr = widget: group: key: value:
+    ''
+      var w = panelWidgets["${widget}"]
+      w.currentConfigGroup = ${widgetConfigGroupFormat group}
+      w.writeConfig("${key}", ${widgetConfigValueFormat value})
+    '';
+  # Generate the text for all of the configuration for a widget with additional
+  # configurations.
+  widgetConfigsToStr = widget: config:
+    lib.concatStringsSep "\n"
+      (lib.concatLists
+        (lib.mapAttrsToList
+          (group: groupAttrs:
+            (lib.mapAttrsToList (key: value: (genWidgetConfigStr widget group key value)) groupAttrs))
+          config));
+
+  #
   # Functions to aid us creating a single panel in the layout.js
-  panelAddWidgetStr = widget: "panelWidgets[\"${widget}\"] = panel.addWidget(\"${widget}\")";
+  #
+  panelWidgetCreationStr = widget: ''panelWidgets["${widget}"] = panel.addWidget("${widget}")'';
+  panelAddWidgetStr = widget: if (builtins.isString widget) then (panelWidgetCreationStr widget) else
+  ''
+    ${panelWidgetCreationStr widget.name}
+    ${if widget.config == null then "" else (widgetConfigsToStr widget.name widget.config)}
+  '';
   panelAddWidgetsStr = panel: lib.concatStringsSep "\n" (map panelAddWidgetStr panel.widgets);
   panelToLayout = panel: ''
 
@@ -128,11 +162,6 @@ let
     ${if panel.minLength != null then "panel.minimumLength = ${builtins.toString panel.minLength}" else ""}
     ${if panel.offset != null then "panel.offset = ${builtins.toString panel.offset}" else ""}
     ${panelAddWidgetsStr panel}
-    ${if builtins.length panel.iconTasksLaunchers > 0 then
-      (panelModifyConfig
-        panel "org.kde.plasma.icontasks" "[\"General\"]"
-        "launchers" (iconTasksLaunchersStr panel.iconTasksLaunchers))
-      else ""}
     ${if panel.extraSettings != null then panel.extraSettings else ""}
   '';
 
@@ -167,9 +196,10 @@ in
         stored_last_update=$(cat "$last_update_file")
       fi
 
-      [ $last_update -gt $stored_last_update ] && \
-      qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "$(cat $layout_file)" && \
-      echo "$last_update" > "$last_update_file"
+      [ $last_update -ne $stored_last_update ] && \
+        qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "$(cat $layout_file)" && \
+        echo "$last_update" > "$last_update_file"
     '';
   };
 }
+


### PR DESCRIPTION
Added an option to add widgets with additional configuration options. Tested on my basic config and it works great! Removed also `iconTasksLaunchers` as this should now be configured. The syntax is implemented as the following:
```nix
{
  name = "org.kde.plasma.kickoff";
  config.General.icon = "nix-snowflake-white";
}
```
To set the launchers for `icontasks` you can for example use:
```nix
{
  name = "org.kde.plasma.icontasks";
  config = {
    General.launchers = [
      "applications:org.kde.dolphin.desktop"
      "applications:org.wezfurlong.wezterm.desktop"
      "applications:brave-browser.desktop"
    ];
  };
}
```
Do note that this solution supports both lists and strings as values, and should work as what you expect with both of these. To add nested configgroups where that may be needed you can use period in the group name, for example `"Group1.Group2.Group3".key = value;`
Would be great if someone could test that this works (by setting https://github.com/magnouvean/plasma-manager as the flake url) for their configuration in order to confirm that this works for the required needs. Should close #56 