### PR TITLE
module(panel): refactors and small fixes

### DIFF
--- a/modules/startup.nix
+++ b/modules/startup.nix
@@ -108,18 +108,21 @@ in
             cfg.startup.startupScript))
         # Desktop scripts
         (lib.mkMerge
-          (lib.mapAttrsToList
+          ((lib.mapAttrsToList
             (name: script: createScriptContent "desktop_script_${name}" script.priority
               ''
                 ${script.preCommands}
-                read -rd ''' script << 'SCRIPT'
-                ${script.text}
-                SCRIPT
-
-                qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "$script"
+                qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "$(cat ${config.xdg.dataHome}/plasma-manager/${cfg.startup.dataDir}/desktop_script_${name}.js)"
                 ${script.postCommands}
               '')
-            cfg.startup.desktopScript))
+            cfg.startup.desktopScript) ++
+          (lib.mapAttrsToList
+            (name: content: {
+              "plasma-manager/${cfg.startup.dataDir}/desktop_script_${name}.js" = {
+                text = content.text;
+              };
+            })
+            cfg.startup.desktopScript)))
         # Datafiles
         (lib.mkMerge
           (lib.mapAttrsToList

--- a/modules/startup.nix
+++ b/modules/startup.nix
@@ -112,8 +112,11 @@ in
             (name: script: createScriptContent "desktop_script_${name}" script.priority
               ''
                 ${script.preCommands}
-                qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript '
-                ${lib.escape [ "'" ] script.text}'
+                read -rd ''' script << 'SCRIPT'
+                ${script.text}
+                SCRIPT
+
+                qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "$script"
                 ${script.postCommands}
               '')
             cfg.startup.desktopScript))


### PR DESCRIPTION
This PR refactors the logic used in generating the desktop script for panels to make it more readable, and adds a `lengthMode` setting that allows Plasma 6 users to configure their panels' length mode.

Additionally, there was a small bug in the desktop script generation logic — if you have two consecutive single quotes in the script, the escaped sequence will produce an invalid Bash script, for whatever reason. I've changed it to use a heredoc instead, which should be much more resilient.
