### PR TITLE
Fix potential bugs in autostart scripts

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -86,11 +86,13 @@ let
         # The files in overrideConfigFiles are in XDG_CONFIG_HOME, so we need to
         # add this to the names to get the full path
         (map (f: "${config.xdg.configHome}/${f}") (lib.lists.subtractLists cfg.overrideConfigExclude cfg.overrideConfigFiles)))
-      # Some of the startup-scripts may keep track of when they were last ran
-      # in order to only run once for each generation. These files start with
-      # last_run and is located in $XDG_DATA_HOME/plasma-manager. When we
-      # reset all the other config-files these startup-scripts should be
-      # re-ran, so we delete these files to ensure they are.
+      # Some of the startup-scripts may keep track of when they were last run,
+      # in order to only run the scripts once for each home-manager generation.
+      # However when we use overrideConfig we need to run these scripts after
+      # every activation (i.e. after applying a new home-manager generation or
+      # after a fresh boot) as the scripts typically write some config-files
+      # which will need to be written once again after the old configs are
+      # deleted on each activation.
       ++ [ "for file in ${config.xdg.dataHome}/plasma-manager/last_run_*; do ${removeFileIfExistsCmd "$file"}; done" ]));
 in
 {

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -100,18 +100,17 @@ in
       {
         # We create a script which applies the different theme settings using
         # kde tools. We then run this using an autostart script, where this is
-        # run only on the first login, granted all the commands succeed (until
-        # we change the settings again).
+        # run only on the first login (unless overrideConfig is enabled),
+        # granted all the commands succeed (until we change the settings again).
         programs.plasma.startup.autoStartScript."apply_themes" = {
           text = ''
-            last_update=$(stat -c %Y "$0")
+            last_update=$(sha256sum "$0")
             last_update_file=${config.xdg.dataHome}/plasma-manager/last_run_themes
-            stored_last_update=0
             if [ -f "$last_update_file" ]; then
                 stored_last_update=$(cat "$last_update_file")
             fi
 
-            if [ $last_update -gt $stored_last_update ]; then
+            if ! [ "$last_update" = "$stored_last_update" ]; then
                 success=1
                 ${if cfg.workspace.lookAndFeel != null then "plasma-apply-lookandfeel -a ${cfg.workspace.lookAndFeel} || success=0" else ""}
                 ${if cfg.workspace.theme != null then "plasma-apply-desktoptheme ${cfg.workspace.theme} || success=0" else ""}
@@ -119,7 +118,7 @@ in
                 ${if cfg.workspace.colorScheme != null then "plasma-apply-colorscheme ${cfg.workspace.colorScheme} || success=0" else ""}
                 ${if cfg.workspace.iconTheme != null then "${pkgs.libsForQt5.plasma-workspace}/libexec/plasma-changeicons ${cfg.workspace.iconTheme} || success=0" else ""}
                 ${if cfg.workspace.wallpaper != null then "plasma-apply-wallpaperimage ${cfg.workspace.wallpaper} || success=0" else ""}
-                [ $success = 1 ] && echo "$last_update" > "$last_update_file"
+                [ $success -eq 1 ] && echo "$last_update" > "$last_update_file"
             fi
           '';
           priority = 1;


### PR DESCRIPTION
Change from using `stat` to using `sha256sum` in autostart script when checking if files have been changed. Also some minor documentation changes. Also remove `plasma-org.kde.plasma.desktop-appletsrc` when generating new panels.