### PR TITLE
add lsp server support to kate

### DIFF
--- a/modules/apps/kate/default.nix
+++ b/modules/apps/kate/default.nix
@@ -198,7 +198,9 @@ in
     default = {};
     type = lib.types.attrs;
     description = ''
-      Add more lsp server settings here. Check out the format on the [KDE page](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html). Note that these are only the settings, the packages have to be installed separately.
+      Add more lsp server settings here. Check out the format on the
+      [KDE page](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html).
+      Note that these are only the settings, the packages have to be installed separately.
     '';
   };
 

--- a/modules/apps/kate/default.nix
+++ b/modules/apps/kate/default.nix
@@ -44,6 +44,7 @@ let
       name = "markdown";
       settings = {
        command = [ "marksman" "server" ];
+        rootIndicatorFileNames = [ ".git"  ".marksman.toml" ];
         url = "https://github.com/artempyanykh/marksman";
         highlightingModeRegex = "^Markdown$";
       };
@@ -257,7 +258,7 @@ in
     default = {};
     type = lib.types.attrs;
     description = ''
-      Add more lsp server settings here. Check out the format on the [KDE page](https://kate-editor.org/post/2019/2019-08-10-kate-lsp-more-languages-supported/).
+      Add more lsp server settings here. Check out the format on the [KDE page](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html).
     '';
   };
 


### PR DESCRIPTION
This PR adds LSP ("language server protocol") settings to kate.

It contains 2 preconfigured LSP servers – [nil]() for nix and [marksman]() for markdown. Users can add custom settings as well.

This PR is marked as a draft since I want to see whether these preconfigured LSP servers (nil and marksman) might be accepted into the kate project. If yes, we do not need these here.