### PR TITLE
Fix problem with startup-scripts when using overrideConfig option

### DIFF
--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -181,7 +181,7 @@ in
       text = ''
         layout_file="${config.xdg.dataHome}/plasma-manager/${cfg.startup.dataDir}/layout.js"
         last_update=$(stat -c %Y $layout_file)
-        last_update_file=${config.xdg.dataHome}/plasma-manager/last_update_layouts
+        last_update_file=${config.xdg.dataHome}/plasma-manager/last_run_layouts
         stored_last_update=0
         if [ -f "$last_update_file" ]; then
           stored_last_update=$(cat "$last_update_file")

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -105,7 +105,7 @@ in
         programs.plasma.startup.autoStartScript."apply_themes" = {
           text = ''
             last_update=$(stat -c %Y "$0")
-            last_update_file=${config.xdg.dataHome}/plasma-manager/last_update
+            last_update_file=${config.xdg.dataHome}/plasma-manager/last_run_themes
             stored_last_update=0
             if [ -f "$last_update_file" ]; then
                 stored_last_update=$(cat "$last_update_file")


### PR DESCRIPTION
Ensures that after removing the config-files when using the `overrideConfig` option, the startup-scripts are being re-ran on next login. This is needed because some of the startup-script (like applying themes) modify config-files, and when they then are reset they will need to be ran again. Also changed the prefix of the files that keep track of when startup-scripts were last run from last_update to last_run, which i.m.o. is more descriptive.