### PR TITLE
Improve startup script interface

### DIFF
--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -213,8 +213,10 @@ in
         ${panelsToLayoutJS config.programs.plasma.panels}
       '';
       postCommands = ''
-        ${if (anyNonDefaultScreens cfg.panels) then "sed -i 's/^lastScreen\\\\x5b\\$i\\\\x5d=/lastScreen[$i]=/' ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc" else ""}
-        ${if (anyNonDefaultScreens cfg.panels) then "# We sleep a second in order to prevent some bugs (like the incorrect height being set)\nsleep 1; nohup plasmashell --replace &" else ""}
+        if [ -f ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc ]; then
+          ${if (anyNonDefaultScreens cfg.panels) then "sed -i 's/^lastScreen\\\\x5b\\$i\\\\x5d=/lastScreen[$i]=/' ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc" else ""}
+          ${if (anyNonDefaultScreens cfg.panels) then "# We sleep a second in order to prevent some bugs (like the incorrect height being set)\nsleep 1; nohup plasmashell --replace &" else ""}
+        fi
       '';
       priority = 2;
     };

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -194,47 +194,28 @@ in
   };
 
   config = lib.mkIf (cfg.enable && (lib.length cfg.panels) > 0) {
-    programs.plasma.startup.dataFile."layout.js" = ''
-      // Removes all existing panels
-      var allPanels = panels();
-      for (var panelIndex = 0; panelIndex < allPanels.length; panelIndex++) {
-        var p = allPanels[panelIndex];
-        p.remove();
-      }
-
-      // Adds the panels
-      ${panelsToLayoutJS config.programs.plasma.panels}
-    '';
-
-    # Very similar to applying themes, we keep track of the last time the panel
-    # was generated successfully, and run this only once per generation (granted
-    # everything succeeds and we are not using overrideConfig).
-    programs.plasma.startup.autoStartScript."apply_layout" = {
-      text = ''
-        layout_file="${config.xdg.dataHome}/plasma-manager/${cfg.startup.dataDir}/layout.js"
-        last_update="$(sha256sum $layout_file)"
-        last_update_file=${config.xdg.dataHome}/plasma-manager/last_run_layouts
-        if [ -f "$last_update_file" ]; then
-          stored_last_update=$(cat "$last_update_file")
-        fi
-
-        if ! [ "$last_update" = "$stored_last_update" ]; then
-          # We delete plasma-org.kde.plasma.desktop-appletsrc to hinder it
-          # growing indefinitely. See:
-          # https://github.com/pjones/plasma-manager/issues/76
-          [ -f ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc ] && rm ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc
-
-          # And finally apply the layout.js
-          success=1
-          qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "$(cat $layout_file)" || success=0
-          ${if (anyNonDefaultScreens cfg.panels) then "sed -i 's/^lastScreen\\\\x5b\\$i\\\\x5d=/lastScreen[$i]=/' ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc" else ""}
-          ${if (anyNonDefaultScreens cfg.panels) then "# We sleep a second in order to prevent some bugs (like the incorrect height being set)\nsleep 1; nohup plasmashell --replace &" else ""}
-
-          [ $success -eq 1 ] && echo "$last_update" > "$last_update_file"
-        fi
+    programs.plasma.startup.desktopScript."apply_panels" = {
+      preCommands = ''
+        # We delete plasma-org.kde.plasma.desktop-appletsrc to hinder it
+        # growing indefinitely. See:
+        # https://github.com/pjones/plasma-manager/issues/76
+        [ -f ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc ] && rm ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc
       '';
-      # Setting up the panels should happen after setting the theme as the theme
-      # may overwrite some settings (like the kickoff-icon)
+      text = ''
+        // Removes all existing panels
+        var allPanels = panels();
+        for (var panelIndex = 0; panelIndex < allPanels.length; panelIndex++) {
+          var p = allPanels[panelIndex];
+          p.remove();
+        }
+
+        // Adds the panels
+        ${panelsToLayoutJS config.programs.plasma.panels}
+      '';
+      postCommands = ''
+        ${if (anyNonDefaultScreens cfg.panels) then "sed -i 's/^lastScreen\\\\x5b\\$i\\\\x5d=/lastScreen[$i]=/' ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc" else ""}
+        ${if (anyNonDefaultScreens cfg.panels) then "# We sleep a second in order to prevent some bugs (like the incorrect height being set)\nsleep 1; nohup plasmashell --replace &" else ""}
+      '';
       priority = 2;
     };
   };

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -101,23 +101,13 @@ in
         # kde tools. We then run this using an autostart script, where this is
         # run only on the first login (unless overrideConfig is enabled),
         # granted all the commands succeed (until we change the settings again).
-        programs.plasma.startup.autoStartScript."apply_themes" = {
+        programs.plasma.startup.startupScript."apply_themes" = {
           text = ''
-            last_update=$(sha256sum "$0")
-            last_update_file=${config.xdg.dataHome}/plasma-manager/last_run_themes
-            if [ -f "$last_update_file" ]; then
-                stored_last_update=$(cat "$last_update_file")
-            fi
-
-            if ! [ "$last_update" = "$stored_last_update" ]; then
-                success=1
-                ${if cfg.workspace.lookAndFeel != null then "plasma-apply-lookandfeel -a ${cfg.workspace.lookAndFeel} || success=0" else ""}
-                ${if cfg.workspace.theme != null then "plasma-apply-desktoptheme ${cfg.workspace.theme} || success=0" else ""}
-                ${if cfg.workspace.cursorTheme != null then "plasma-apply-cursortheme ${cfg.workspace.cursorTheme} || success=0" else ""}
-                ${if cfg.workspace.colorScheme != null then "plasma-apply-colorscheme ${cfg.workspace.colorScheme} || success=0" else ""}
-                ${if cfg.workspace.iconTheme != null then "${pkgs.libsForQt5.plasma-workspace}/libexec/plasma-changeicons ${cfg.workspace.iconTheme} || success=0" else ""}
-                [ $success -eq 1 ] && echo "$last_update" > "$last_update_file"
-            fi
+            ${if cfg.workspace.lookAndFeel != null then "plasma-apply-lookandfeel -a ${cfg.workspace.lookAndFeel}" else ""}
+            ${if cfg.workspace.theme != null then "plasma-apply-desktoptheme ${cfg.workspace.theme}" else ""}
+            ${if cfg.workspace.cursorTheme != null then "plasma-apply-cursortheme ${cfg.workspace.cursorTheme}" else ""}
+            ${if cfg.workspace.colorScheme != null then "plasma-apply-colorscheme ${cfg.workspace.colorScheme}" else ""}
+            ${if cfg.workspace.iconTheme != null then "${pkgs.libsForQt5.plasma-workspace}/libexec/plasma-changeicons ${cfg.workspace.iconTheme}" else ""}
           '';
           priority = 1;
         };
@@ -126,17 +116,9 @@ in
       # We need to set the wallpaper after the panels are created in order for
       # this not to be reset when specifying the screens for panels. See:
       # https://github.com/pjones/plasma-manager/issues/116.
-      programs.plasma.startup.autoStartScript."set_wallpaper" = {
+      programs.plasma.startup.startupScript."set_wallpaper" = {
         text = ''
-          last_update=$(sha256sum "$0")
-          last_update_file=${config.xdg.dataHome}/plasma-manager/last_run_wallpaper
-          if [ -f "$last_update_file" ]; then
-              stored_last_update=$(cat "$last_update_file")
-          fi
-
-          if ! [ "$last_update" = "$stored_last_update" ]; then
-              plasma-apply-wallpaperimage ${cfg.workspace.wallpaper} && echo "$last_update" > "$last_update_file"
-          fi
+          plasma-apply-wallpaperimage ${cfg.workspace.wallpaper}
         '';
         priority = 3;
       };


### PR DESCRIPTION
This drastically improves and standardizes the startup-script interface, so that creating your own startup-scripts and desktop-scripts is much easier. This should more easily open up for implementing desktop-scripts for various other tasks than just panels, which would be useful for #130  and other uses I am sure. It works for my use-cases a.t.m. and the normal user shouldn't really see any difference, but I will test a little more before merging. If anyone wants to test on their config feel free to do so and see if there are any issues.