### PR TITLE
Add priority system for startup scripts

### DIFF
--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -176,19 +176,25 @@ in
       // Adds the panels
       ${panelsToLayoutJS config.programs.plasma.panels}
     '';
-    programs.plasma.startup.autoStartScript."apply_layout" = ''
-      layout_file="${config.xdg.dataHome}/plasma-manager/${config.programs.plasma.startup.dataDir}/layout.js"
-      last_update=$(stat -c %Y $layout_file)
-      last_update_file=${config.xdg.dataHome}/plasma-manager/last_update_layouts
-      stored_last_update=0
-      if [ -f "$last_update_file" ]; then
-        stored_last_update=$(cat "$last_update_file")
-      fi
 
-      [ $last_update -ne $stored_last_update ] && \
-        qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "$(cat $layout_file)" && \
-        echo "$last_update" > "$last_update_file"
-    '';
+    programs.plasma.startup.autoStartScript."apply_layout" = {
+      text = ''
+        layout_file="${config.xdg.dataHome}/plasma-manager/${cfg.startup.dataDir}/layout.js"
+        last_update=$(stat -c %Y $layout_file)
+        last_update_file=${config.xdg.dataHome}/plasma-manager/last_update_layouts
+        stored_last_update=0
+        if [ -f "$last_update_file" ]; then
+          stored_last_update=$(cat "$last_update_file")
+        fi
+
+        [ "$last_update" -ne "$stored_last_update" ] && \
+          qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "$(cat $layout_file)" && \
+          echo "$last_update" > "$last_update_file"
+      '';
+      # Setting up the panels should happen after setting the theme as the theme
+      # may overwrite some settings (like the kickoff-icon)
+      priority = 2;
+    };
   };
 }
 

--- a/modules/startup.nix
+++ b/modules/startup.nix
@@ -13,7 +13,7 @@ let
       };
       priority = lib.mkOption {
         type = lib.types.int;
-        description = "Tells when the script should be executed in relation to rest of the startup-scripts. Lower priority means earlier execution.";
+        description = "The priority for the execution of the script. Lower priority means earlier execution.";
         default = 0;
       };
     };

--- a/modules/startup.nix
+++ b/modules/startup.nix
@@ -4,11 +4,25 @@
 let
   cfg = config.programs.plasma;
   topScriptName = "run_all.sh";
+
+  startupScriptType = lib.types.submodule {
+    options = {
+      text = lib.mkOption {
+        type = lib.types.str;
+        description = "The content of the startup-script.";
+      };
+      priority = lib.mkOption {
+        type = lib.types.int;
+        description = "Tells when the script should be executed in relation to rest of the startup-scripts. Lower priority means earlier execution.";
+        default = 0;
+      };
+    };
+  };
 in
 {
   options.programs.plasma.startup = {
     autoStartScript = lib.mkOption {
-      type = lib.types.attrsOf lib.types.str;
+      type = lib.types.attrsOf startupScriptType;
       default = { };
       description = "Commands/scripts to be run at startup.";
     };
@@ -36,11 +50,11 @@ in
         # Autostart scripts
         (lib.mkMerge
           (lib.mapAttrsToList
-            (name: content: {
-              "plasma-manager/${cfg.startup.scriptsDir}/${name}.sh" = {
+            (name: script: {
+              "plasma-manager/${cfg.startup.scriptsDir}/${builtins.toString script.priority}_${name}.sh" = {
                 text = ''
                   #!/bin/sh
-                  ${content}
+                  ${script.text}
                 '';
                 executable = true;
               };

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -102,25 +102,28 @@ in
         # kde tools. We then run this using an autostart script, where this is
         # run only on the first login, granted all the commands succeed (until
         # we change the settings again).
-        programs.plasma.startup.autoStartScript."apply_themes" = ''
-          last_update=$(stat -c %Y ${config.xdg.dataHome}/plasma-manager/${cfg.startup.scriptsDir}/apply_themes.sh)
-          last_update_file=${config.xdg.dataHome}/plasma-manager/last_update
-          stored_last_update=0
-          if [ -f "$last_update_file" ]; then
-              stored_last_update=$(cat "$last_update_file")
-          fi
+        programs.plasma.startup.autoStartScript."apply_themes" = {
+          text = ''
+            last_update=$(stat -c %Y "$0")
+            last_update_file=${config.xdg.dataHome}/plasma-manager/last_update
+            stored_last_update=0
+            if [ -f "$last_update_file" ]; then
+                stored_last_update=$(cat "$last_update_file")
+            fi
 
-          if [ $last_update -gt $stored_last_update ]; then
-              success=1
-              ${if cfg.workspace.lookAndFeel != null then "plasma-apply-lookandfeel -a ${cfg.workspace.lookAndFeel} || success=0" else ""}
-              ${if cfg.workspace.theme != null then "plasma-apply-desktoptheme ${cfg.workspace.theme} || success=0" else ""}
-              ${if cfg.workspace.cursorTheme != null then "plasma-apply-cursortheme ${cfg.workspace.cursorTheme} || success=0" else ""}
-              ${if cfg.workspace.colorScheme != null then "plasma-apply-colorscheme ${cfg.workspace.colorScheme} || success=0" else ""}
-              ${if cfg.workspace.iconTheme != null then "${pkgs.libsForQt5.plasma-workspace}/libexec/plasma-changeicons ${cfg.workspace.iconTheme} || success=0" else ""}
-              ${if cfg.workspace.wallpaper != null then "plasma-apply-wallpaperimage ${cfg.workspace.wallpaper} || success=0" else ""}
-              [ $success = 1 ] && echo "$last_update" > "$last_update_file"
-          fi
-        '';
+            if [ $last_update -gt $stored_last_update ]; then
+                success=1
+                ${if cfg.workspace.lookAndFeel != null then "plasma-apply-lookandfeel -a ${cfg.workspace.lookAndFeel} || success=0" else ""}
+                ${if cfg.workspace.theme != null then "plasma-apply-desktoptheme ${cfg.workspace.theme} || success=0" else ""}
+                ${if cfg.workspace.cursorTheme != null then "plasma-apply-cursortheme ${cfg.workspace.cursorTheme} || success=0" else ""}
+                ${if cfg.workspace.colorScheme != null then "plasma-apply-colorscheme ${cfg.workspace.colorScheme} || success=0" else ""}
+                ${if cfg.workspace.iconTheme != null then "${pkgs.libsForQt5.plasma-workspace}/libexec/plasma-changeicons ${cfg.workspace.iconTheme} || success=0" else ""}
+                ${if cfg.workspace.wallpaper != null then "plasma-apply-wallpaperimage ${cfg.workspace.wallpaper} || success=0" else ""}
+                [ $success = 1 ] && echo "$last_update" > "$last_update_file"
+            fi
+          '';
+          priority = 1;
+        };
       })
   ];
 }


### PR DESCRIPTION
Adds configuration options for a priority-system for startup-scripts, allowing us to control the order at which the startup-scripts are executing. Also set the panel-configuration to priority 2 and theme-application to priority 1, meaning that the theme is set before the panel is (I think this makes more sense as the panel will be created with the correct theme from the start).