### PR TITLE
simplify demo-vm

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,13 +38,10 @@
             inherit system;
             modules = [
               (import test/demo.nix {
-                pkgs = nixpkgsFor.x86_64-linux;
-                home-manager = inputs.home-manager;
-                module = self.homeManagerModules.plasma-manager;
-                extraPackages = with self.packages.${system}; [
-                  rc2nix
-                ];
+                home-manager-module = inputs.home-manager.nixosModules.home-manager;
+                plasma-module = self.homeManagerModules.plasma-manager;
               })
+              (_: {environment.systemPackages = [ self.packages.${system}.rc2nix]; })
             ];
           }).config.system.build.vm;
 

--- a/script/write_config.py
+++ b/script/write_config.py
@@ -3,7 +3,7 @@ import json
 import os
 import re
 import sys
-from typing import Dict
+from typing import Dict, Optional
 
 
 class KConfParser:
@@ -89,7 +89,7 @@ class KConfParser:
                     f.write(f"{self.key_value_to_line(key, value)}\n")
 
     @staticmethod
-    def get_key_value(line: str) -> tuple[str, str | None]:
+    def get_key_value(line: str) -> tuple[str, Optional[str]]:
         line_splitted = line.split("=", 1)
         key = line_splitted[0].strip()
         value = line_splitted[1].strip() if len(line_splitted) > 1 else None

--- a/test/demo.nix
+++ b/test/demo.nix
@@ -1,25 +1,13 @@
-{ pkgs
-, home-manager
-, module
-, extraPackages
+{ home-manager-module
+, plasma-module
 }:
 
-let
-  homeConfig = {
-    imports = [ ../example/home.nix ];
-  };
-
-  user = import ./user.nix {
-    inherit module home-manager homeConfig;
-  };
-
-in
 { modulesPath, ... }:
 {
   imports = [
     (modulesPath + "/profiles/qemu-guest.nix")
     (modulesPath + "/virtualisation/qemu-vm.nix")
-    user
+    home-manager-module
   ];
 
   config = {
@@ -40,13 +28,11 @@ in
       ];
     };
 
-    virtualisation = {
-      forwardPorts = [{
-        from = "host";
-        host.port = 2222;
-        guest.port = 22;
-      }];
-    };
+    virtualisation.forwardPorts = [{
+      from = "host";
+      host.port = 2222;
+      guest.port = 22;
+    }];
 
     services.xserver = {
       enable = true;
@@ -57,6 +43,18 @@ in
       displayManager.autoLogin.user = "fake";
     };
 
-    environment.systemPackages = extraPackages;
+    system.stateVersion = "22.05";
+
+    users.users.fake = {
+      createHome = true;
+      isNormalUser = true;
+      password = "password";
+      group = "users";
+    };
+
+    home-manager.users.fake = {
+      home.stateVersion = "22.05";
+       imports = [ plasma-module ];
+    };
   };
 }


### PR DESCRIPTION
This PR simplifies the demo VM by reducing the amount of parameters that test/demo.nix takes. Furthermore, the dependency on test/user.nix was removed as automated tests and demonstration are 2 different things and its just easier to duplicate these 5 lines of code instead. As soon as https://github.com/pjones/plasma-manager/pull/72 is merged, user.nix can be removed.