### PR TITLE
module(widgets): mass refactor, add system tray and battery

### DIFF
--- a/examples/home.nix
+++ b/examples/home.nix
@@ -60,18 +60,23 @@
           # If no configuration is needed, specifying only the name of the
           # widget will add them with the default configuration.
           "org.kde.plasma.marginsseparator"
-          "org.kde.plasma.systemtray"
           # If you need configuration for your widget, instead of specifying the
           # the keys and values directly using the config attribute as shown
           # above, plasma-manager also provides some higher-level interfaces for
           # configuring the widgets. See modules/widgets for supported widgets
-          # and options for these widgets. The widget below shows an example of
-          # usage, where we add a digital clock, setting 12h time and first day
-          # of the week to sunday.
+          # and options for these widgets. The widgets below shows two examples
+          # of usage, one where we add a digital clock, setting 12h time and
+          # first day of the week to sunday and another adding a systray with
+          # all systray-entries shown.
           {
             digitalClock = {
               calendar.firstDayOfWeek = "sunday";
               time.format = "12h";
+            };
+          }
+          {
+            systemTray = {
+              items.showAll = true;
             };
           }
         ];

--- a/examples/home.nix
+++ b/examples/home.nix
@@ -67,7 +67,7 @@
           # and options for these widgets. The widgets below shows two examples
           # of usage, one where we add a digital clock, setting 12h time and
           # first day of the week to sunday and another adding a systray with
-          # all systray-entries shown.
+          # some modifications in which entries to show.
           {
             digitalClock = {
               calendar.firstDayOfWeek = "sunday";
@@ -75,8 +75,17 @@
             };
           }
           {
-            systemTray = {
-              items.showAll = true;
+            systemTray.items = {
+              # We explicitly show bluetooth and battery
+              shown = [
+                "org.kde.plasma.battery"
+                "org.kde.plasma.bluetooth"
+              ];
+              # And explicitly hide networkmanagement and volume
+              hidden = [
+                "org.kde.plasma.networkmanagement"
+                "org.kde.plasma.volume"
+              ];
             };
           }
         ];

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -178,7 +178,7 @@ in
         # https://github.com/pjones/plasma-manager/issues/76
         [ -f ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc ] && rm ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc
       '';
