### PR TITLE
modules(fonts): init

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ At the moment `plasma-manager` supports configuring the following:
 - Shortcuts (via the `shortcuts` module)
 - Hotkeys (via the `hotkeys` module)
 - Panels (via the `panels` module)
+- Fonts (via the `fonts` module)
 - KDE apps (via the `apps` module). In particular the following kde apps have
   modules in `plasma-manager`:
   - kate

--- a/examples/home.nix
+++ b/examples/home.nix
@@ -22,6 +22,13 @@
       command = "konsole";
     };
 
+    fonts = {
+      general = {
+        family = "JetBrains Mono";
+        pointSize = 12;
+      };
+    };
+
     panels = [
       # Windows-like panel at the bottom
       {

--- a/lib/qfont.nix
+++ b/lib/qfont.nix
@@ -1,0 +1,179 @@
+{lib, ...}: let
+  #=== ENUMS ===
+  enums = {
+    # QFont::StyleHint
+    styleHint = rec {
+      anyStyle = 5;
+      sansSerif = helvetica;
+      helvetica = 0;
+      serif = times;
+      times = 1;
+      typewriter = courier;
+      courier = 2;
+      oldEnglish = 3;
+      decorative = oldEnglish;
+      monospace = 7;
+      fantasy = 8;
+      cursive = 6;
+      system = 4;
+    };
+
+    # QFont::Weight
+    weight = {
+      thin = 100;
+      extraLight = 200;
+      light = 300;
+      normal = 400;
+      medium = 500;
+      demiBold = 600;
+      bold = 700;
+      extraBold = 800;
+      black = 900;
+    };
+
+    # QFont::Style
+    style = {
+      normal = 0;
+      italic = 1;
+      oblique = 2;
+    };
+
+    # QFont::Capitalization
+    capitalization = {
+      mixedCase = 0;
+      allUppercase = 1;
+      allLowercase = 2;
+      smallCaps = 3;
+      capitalize = 4;
+    };
+
+    # QFont::SpacingType
+    spacingType = {
+      percentage = 0;
+      absolute = 1;
+    };
+
+    # QFont::Stretch
+    stretch = {
+      anyStretch = 0;
+      ultraCondensed = 50;
+      extraCondensed = 62;
+      condensed = 75;
+      semiCondensed = 87;
+      unstretched = 100;
+      semiExpanded = 112;
+      expanded = 125;
+      extraExpanded = 150;
+      ultraExpanded = 200;
+    };
+
+    # QFont::StyleStrategy
+    # This one's... special.
+    styleStrategy = {
+      prefer = {
+        default = 1;
+        bitmap = 2;
+        device = 4;
+        outline = 8;
+        forceOutline = 16;
+      };
+      matchingPrefer = {
+        default = 0;
+        exact = 32;
+        quality = 64;
+      };
+      antialiasing = {
+        default = 0;
+        prefer = 128;
+        disable = 256;
+      };
+      noSubpixelAntialias = 2048;
+      preferNoShaping = 4096;
+      noFontMerging = 32768;
+    };
+  };
+
+  inherit (builtins) attrNames mapAttrs removeAttrs isAttrs;
+  inherit (lib) filterAttrs;
+
+  toEnums = v: lib.types.enum (attrNames v);
+in
+  mapAttrs (_: toEnums) (removeAttrs enums ["styleStrategy"])
+  // {
+    styleStrategy = mapAttrs (_: toEnums) (filterAttrs (_: isAttrs) enums.styleStrategy);
+
+    # Converts a font specified by the given attrset to a string representation compatible with
+    # QFont::fromString and QFont::toString.
+    fontToString = {
+      family,
+      pointSize ? null,
+      pixelSize ? null,
+      styleHint ? "anyStyle",
+      weight ? "normal",
+      style ? "normal",
+      underline ? false,
+      strikeOut ? false,
+      fixedPitch ? false,
+      capitalization ? "mixedCase",
+      letterSpacingType ? "percentage",
+      letterSpacing ? 0,
+      wordSpacing ? 0,
+      stretch ? "anyStretch",
+      styleStrategy ? {},
+      styleName ? null,
+    }: let
+      inherit (builtins) isString toString foldl' bitOr;
+
+      styleStrategy' = let
+        match = s: enums.styleStrategy.${s}.${styleStrategy.${s} or "default"};
+        ifSet = k:
+          if styleStrategy.${k} or false
+          then enums.styleStrategy.${k}
+          else 0;
+      in
+        foldl' bitOr 0 [
+          (match "prefer")
+          (match "matchingPrefer")
+          (match "antialiasing")
+          (ifSet "noSubpixelAntialias")
+          (ifSet "preferNoShaping")
+          (ifSet "noFontMerging")
+        ];
+
+      sizeToString = s:
+        if s == null
+        then "-1"
+        else toString s;
+
+      numOrEnum = attrs: s:
+        if isString s
+        then toString attrs.${s}
+        else toString s;
+
+      zeroOrOne = b:
+        if b
+        then "1"
+        else "0";
+    in
+      assert lib.assertMsg (lib.xor (pointSize != null) (pixelSize != null))
+      "Exactly one of `pointSize` and `pixelSize` has to be set.";
+        builtins.concatStringsSep "," ([
+            family
+            (sizeToString pointSize)
+            (sizeToString pixelSize)
+            (toString enums.styleHint.${styleHint})
+            (numOrEnum enums.weight weight)
+            (numOrEnum enums.style style)
+            (zeroOrOne underline)
+            (zeroOrOne strikeOut)
+            (zeroOrOne fixedPitch)
+            "0"
+            (toString enums.capitalization.${capitalization})
+            (toString enums.spacingType.${letterSpacingType})
+            (toString letterSpacing)
+            (toString wordSpacing)
+            (numOrEnum enums.stretch stretch)
+            (toString styleStrategy')
+          ]
+          ++ lib.optional (styleName != null) styleName);
+  }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -11,6 +11,7 @@
     ./kwin.nix
     ./startup.nix
     ./panels.nix
+    ./fonts.nix
     ./apps
   ];
 

