### PR TITLE
Add support for persistent keys

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -27,6 +27,14 @@ let
           adding [$e] to the end of the key.
         '';
       };
+      persistent = lib.mkOption {
+        type = bool;
+        default = false;
+        description = ''
+          When overrideConfig is enabled and the key is persistent,
+          plasma-manager will leave it unchanged after activation.
+        '';
+      };
     };
   });
 in


### PR DESCRIPTION
Should address the persistence we have discussed in #120. To allow for the functionality I had to do quite a bit of refactoring, and therefore this is quite a big change moving some of the nix code to the python script. Therefore there could also be some bugs introduced (though none I have found just yet). I very much welcome anyone to test on their own configs and let me know how it works before we merge (it's probably wise to backup the config-files just in case some bug I have overseen). This also hopefully should open up for solving #119 more easily as we can just enable persistence for some of the keys (granted we can find out which ones are at fault).