### PR TITLE
Fix typos

### DIFF
--- a/example/home.nix
+++ b/example/home.nix
@@ -26,7 +26,7 @@
         widgets = [
           "org.kde.plasma.kickoff"
           "org.kde.plasma.icontasks"
-          "org.kde.plasma.marignsseperator"
+          "org.kde.plasma.marginsseperator"
           "org.kde.plasma.systemtray"
           "org.kde.plasma.digitalclock"
         ];

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -53,7 +53,7 @@ let
           "org.kde.plasma.kickoff"
           "org.kde.plasma.pager"
           "org.kde.plasma.icontasks"
-          "org.kde.plasma.marignsseperator"
+          "org.kde.plasma.marginsseperator"
           "org.kde.plasma.systemtray"
           "org.kde.plasma.digitalclock"
           "org.kde.plasma.showdesktop"
@@ -61,7 +61,7 @@ let
         example = [
           "org.kde.plasma.kickoff"
           "org.kde.plasma.icontasks"
-          "org.kde.plasma.marignsseperator"
+          "org.kde.plasma.marginsseperator"
           "org.kde.plasma.digitalclock"
         ];
         description = ''


### PR DESCRIPTION
One of the typos is in the widget IDs in the default panel settings, so this should make they appear as intended