--- a/modules/fonts.nix
+++ b/modules/fonts.nix
@@ -1,0 +1,285 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  inherit (lib) mkIf mkOption types;
+  qfont = import ../lib/qfont.nix {inherit lib;};
+
+  styleStrategyType = types.submodule {
+    options = with qfont.styleStrategy; {
+      prefer = mkOption {
+        type = prefer;
+        default = "default";
+        description = ''
+          Which type of font is preferred by the font when finding an appropriate default family.
+
+          `default`, `bitmap`, `device`, `outline`, `forceOutline` correspond to the
+          `PreferDefault`, `PreferBitmap`, `PreferDevice`, `PreferOutline`, `ForceOutline` enum flags
+          respectively.
+        '';
+      };
+      matchingPrefer = mkOption {
+        type = matchingPrefer;
+        default = "default";
+        description = ''
+          Whether the font matching process prefers exact matches, of best quality matches.
+
+          `default` corresponds to not setting any enum flag, and `exact` and `quality`
+          correspond to `PreferMatch` and `PreferQuality` enum flags respectively.
+        '';
+      };
+      antialiasing = mkOption {
+        type = antialiasing;
+        default = "default";
+        description = ''
+          Whether antialiasing is preferred for this font.
+
+          `default` corresponds to not setting any enum flag, and `prefer` and `disable`
+          correspond to `PreferAntialias` and `NoAntialias` enum flags respectively.
+        '';
+      };
+      noSubpixelAntialias = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          If set to true, this font will try to avoid subpixel antialiasing.
+
+          Corresponds to the `NoSubpixelAntialias` enum flag.
+        '';
+      };
+      noFontMerging = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          If set to true, this font will not try to find a substitute font when encountering missing glyphs.
+
+          Corresponds to the `NoFontMerging` enum flag.
+        '';
+      };
+      preferNoShaping = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          If set to true, this font will not try to apply shaping rules that may be required for some scripts
+          (e.g. Indic scripts), increasing performance if these rules are not required.
+
+          Corresponds to the `PreferNoShaping` enum flag.
+        '';
+      };
+    };
+  };
+
+  fontType = types.submodule {
+    options = {
+      family = mkOption {
+        type = types.str;
+        description = "The font family of this font.";
+        example = "Noto Sans";
+      };
+      pointSize = mkOption {
+        type = types.nullOr types.numbers.positive;
+        default = null;
+        description = ''
+          The point size of this font.
+
+          Could be a decimal, but usually an integer. Mutually exclusive with pixel size.
+        '';
+      };
+      pixelSize = mkOption {
+        type = types.nullOr types.ints.u16;
+        default = null;
+        description = ''
+          The pixel size of this font.
+
+          Mutually exclusive with point size.
+        '';
+      };
+      styleHint = mkOption {
+        type = qfont.styleHint;
+        default = "anyStyle";
+        description = ''
+          The style hint of this font.
+
+          See https://doc.qt.io/qt-6/qfont.html#StyleHint-enum for more.
+        '';
+      };
+      weight = mkOption {
+        type = types.either (types.ints.between 1 1000) qfont.weight;
+        default = "normal";
+        description = ''
+          The weight of the font, either as a number between 1 to 1000 or as a pre-defined weight string.
+
+          See https://doc.qt.io/qt-6/qfont.html#Weight-enum for more.
+        '';
+      };
+      style = mkOption {
+        type = qfont.style;
+        default = "normal";
+        description = "The style of the font.";
+      };
+      underline = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether the font is underlined.";
+      };
+      strikeOut = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether the font is struck out.";
+      };
+      fixedPitch = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether the font has a fixed pitch.";
+      };
+      capitalization = mkOption {
+        type = qfont.capitalization;
+        default = "mixedCase";
+        description = ''
+          The capitalization settings for this font.
+
+          See https://doc.qt.io/qt-6/qfont.html#Capitalization-enum for more.
+        '';
+      };
+      letterSpacingType = mkOption {
+        type = qfont.spacingType;
+        default = "percentage";
+        description = ''
+          Whether to use percentage or absolute spacing for this font.
+
+          See https://doc.qt.io/qt-6/qfont.html#SpacingType-enum for more.
+        '';
+      };
+      letterSpacing = mkOption {
+        type = types.number;
+        default = 0;
+        description = ''
+          The amount of letter spacing for this font.
+
+          Could be a percentage or an absolute spacing change (positive increases spacing, negative decreases spacing),
+          based on the selected `letterSpacingType`.
+        '';
+      };
+      wordSpacing = mkOption {
+        type = types.number;
+        default = 0;
+        description = ''
+          The amount of word spacing for this font, in pixels.
+
+          Positive values increase spacing while negative ones decrease spacing.
+        '';
+      };
+      stretch = mkOption {
+        type = types.either (types.ints.between 1 4000) qfont.stretch;
+        default = "anyStretch";
+        description = ''
+          The stretch factor for this font, as an integral percentage (i.e. 150 means a 150% stretch),
+          or as a pre-defined stretch factor string.
+        '';
+      };
+      styleStrategy = mkOption {
+        type = styleStrategyType;
+        default = {};
+        description = ''
+          The strategy for matching similar fonts to this font.
+
+          See https://doc.qt.io/qt-6/qfont.html#StyleStrategy-enum for more.
+        '';
+      };
+      styleName = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          The style name of this font, overriding the `style` and `weight` parameters when set.
+          Used for special fonts that have styles beyond traditional settings.
+        '';
+      };
+    };
+  };
+
+  inherit (config.programs.plasma) enable;
+  cfg = lib.filterAttrs (_: v: v != null) config.programs.plasma.fonts;
+in {
+  options.programs.plasma.fonts = {
+    general = mkOption {
+      type = types.nullOr fontType;
+      default = null;
+      description = "The main font of the system.";
+      example = lib.literalExpression ''
+        {
+          family = "Noto Sans";
+          pointSize = 11;
+        }
+      '';
+    };
+    fixedWidth = mkOption {
+      type = types.nullOr fontType;
+      default = null;
+      description = "The fixed width or monospace font of the system.";
+      example = lib.literalExpression ''
+        {
+          family = "Iosevka";
+          pointSize = 11;
+        }
+      '';
+    };
+    small = mkOption {
+      type = types.nullOr fontType;
+      default = null;
+      description = "The font used for very small text.";
+      example = lib.literalExpression ''
+        {
+          family = "Noto Sans";
+          pointSize = 8;
+        }
+      '';
+    };
+    toolbar = mkOption {
+      type = types.nullOr fontType;
+      default = null;
+      description = "The font used for toolbars.";
+      example = lib.literalExpression ''
+        {
+          family = "Noto Sans";
+          pointSize = 10;
+        }
+      '';
+    };
+    menu = mkOption {
+      type = types.nullOr fontType;
+      default = null;
+      description = "The font used for menus.";
+      example = lib.literalExpression ''
+        {
+          family = "Noto Sans";
+          pointSize = 10;
+        }
+      '';
+    };
+    windowTitle = mkOption {
+      type = types.nullOr fontType;
+      default = null;
+      description = "The font used for windowTitles.";
+      example = lib.literalExpression ''
+        {
+          family = "Noto Sans";
+          pointSize = 10;
+        }
+      '';
+    };
+  };
+
+  config.programs.plasma.configFile.kdeglobals = let
+    mkFont = f: mkIf (enable && builtins.hasAttr f cfg) (qfont.fontToString cfg.${f});
+  in {
+    General = {
+      font.value = mkFont "general";
+      fixed.value = mkFont "fixedWidth";
+      smallestReadableFont.value = mkFont "small";
+      toolBarFont.value = mkFont "toolbar";
+      menuFont.value = mkFont "menu";
+    };
+    WM.activeFont.value = mkFont "windowTitle";
+  };
+}


### PR DESCRIPTION
This PR adds a new module for setting system fonts. I honestly spent way too much time reading how `QFont` works, but this module should at least be _very_ comprehensive to anyone who needs it.

Tested locally in my own system flake — works great!

I'm not exactly happy with how I handled the `pointSize` vs `pixelSize` thing, but submodules unfortunately can't have assertions... :(