-      text = builtins.trace text text; 
+      text = builtins.trace text text;
       postCommands = lib.mkIf (anyNonDefaultScreens cfg.panels) ''
         if [ -f ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc ]; then
           sed -i 's/^lastScreen\\x5b$i\\x5d=/lastScreen[$i]=/' ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -136,7 +136,7 @@ let
     in
     ''
       {
-        const panel = new Panel;
+        const panel = new Panel();
         panel.height = ${toString panel.height};
         panel.floating = ${boolToString panel.floating};
         ${stringIfNotNull panel.alignment ''panel.alignment = "${panel.alignment}";''}

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -121,86 +121,48 @@ let
   # some hacky tricks to place them on their screens.
   anyNonDefaultScreens = builtins.any (panel: panel.screen != 0);
 
-  # any value or null -> string -> string 
-  # If value is null, returns the empty string, otherwise returns the provided string
-  stringIfNotNull = v: lib.optionalString (v != null);
-
-  # string -> string
-  # Wrap a string in double quotes.
-  wrapInQuotes = s: ''"${s}"'';
-
-  # list of strings -> string
-  # Converts a list of strings to a single string, that can be parsed as a string list in JavaScript
-  toJSStringList = values: ''[${lib.concatMapStringsSep ", " wrapInQuotes values}]'';
-
-  # Generate writeConfig calls to include for a widget with additional
-  # configurations.
-  genWidgetConfigStr = widget: group: key: value:
-    ''
-      var w = panelWidgets["${widget}"];
-      w.currentConfigGroup = ${toJSStringList (lib.splitString "/" group)};
-      w.writeConfig("${key}", ${
-        if builtins.isString value then 
-          wrapInQuotes value 
-        else
-          toJSStringList value 
-      });
-    '';
-  # Generate the text for all of the configuration for a widget with additional
-  # configurations.
-  widgetConfigsToStr = widget: config: lib.pipe config [
-    (lib.mapAttrsToList
-      (group: lib.mapAttrsToList (genWidgetConfigStr widget group))
-    )
-    lib.concatLists
-    (lib.concatStringsSep "\n")
-  ];
-
-  #
-  # Functions to aid us creating a single panel in the layout.js
-  #
-  plasma6OnlyCmd = cmd: ''
-    if (applicationVersion.split(".")[0] == 6) {
-      ${cmd}
-    }
-  '';
-
-  panelAddWidgetStr = widget:
-    let
-      widget' = widgets.convert widget;
-      createWidget = name: ''panelWidgets["${name}"] = panel.addWidget("${name}");'';
-    in
-    if builtins.isString widget
-    then createWidget widget
-    else
-      ''
-        ${createWidget widget'.name}
-        ${stringIfNotNull widget'.config (widgetConfigsToStr widget'.name widget'.config)}
-      '';
 
   panelToLayout = panel:
     let
+      inherit (widgets.lib) addWidgetStmts stringIfNotNull;
       inherit (lib) boolToString optionalString;
       inherit (builtins) toString;
+
+      # Functions to aid us creating a single panel in the layout.js
+      plasma6OnlyCmd = cmd: ''
+        if (isPlasma6) {
+          ${cmd}
+        }
+      '';
     in
     ''
-      var panel = new Panel;
-      panel.height = ${toString panel.height};
-      panel.floating = ${boolToString panel.floating};
-      ${stringIfNotNull panel.alignment ''panel.alignment = "${panel.alignment}";''}
-      ${stringIfNotNull panel.hiding ''panel.hiding = "${panel.hiding}";''}
-      ${stringIfNotNull panel.location ''panel.location = "${panel.location}";''}
-      ${stringIfNotNull panel.lengthMode (plasma6OnlyCmd ''panel.lengthMode = "${panel.lengthMode}";'')}
-      ${stringIfNotNull panel.maxLength "panel.maximumLength = ${toString panel.maxLength};"}
-      ${stringIfNotNull panel.minLength "panel.minimumLength = ${toString panel.minLength};"}
-      ${stringIfNotNull panel.offset "panel.offset = ${toString panel.offset};"}
-      ${optionalString (panel.screen != 0) ''panel.writeConfig("lastScreen[$i]", ${toString panel.screen});''}
+      {
+        const panel = new Panel;
+        panel.height = ${toString panel.height};
+        panel.floating = ${boolToString panel.floating};
+        ${stringIfNotNull panel.alignment ''panel.alignment = "${panel.alignment}";''}
+        ${stringIfNotNull panel.hiding ''panel.hiding = "${panel.hiding}";''}
+        ${stringIfNotNull panel.location ''panel.location = "${panel.location}";''}
+        ${stringIfNotNull panel.lengthMode (plasma6OnlyCmd ''panel.lengthMode = "${panel.lengthMode}";'')}
+        ${stringIfNotNull panel.maxLength "panel.maximumLength = ${toString panel.maxLength};"}
+        ${stringIfNotNull panel.minLength "panel.minimumLength = ${toString panel.minLength};"}
+        ${stringIfNotNull panel.offset "panel.offset = ${toString panel.offset};"}
+        ${optionalString (panel.screen != 0) ''panel.writeConfig("lastScreen[$i]", ${toString panel.screen});''}
 
-      var panelWidgets = {};
-      ${lib.concatMapStringsSep "\n" panelAddWidgetStr panel.widgets}
-
-      ${stringIfNotNull panel.extraSettings panel.extraSettings}
+        ${addWidgetStmts "panel" "panelWidgets" panel.widgets}
+        ${stringIfNotNull panel.extraSettings panel.extraSettings}
+      }
     '';
+
+  text = ''
+    // Removes all existing panels
+    panels().forEach((panel) => panel.remove());
+
+    const isPlasma6 = applicationVersion.split(".")[0] == 6;
+
+    // Adds the panels
+    ${lib.concatMapStringsSep "\n" panelToLayout config.programs.plasma.panels}
+  '';
 in
 {
   options.programs.plasma.panels = lib.mkOption {
@@ -216,13 +178,7 @@ in
         # https://github.com/pjones/plasma-manager/issues/76
         [ -f ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc ] && rm ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc
       '';
-      text = ''
-        // Removes all existing panels
-        panels().forEach((panel) => panel.remove());
-
-        // Adds the panels
-        ${lib.concatMapStringsSep "\n" panelToLayout config.programs.plasma.panels}
-      '';
+      text = builtins.trace text text; 
       postCommands = lib.mkIf (anyNonDefaultScreens cfg.panels) ''
         if [ -f ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc ]; then
           sed -i 's/^lastScreen\\x5b$i\\x5d=/lastScreen[$i]=/' ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc

--- a/modules/widgets/battery.nix
+++ b/modules/widgets/battery.nix
@@ -3,16 +3,13 @@
     description = "The battery indicator widget.";
 
     # See https://invent.kde.org/plasma/plasma-workspace/-/blob/master/applets/batterymonitor/package/contents/config/main.xml for the accepted raw options
-    opts.showPercentage = lib.mkOption {
-      type = with lib.types; nullOr bool;
-      default = null;
-      example = true;
-      description = "Enable to show the battery percentage as a small label over the battery icon.";
-    };
+    opts.showPercentage = widgets.lib.mkBoolOption "Enable to show the battery percentage as a small label over the battery icon.";
 
-    convert = { showPercentage ? null }: {
+    convert = { showPercentage }: {
       name = "org.kde.plasma.battery";
-      config.General.showPercentage = widgets.lib.boolToString' showPercentage;
+      config.General = lib.filterAttrs (_: v: v != null) {
+        inherit showPercentage;
+      };
     };
   };
 }

--- a/modules/widgets/battery.nix
+++ b/modules/widgets/battery.nix
@@ -1,0 +1,18 @@
+{lib, widgets, ...}: {
+  battery = {
+    description = "The battery indicator widget.";
+
+    # See https://invent.kde.org/plasma/plasma-workspace/-/blob/master/applets/batterymonitor/package/contents/config/main.xml for the accepted raw options
+    opts.showPercentage = lib.mkOption {
+      type = with lib.types; nullOr bool;
+      default = null;
+      example = true;
+      description = "Enable to show the battery percentage as a small label over the battery icon.";
+    };
+
+    convert = { showPercentage ? null }: {
+      name = "org.kde.plasma.battery";
+      config.General.showPercentage = widgets.lib.boolToString' showPercentage;
+    };
+  };
+}

--- a/modules/widgets/battery.nix
+++ b/modules/widgets/battery.nix
@@ -1,4 +1,4 @@
-{lib, widgets, ...}: {
+{ lib, widgets, ... }: {
   battery = {
     description = "The battery indicator widget.";
 

--- a/modules/widgets/default.nix
+++ b/modules/widgets/default.nix
@@ -5,6 +5,7 @@ let
   };
 
   sources = lib.mergeAttrsList (map (s: import s args') [
+    ./battery.nix
     ./digital-clock.nix
     ./system-monitor.nix
     ./system-tray.nix

--- a/modules/widgets/default.nix
+++ b/modules/widgets/default.nix
@@ -60,7 +60,7 @@ let
       };
     };
   };
-    
+
   isKnownWidget = lib.flip builtins.hasAttr sources;
 
   self = {
@@ -78,7 +78,7 @@ let
 
         converters = mapAttrs (_: s: s.convert) sources;
       in
-      if isAttrs composite && length keys == 1 && isKnownWidget type 
+      if isAttrs composite && length keys == 1 && isKnownWidget type
       then {
         config = null;
         extraConfig = "";
@@ -86,4 +86,4 @@ let
       else composite; # not a known composite type
   };
 in
-  self
+self

--- a/modules/widgets/default.nix
+++ b/modules/widgets/default.nix
@@ -1,8 +1,13 @@
 { lib, ... } @ args:
 let
-  sources = lib.mergeAttrsList (map (s: import s args) [
+  args' = args // {
+    widgets = self;
+  };
+
+  sources = lib.mergeAttrsList (map (s: import s args') [
     ./digital-clock.nix
     ./system-monitor.nix
+    ./system-tray.nix
   ]);
 
   compositeWidgetType = lib.pipe sources [
@@ -29,23 +34,55 @@ let
         example = {
           General.icon = "nix-snowflake-white";
         };
-        description = "Extra configuration-options for the widget.";
+        description = '' 
+          Configuration options for the widget.
+
+          See https://develop.kde.org/docs/plasma/scripting/keys/ for an (incomplete) list of options
+          that can be set here.
+        '';
+      };
+      extraConfig = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        example = ''
+          (widget) => {
+            widget.currentConfigGroup = ["General"];
+            widget.writeConfig("title", "My widget");
+          }
+        '';
+        description = ''
+          Extra configuration for the widget in JavaScript.
+
+          Should be a lambda/anonymous function that takes the widget as its sole argument,
+          which can then be called by the script.
+        '';
       };
     };
   };
+    
+  isKnownWidget = lib.flip builtins.hasAttr sources;
+
+  self = {
+    inherit isKnownWidget;
+
+    type = lib.types.either compositeWidgetType simpleWidgetType;
+
+    lib = import ./lib.nix (args // { widgets = self; });
+
+    convert = composite:
+      let
+        inherit (builtins) length head attrNames mapAttrs isAttrs;
+        keys = attrNames composite;
+        type = head keys;
+
+        converters = mapAttrs (_: s: s.convert) sources;
+      in
+      if isAttrs composite && length keys == 1 && isKnownWidget type 
+      then {
+        config = null;
+        extraConfig = "";
+      } // converters.${type} composite.${type}
+      else composite; # not a known composite type
+  };
 in
-{
-  type = lib.types.either compositeWidgetType simpleWidgetType;
-
-  convert = composite:
-    let
-      inherit (builtins) length head attrNames hasAttr mapAttrs isAttrs;
-      keys = attrNames composite;
-      type = head keys;
-
-      converters = mapAttrs (_: s: s.convert) sources;
-    in
-    if isAttrs composite && length keys == 1 && hasAttr type converters
-    then converters.${type} composite.${type}
-    else composite; # not a known composite type
-}
+  self

--- a/modules/widgets/digital-clock.nix
+++ b/modules/widgets/digital-clock.nix
@@ -184,10 +184,10 @@ in
     };
 
     convert =
-      { date ? {}
-      , time ? {}
-      , timeZone ? {}
-      , calendar ? {}
+      { date ? { }
+      , time ? { }
+      , timeZone ? { }
+      , calendar ? { }
       , font ? null
       ,
       }:

--- a/modules/widgets/digital-clock.nix
+++ b/modules/widgets/digital-clock.nix
@@ -1,6 +1,7 @@
 { lib, widgets, ... }:
 let
-  inherit (lib) mkEnableOption mkOption types;
+  inherit (lib) mkOption types;
+  inherit (widgets.lib) mkBoolOption mkEnumOption boolToString' getEnum;
 
   fontType = types.submodule {
     options = {
@@ -9,12 +10,13 @@ let
         example = "Noto Sans";
         description = "The family of the font.";
       };
-      bold = mkEnableOption "bold text";
-      italic = mkEnableOption "italic text";
+      bold = mkBoolOption "Enable bold text.";
+      italic = mkBoolOption "Enable italic text.";
       weight = mkOption {
         type = types.ints.between 1 1000;
         default = 50;
         description = "The weight of the font.";
+        apply = builtins.toString;
       };
       style = mkOption {
         type = types.nullOr types.str;
@@ -25,21 +27,9 @@ let
         type = types.ints.positive;
         default = 10;
         description = "The size of the font.";
+        apply = builtins.toString;
       };
     };
-  };
-
-  enums = {
-    date = {
-      format = [ "shortDate" "longDate" "isoDate" ];
-      position = [ "adaptive" "besideTime" "belowTime" ];
-    };
-    time = {
-      showSeconds = [ "never" "onlyInTooltip" "always" ];
-      format = [ "12h" "default" "24h" ];
-    };
-    timeZone.format = [ "code" "city" "offset" ];
-    calendar.weekdays = [ "sunday" "monday" "tuesday" "wednesday" "thursday" "friday" "saturday" ];
   };
 in
 {
@@ -50,34 +40,43 @@ in
       # See https://invent.kde.org/plasma/plasma-workspace/-/blob/master/applets/digital-clock/package/contents/config/main.xml for the accepted raw options
 
       date = {
-        enable = mkOption {
-          type = types.nullOr types.bool;
-          default = null;
-          example = true;
-          description = "Enable showing the current date.";
-        };
+        enable = mkBoolOption "Enable showing the current date.";
 
-        format = mkOption {
-          type = types.nullOr (types.either (types.enum enums.date.format) (types.submodule {
-            options.custom = mkOption {
-              type = types.str;
-              example = "ddd d";
-              description = "The custom date format to use.";
-            };
-          }));
-          default = null;
-          example = { custom = "d.MM.yyyy"; };
-          description = ''
-            The date format used for this clock.
+        format =
+          let
+            enum = [ "shortDate" "longDate" "isoDate" ];
+          in
+          mkOption {
+            type = types.nullOr (types.either (types.enum enum) (types.submodule {
+              options.custom = mkOption {
+                type = types.str;
+                example = "ddd d";
+                description = "The custom date format to use.";
+              };
+            }));
+            default = null;
+            example = { custom = "d.MM.yyyy"; };
+            description = ''
+              The date format used for this clock.
 
-            Could be as a short date, long date, a ISO 8601 date (yyyy-mm-dd), or a custom date format.
-            Short and long date formats are locale-dependent.
-          '';
-        };
+              Could be as a short date, long date, a ISO 8601 date (yyyy-mm-dd), or a custom date format.
+              Short and long date formats are locale-dependent.
+            '';
+            apply = f:
+              if f == null then
+                null
+              else if f ? custom then
+                {
+                  dateFormat = "custom";
+                  customDateFormat = f.custom;
+                }
+              else
+                { dateFormat = getEnum enum f; };
 
-        position = mkOption {
-          type = types.nullOr (types.enum enums.date.position);
-          default = null;
+          };
+
+        position = mkEnumOption [ "adaptive" "besideTime" "belowTime" ] // {
+          example = "belowTime";
           description = ''
             The position where the date is displayed.
 
@@ -87,18 +86,16 @@ in
       };
 
       time = {
-        showSeconds = mkOption {
-          type = types.nullOr (types.enum enums.time.showSeconds);
-          default = null;
+        showSeconds = mkEnumOption [ "never" "onlyInTooltip" "always" ] // {
+          example = "always";
           description = ''
             When and where the seconds should be shown on the clock.
 
             Could be never, only in the tooltip on hover, or always.
           '';
         };
-        format = mkOption {
-          type = types.nullOr (types.enum enums.time.format);
-          default = null;
+        format = mkEnumOption [ "12h" "default" "24h" ] // {
+          example = "24h";
           description = ''
             The time format used for this clock.
 
@@ -127,14 +124,8 @@ in
             The special value "Local" indicates the system's current timezone.
           '';
         };
-        changeOnScroll = mkOption {
-          type = types.nullOr types.bool;
-          default = null;
-          description = "Allow changing the displayed timezone by scrolling on the widget with the mouse wheel.";
-        };
-        format = mkOption {
-          type = types.nullOr (types.enum enums.timeZone.format);
-          default = null;
+        changeOnScroll = mkBoolOption "Allow changing the displayed timezone by scrolling on the widget with the mouse wheel.";
+        format = mkEnumOption [ "code" "city" "offset" ] // {
           example = "code";
           description = ''
             The format of the timezone displayed, whether as a
@@ -145,13 +136,11 @@ in
             listed above would display "CST", "Shanghai" and "+8" respectively.
           '';
         };
-        alwaysShow = mkEnableOption "always showing the selected timezone, when it's the same with the system timezone";
+        alwaysShow = mkBoolOption "Always show the selected timezone, when it's the same with the system timezone";
       };
 
       calendar = {
-        firstDayOfWeek = mkOption {
-          type = types.nullOr (types.enum enums.calendar.weekdays);
-          default = null;
+        firstDayOfWeek = mkEnumOption [ "sunday" "monday" "tuesday" "wednesday" "thursday" "friday" "saturday" ] // {
           example = "monday";
           description = ''
             The first day of the week that the calendar uses.
@@ -164,7 +153,7 @@ in
           default = null;
           description = "List of enabled calendar plugins, where additional event data can be sourced from.";
         };
-        showWeekNumbers = mkEnableOption "showing week numbers in the calendar";
+        showWeekNumbers = mkBoolOption "Enable showing week numbers in the calendar";
       };
 
       font = mkOption {
@@ -180,54 +169,48 @@ in
 
           If null, then it will use the system font and automatically expand to fill available space.
         '';
-      };
-    };
-
-    convert =
-      { date ? { }
-      , time ? { }
-      , timeZone ? { }
-      , calendar ? { }
-      , font ? null
-      ,
-      }:
-      let
-        inherit (builtins) toString;
-        inherit (widgets.lib) boolToString' getEnum;
-
-        isDateFormatCustom = date ? format && date.format ? custom;
-      in
-      {
-        name = "org.kde.plasma.digitalclock";
-        config.Appearance = lib.filterAttrs (_: v: v != null) (
+        apply = font:
           {
-            showDate = boolToString' (date.enable or null);
-            dateDisplayFormat = getEnum enums.date.position (date.position or null);
-            dateFormat = if isDateFormatCustom then "custom" else date.format or null;
-            customDateFormat = if isDateFormatCustom then date.format.custom else null;
-
-            showSeconds = getEnum enums.time.showSeconds (time.showSeconds or null);
-            use24hFormat = getEnum enums.time.format (time.format or null);
-
-            selectedTimeZones = timeZone.selected or null;
-            lastSelectedTimezone = timeZone.lastSelected or null;
-            wheelChangesTimezone = boolToString' (timeZone.changeOnScroll or null);
-            displayTimezoneFormat = getEnum enums.timeZone.format (timeZone.format or null);
-            showLocalTimezone = boolToString' (timeZone.alwaysShow or null);
-
-            firstDayOfWeek = getEnum enums.calendar.weekdays (calendar.firstDayOfWeek or null);
-            enabledCalendarPlugins = calendar.plugins or null;
-
             autoFontAndSize = boolToString' (font == null);
           }
           // lib.optionalAttrs (font != null) {
             fontFamily = font.family;
-            boldText = boolToString' font.bold;
-            italicText = boolToString' font.italic;
-            fontWeight = toString font.weight;
-            fontStyleName = font.styleName;
-            fontSize = toString font.size;
+            boldText = font.bold;
+            italicText = font.italic;
+            fontWeight = font.weight;
+            fontStyleName = font.style;
+            fontSize = font.size;
+          };
+      };
+    };
+
+    convert =
+      { date
+      , time
+      , timeZone
+      , calendar
+      , font
+      }: {
+        name = "org.kde.plasma.digitalclock";
+        config.Appearance = lib.filterAttrs (_: v: v != null) (
+          {
+            showDate = date.enable;
+            dateDisplayFormat = date.position;
+
+            showSeconds = time.showSeconds;
+            use24hFormat = time.format;
+
+            selectedTimeZones = timeZone.selected;
+            lastSelectedTimezone = timeZone.lastSelected;
+            wheelChangesTimezone = timeZone.changeOnScroll;
+            displayTimezoneFormat = timeZone.format;
+            showLocalTimezone = timeZone.alwaysShow;
+
+            firstDayOfWeek = calendar.firstDayOfWeek;
+            enabledCalendarPlugins = calendar.plugins;
           }
+          // date.format
+          // font
         );
       };
   };

--- a/modules/widgets/digital-clock.nix
+++ b/modules/widgets/digital-clock.nix
@@ -64,7 +64,7 @@ in
             '';
             apply = f:
               if f == null then
-                {}
+                { }
               else if f ? custom then
                 {
                   dateFormat = "custom";

--- a/modules/widgets/digital-clock.nix
+++ b/modules/widgets/digital-clock.nix
@@ -64,7 +64,7 @@ in
             '';
             apply = f:
               if f == null then
-                null
+                {}
               else if f ? custom then
                 {
                   dateFormat = "custom";

--- a/modules/widgets/lib.nix
+++ b/modules/widgets/lib.nix
@@ -1,0 +1,81 @@
+{lib, widgets, ...}: let
+  inherit (lib) 
+    optionalString
+    concatMapStringsSep 
+    concatStringsSep 
+    mapAttrsToList
+    splitString
+    ;
+
+  # any value or null -> string -> string 
+  # If value is null, returns the empty string, otherwise returns the provided string
+  stringIfNotNull = v: optionalString (v != null);
+
+  # string -> string
+  # Wrap a string in double quotes.
+  wrapInQuotes = s: ''"${s}"'';
+
+  # list of strings -> string
+  # Converts a list of strings to a single string, that can be parsed as a string list in JavaScript
+  toJSStringList = values: ''[${concatMapStringsSep ", " wrapInQuotes values}]'';
+
+  setWidgetSettings = var: settings: let
+    perConfig = key: value: ''${var}.writeConfig("${key}", ${
+      if builtins.isString value
+      then wrapInQuotes value
+      else toJSStringList value
+    });'';
+    perGroup = group: configs: ''
+      ${var}.currentConfigGroup = ${toJSStringList (splitString "/" group)};
+      ${concatStringsSep "\n" (mapAttrsToList perConfig configs)}
+    '';
+  in 
+    concatStringsSep "\n" (mapAttrsToList perGroup settings);
+
+  addWidgetStmts = containment: var: ws: let 
+    widgetConfigsToStmts = widget: ''
+      var w = ${var}["${widget.name}"];
+      ${setWidgetSettings "w" widget.config}
+    '';
+
+    addStmt = widget:
+      let
+        widget' = widgets.convert widget;
+        createWidget = name: ''${var}["${name}"] = ${containment}.addWidget("${name}");'';
+      in
+      if builtins.isString widget
+      then createWidget widget
+      else
+        ''
+          ${createWidget widget'.name}
+          ${stringIfNotNull widget'.config (widgetConfigsToStmts widget')}
+          ${lib.optionalString (widget'.extraConfig != "") ''
+            (${widget'.extraConfig})(${var}["${widget'.name}"]);
+          ''}
+        '';
+  in ''
+    const ${var} = {};
+    ${lib.concatMapStringsSep "\n" addStmt ws}
+  '';
+
+  boolToString' = b: if b == null then null else lib.boolToString b;
+
+  getEnum = es: e:
+    if e == null
+    then null
+    else
+      toString (
+        lib.lists.findFirstIndex
+          (x: x == e)
+          (throw "getEnum: nonexistent key ${e}! This is a bug!")
+          es
+      );
+in {
+  inherit 
+    stringIfNotNull 
+    setWidgetSettings
+    addWidgetStmts
+    boolToString'
+    getEnum
+    ;
+}

--- a/modules/widgets/system-monitor.nix
+++ b/modules/widgets/system-monitor.nix
@@ -7,6 +7,8 @@ in
     description = "A system monitor widget.";
 
     opts = {
+      # See https://invent.kde.org/plasma/plasma-workspace/-/blob/master/applets/systemmonitor/systemmonitor/package/contents/config/main.xml for the accepted raw options 
+
       title = mkOption {
         type = types.nullOr types.str;
         default = null;
@@ -64,11 +66,11 @@ in
     };
 
     convert =
-      { title
-      , displayStyle
-      , totalSensors
-      , sensors
-      , textOnlySensors
+      { title ? null
+      , displayStyle ? null
+      , totalSensors ? null
+      , sensors ? null
+      , textOnlySensors ? null
       ,
       }:
       let

--- a/modules/widgets/system-tray.nix
+++ b/modules/widgets/system-tray.nix
@@ -94,7 +94,7 @@ in
           default = { };
           example = {
             # Example of a widget-specific config
-            battery.enablePercentage = true;
+            battery.showPercentage = true;
 
             # Example of raw config for an untyped widget
             "org.kde.plasma.devicenotifier".config = {

--- a/modules/widgets/system-tray.nix
+++ b/modules/widgets/system-tray.nix
@@ -1,0 +1,164 @@
+{lib, widgets, ...}: let
+  inherit (lib) mkOption types;
+
+  enums.icons.spacing = ["small" "medium" "large"];
+in {
+  systemTray = {
+    description = "A system tray of other widgets/plasmoids";
+
+    opts = {
+      # See https://invent.kde.org/plasma/plasma-workspace/-/blob/master/applets/systemtray/package/contents/config/main.xml for the accepted raw options.
+
+      pin = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Whether the popup should remain open when another window is activated.";
+      };
+
+      icons = {
+        spacing = mkOption {
+          type = types.nullOr (types.either (types.enum enums.icons.spacing) types.ints.positive);
+          default = null;
+          description = ''
+            The spacing between icons.
+
+            Could be an integer unit, or "small" (1 unit), "medium" (2 units) or "large" (6 units).
+          '';
+        };
+        scaleToFit = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = ''
+            Whether to automatically scale System Tray icons to fix the available thickness of the panel.
+
+            If false, tray icons will be capped at the smallMedium size (22px) and become a two-row/column
+            layout when the panel is thick.
+          '';
+        };
+      };
+
+      items = {
+        showAll = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = "If true, all system tray entries will always be in the main bar, outside the popup.";
+        };
+
+        hidden = mkOption {
+          type = types.nullOr (types.listOf types.str);
+          default = null;
+          example = [
+            # Plasmoid plugin example
+            "org.kde.plasma.brightness"
+
+            # StatusNotifier example
+            "org.kde.plasma.addons.katesessions"
+          ];
+          description = ''
+            List of widgets that should be hidden from the main bar, only visible in the popup.
+
+            Expects a list of plasmoid plugin IDs or StatusNotifier IDs.
+          '';
+        };
+
+        shown = mkOption {
+          type = types.nullOr (types.listOf types.str);
+          default = null;
+          example = [
+            # Plasmoid plugin example
+            "org.kde.plasma.battery"
+
+            # StatusNotifier example
+            "org.kde.plasma.addons.katesessions"
+          ];
+          description = ''
+            List of widgets that should be shown in the main bar.
+
+            Expects a list of plasmoid plugin IDs or StatusNotifier IDs.
+          '';
+        };
+
+        extra = mkOption {
+          type = types.nullOr (types.listOf types.str);
+          default = null;
+          example = ["org.kde.plasma.battery"];
+          description = ''
+            List of extra widgets that are explicitly enabled in the system tray.
+
+            Expects a list of plasmoid plugin IDs.
+          '';
+        };
+
+        configs = mkOption {
+          # TODO: bother with typing this later
+          type = types.attrsOf types.anything;
+          default = {};
+          example = {
+            # Example of a widget-specific config
+            battery.enablePercentage = true;
+
+            # Example of raw config for an untyped widget
+            "org.kde.plasma.devicenotifier".config = {
+              removableDevices = false;
+              nonRemovableDevices = true;
+            };
+          };
+          description = ''
+            Configurations for each widget in the tray.
+
+            Uses widget-specific configs if the key is a known widget type,
+            otherwise uses raw configs that's not specifically checked to be valid,
+            or even idiomatic in Nix!
+          '';
+        };
+      };
+    };
+
+    convert = {
+      pin ? null,
+      icons ? {},
+      items ? {},
+    }: let 
+      inherit (widgets.lib) boolToString';
+
+      settings.General = lib.filterAttrs (_: v: v != null) {
+        pin = boolToString' pin;
+        extraItems = items.extra or null;
+        hiddenItems = items.hidden or null;
+        shownItems = items.shown or null;
+        showAllItems = boolToString' (items.showAll or null);
+        scaleItemsToFit = boolToString' (icons.scaleToFit or null);
+        iconSpacing = if !(icons ? spacing) then 
+          null
+        else if builtins.isInt icons.spacing then 
+          toString icons.spacing
+        else
+          widgets.lib.getEnum enums.icons.spacing icons.spacing;
+      }; 
+
+      configs' = lib.mapAttrsToList (name: config: 
+        if widgets.isKnownWidget name then
+          # Looks a bit funny, does the job just right.
+          widgets.convert { ${name} = config; }
+        else
+          { 
+            inherit name; 
+            config = null; 
+            extraConfig = "";
+          } // config
+      ) items.configs;
+    in {
+      name = "org.kde.plasma.systemtray";
+      extraConfig = ''
+        (widget) => {
+          const tray = desktopById(widget.readConfig("SystrayContainmentId"));
+          if (!tray) return; // if somehow the containment doesn't exist
+          
+          ${widgets.lib.setWidgetSettings "tray" (builtins.trace items.shown settings)}
+          
+          ${widgets.lib.addWidgetStmts "tray" "trayWidgets" configs'}
+        }
+      '';
+    };
+  };
+}


### PR DESCRIPTION
Fixes #126 

Here's a list of changes:

- Most of the code that generates the JS required for adding and configuring the widgets are now moved to `modules/widgets/lib.nix`. Since system trays are also technically containments, and configuring things there is very similar to configuring a panel, it's worth refactoring it into code that can be shared for both.

- Every panel is now in its own scope, in order to avoid name collisions. As a direct consequence of that, all `var`s are replaced by `const`s, as there's now no need for redeclaring variables. Besides, `var` is a code smell anyways in modern JS due to its unpredictable scoping rules, and it's best to avoid it in new code.

- Config fields in the same group of the same widget will now share the `w.currentConfigGroup` and `w` variable assignments. Essentially, instead of this:

  ```js
  var w = panelWidgets["org.kde.plasma.systemmonitor"];
  w.currentConfigGroup = ["Appearance"];
  w.writeConfig("title", "CPU Usage");

  var w = panelWidgets["org.kde.plasma.systemmonitor"];
  w.currentConfigGroup = ["Sensors"];
  w.writeConfig("highPrioritySensorIds", '["cpu/all/usage"]');

  var w = panelWidgets["org.kde.plasma.systemmonitor"];
  w.currentConfigGroup = ["Sensors"];
  w.writeConfig("lowPrioritySensorIds", '["cpu/all/temperature"]');

  var w = panelWidgets["org.kde.plasma.systemmonitor"];
  w.currentConfigGroup = ["Sensors"];
  w.writeConfig("totalSensors", '["cpu/all/usage"]');
  ```

  We now generate:

  ```js
  const w = panelWidgets["org.kde.plasma.systemmonitor"];
  w.currentConfigGroup = ["Appearance"];
  w.writeConfig("title", "CPU Usage");

  w.currentConfigGroup = ["Sensors"];
  w.writeConfig("highPrioritySensorIds", "[\"cpu/all/usage\""]);
  w.writeConfig("lowPrioritySensorIds", "[\"cpu/all/temperature\""]);
  w.writeConfig("totalSensors", "[\"cpu/all/usage\"]");
  ```

  This _massively_ cuts down generated code, and is much cleaner in general.

- Every setting on every widget is now nullable. Setting anything to null basically makes it unset, which allows us to eliminate setting a default on the Nix side, so that upstream default changes won't affect us.
- An `extraConfig` field has been added for raw widgets, that takes a lambda/anonymous function that accepts one argument — the widget to be configured. I figure this allows more room for the user to name the widget whatever they want, and not rely on hardcoded variable names.

  This is _required_ to make system trays work, because configuring them is... quite peculiar, to say the least.

- I've added a link to the config/main.xml file that defines each widget's config options, which is a much more reliable source than KDE docs.

- The widget system now makes use of native module system features (such as the `apply` field for `mkOption`), in order to make converters less of an eyesore, make Nix report better errors, and make the system more robust against erroneous user input in general.

- And of course, you can now customize system trays to your liking, without knowing what eldritch horror lies beneath to make it work.

- Also, battery indicators!
