### PR TITLE
Various bug fixes

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -91,7 +91,7 @@ let
       # last_run and is located in $XDG_DATA_HOME/plasma-manager. When we
       # reset all the other config-files these startup-scripts should be
       # re-ran, so we delete these files to ensure they are.
-      ++ [ "for file in ${config.xdg.dataHome}/plasma-manager/last_run*; do ${removeFileIfExistsCmd "$file"}; done" ]));
+      ++ [ "for file in ${config.xdg.dataHome}/plasma-manager/last_run_*; do ${removeFileIfExistsCmd "$file"}; done" ]));
 in
 {
   options.programs.plasma = {
@@ -153,7 +153,7 @@ in
     (lib.mkRenamedOptionModule [ "programs" "plasma" "files" ] [ "programs" "plasma" "configFile" ])
   ];
 
-  config = lib.mkIf (plasmaCfg.enable && (builtins.length (builtins.attrNames cfg) > 0)) {
+  config = lib.mkIf plasmaCfg.enable {
     home.activation.configure-plasma = (lib.hm.dag.entryAfter [ "writeBoundary" ]
       ''
         $DRY_RUN_CMD ${if plasmaCfg.overrideConfig then (createResetScript plasmaCfg) else ""}

--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -33,17 +33,21 @@ let
 
   # Gets a list with long names and turns it into short names
   getShortNames = wantedButtons:
-    lists.forEach (
-      lists.flatten (
-        lists.forEach wantedButtons (currentButton:
-          lists.remove null (
-            lists.imap0 ( index: value:
-              if value == currentButton then "${toString index}" else null
-            ) validTitlebarButtons.longNames
+    lists.forEach
+      (
+        lists.flatten (
+          lists.forEach wantedButtons (currentButton:
+            lists.remove null (
+              lists.imap0
+                (index: value:
+                  if value == currentButton then "${toString index}" else null
+                )
+                validTitlebarButtons.longNames
+            )
           )
         )
       )
-    ) getShortNameFromIndex;
+      getShortNameFromIndex;
 
   # Gets the index and returns the short name in that position
   getShortNameFromIndex = position: builtins.elemAt validTitlebarButtons.shortNames (strings.toInt position);
@@ -68,7 +72,7 @@ in
     };
   };
 
-  config = mkIf (cfg.enable) {
+  config = mkIf cfg.enable {
     # Titlebar buttons
     programs.plasma.configFile."kwinrc"."org\\.kde\\.kdecoration2" = mkMerge [
       (

--- a/modules/shortcuts.nix
+++ b/modules/shortcuts.nix
@@ -10,14 +10,15 @@ let
       # Keys are expected to be a list:
       keys =
         if builtins.isList skey
-        then (if builtins.length skey == 0 then [ "none" ] else skey)
+        then
+          (if ((builtins.length skey) == 0) then [ "none" ] else skey)
         else [ skey ];
 
       # Don't allow un-escaped commas:
       escape = lib.escape [ "," ];
     in
     lib.concatStringsSep "," [
-      (lib.concatStringsSep "\t" (map escape keys))
+      (if ((builtins.length keys) == 1) then (escape (builtins.head keys)) else "\t" + (lib.concatStringsSep "\t" (map escape keys)))
       "" # List of default keys, not needed.
       "" # Display string, not needed.
     ];
@@ -42,7 +43,7 @@ in
     '';
   };
 
-  config = lib.mkIf (cfg.enable && builtins.attrNames cfg.shortcuts != 0) {
+  config = lib.mkIf cfg.enable {
     programs.plasma.configFile."kglobalshortcutsrc" =
       shortcutsToSettings cfg.shortcuts;
   };

--- a/modules/spectacle.nix
+++ b/modules/spectacle.nix
@@ -69,7 +69,7 @@ in
     };
   };
 
-  config = lib.mkIf (cfg.enable) {
+  config = lib.mkIf cfg.enable {
     programs.plasma.shortcuts."org.kde.spectacle.desktop" = lib.mkMerge [
       (
         lib.mkIf (cfg.spectacle.shortcuts.captureActiveWindow != null) {

--- a/modules/startup.nix
+++ b/modules/startup.nix
@@ -85,7 +85,7 @@ in
         }
       ];
 
-      xdg.configFile."autostart/plasma-manager-apply-themes.desktop".text = ''
+      xdg.configFile."autostart/plasma-manager-autostart.desktop".text = ''
         [Desktop Entry]
         Type=Application
         Name=Plasma Manager theme application

--- a/script/write_config.py
+++ b/script/write_config.py
@@ -16,7 +16,7 @@ class KConfParser:
         """Read the config from the path specified on instantiation. If the
         path doesn't exist, do nothing"""
         try:
-            with open(self.filepath, "r") as f:
+            with open(self.filepath, "r", encoding="utf-8") as f:
                 current_group = 0
                 for l in f:
                     # Checks if the current line indicates a group.
@@ -39,9 +39,15 @@ class KConfParser:
 
         # Escapes symbols like \t, \n and so on if escape_value is True. This
         # should be true when reading from the nix json, but not when reading
-        # from file (as reading from file already is escaped).
+        # from file (as reading from a file that is already escaped).
         if escape_value:
-            value = value.encode("unicode_escape").decode()
+            to_escape = ["\t", "\n"]
+            # value = value.encode("unicode_escape").decode()
+            for escape_char in to_escape:
+                value = value.replace(
+                    escape_char, escape_char.encode("unicode_escape").decode()
+                )
+
         self.data[group][key] = value
 
     def remove_value(self, group, key):
@@ -61,7 +67,7 @@ class KConfParser:
         if not os.path.exists(dir):
             os.makedirs(dir)
 
-        with open(self.filepath, "w") as f:
+        with open(self.filepath, "w", encoding="utf-8") as f:
             # We skip a newline before the first category
             skip_newline = True
 
@@ -83,7 +89,7 @@ class KConfParser:
                     f.write(f"{self.key_value_to_line(key, value)}\n")
 
     @staticmethod
-    def get_key_value(line: str) -> tuple[str, str]:
+    def get_key_value(line: str) -> tuple[str, str | None]:
         line_splitted = line.split("=", 1)
         key = line_splitted[0].strip()
         value = line_splitted[1].strip() if len(line_splitted) > 1 else None


### PR DESCRIPTION
This PR addresses some bugs I, and others in the issues, have encountered. Also this does some minor refactoring. The bugs this addresses in particular is:
- Adds functionality for multiple keybindings (which should close #25 )
- Fixes problems with escaping non-ASCII characters (like ¤), and now only escapes \n and \t
- Removes check for `file` `dataFile` and `configFile` being empty before applying the config-writing script, as this seems redundant now with the new config-writing system (I am not really sure why it was there in the first place)

Specifically the last solution I would be welcome to thoughts on, as I am not sure if I see if there was ever a good reason for checking `(builtins.length (builtins.attrNames cfg) > 0)` before running the config-writing part, but I could be missing something. The config-writing system should be able to handle empty inputs, so I don't think it should be a problem. I have tested that plasma-manager works as expected with this change and the bugs should be fixed.