### PR TITLE
refactor basic test

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,15 +70,11 @@
       });
 
       checks = forAllSystems (system:
-        let
-          test = path: import path {
-            pkgs = nixpkgsFor.${system};
-            home-manager = inputs.home-manager;
-            module = self.homeManagerModules.plasma-manager;
-          };
-        in
         {
-          default = test ./test/basic.nix;
+          default = nixpkgsFor.${system}.callPackage ./test/basic.nix {
+            home-manager-module = inputs.home-manager.nixosModules.home-manager;
+            plasma-module = self.homeManagerModules.plasma-manager;
+          };
         });
 
       devShells = forAllSystems (system: {

--- a/test/user.nix
+++ b/test/user.nix
@@ -20,6 +20,7 @@
 
     users.fake = { ... }: {
       imports = [ module homeConfig ];
+      home.stateVersion = "23.11";
     };
   };
 }


### PR DESCRIPTION
This PR replaces the `pkgs.nixosTest` call with `pkgs.testers.nixosTest` which is the new better nixos test. Furthermore, we are calling the test via `callPackage` now.