### PR TITLE
Add dodgewindows to hiding for plasma 6

### DIFF
--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -62,7 +62,7 @@ let
         description = "The alignment of the panel.";
       };
       hiding = lib.mkOption {
-        type = lib.types.nullOr (lib.types.enum [ "none" "autohide" "windowscover" "windowsbelow" ]);
+        type = lib.types.nullOr (lib.types.enum [ "none" "autohide" "windowscover" "windowsbelow" "dodgewindows" ]);
         default = null;
         example = "autohide";
         description = "The hiding mode of the panel.";


### PR DESCRIPTION
Plasma 6 includes a `dodgewindows` option for panels. I'm not sure if backwards compatibility is a concern here. However, this seemingly isn't a concern with the `floating` option.