### PR TITLE
Fix typo in konsole.nix

### DIFF
--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -118,7 +118,7 @@ in
     programs.plasma.configFile."konsolerc" = mkMerge [
       (
         mkIf (cfg.defaultProfile != null ) {
-          "Desktop entry"."DefaultProfile" = cfg.defaultProfile;
+          "Desktop Entry"."DefaultProfile" = cfg.defaultProfile;
         }
       )
       (


### PR DESCRIPTION
Konsolerc is case sensitive so the default profile option works now after fixing the typo