### PR TITLE
Remove unused function

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -38,13 +38,6 @@ let
   };
 
   ##############################################################################
-  # Remove reserved options from a settings attribute set.
-  settingsToConfig = settings:
-    lib.filterAttrs
-      (k: v: !(builtins.elem k [ "configGroupNesting" ]))
-      settings;
-
-  ##############################################################################
   # Generate a script that will use write_config.py to update all
   # settings.
   script = pkgs.writeScript "plasma-config" (writeConfig cfg);


### PR DESCRIPTION
Removes a function which is no longer needed, presumably after changing to our own config-writing system.

I found this function while trying to implement some way to update the kde theme on each generation (without needing to re-log back in), but this will probably have to wait for a while as implementing this introduced lots of issues, in particular with environment variables and packages not being available in activation-scripts (the most problematic issue would be that we will have to manage the dependencies of the startup-scripts our self, which would be dependent on our `flake.nix`, which just becomes a mess, with potential conflicts with dependencies not working for some plasma versions and so on). If we could find a way to run a command as in a normal user-shell with all the packages available on the system it could be implemented, but I don't think this really is possible (and from the nix perspective I can understand why not). You can of course just run it manually by running `~/.local/share/plasma-manager/run_all.sh`, which is what I am going to be doing.