### PR TITLE
add github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: "Check"
+on:
+  pull_request:
+# cancel previous runs when pushing new changes
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v22
+      with:
+        extra_nix_config: "system-features = kvm nixos-test"
+    - run: nix flake check -L --keep-going
+    - run: nix flake check -L --keep-going ./example

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-/example/result
+result-*
+result
+.direnv

--- a/example/home.nix
+++ b/example/home.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ pkgs, ... }:
 {
   programs.plasma = {
     enable = true;

--- a/script/write_config.py
+++ b/script/write_config.py
@@ -3,7 +3,7 @@ import json
 import os
 import re
 import sys
-from typing import Dict
+from typing import Dict, Optional
 
 
 class KConfParser:
@@ -89,7 +89,7 @@ class KConfParser:
                     f.write(f"{self.key_value_to_line(key, value)}\n")
 
     @staticmethod
-    def get_key_value(line: str) -> tuple[str, str | None]:
+    def get_key_value(line: str) -> tuple[str, Optional[str]]:
         line_splitted = line.split("=", 1)
         key = line_splitted[0].strip()
         value = line_splitted[1].strip() if len(line_splitted) > 1 else None


### PR DESCRIPTION
I just started using this project and noticed potential for improvement. This is the first of a series of PRs. This PR adds a github action file that executes `nix flake check` for the main flake and the example flake. This workflow is automatically executed on every PR.

:warning: The maintainers of this repository may have to enable actions in the repository settings for this to work.

I tested this in a PR in my own fork https://github.com/m1-s/plasma-manager/pull/1/