### PR TITLE
Update outdated section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Configuration is broken down into three layers:
 
      The other two layers ultimately generate Nix configuration for
      this low-level layer.  Configuration at this level is essentially
-     in the final state before being sent to the `kwriteconfig5` tool.
+     in the final state before being sent to our custom
+     configuration-writing script (which is very similar to
+     `kwriteconfig5`).
 
 An example is available in the `example` directory.
 


### PR DESCRIPTION
After having implemented our own configuration-writing script, the project doesn't use kwriteconfig5 directly anymore, which yields the previous sentence incorrect. This fixes that.