### PR TITLE
Add persistence to keys modified by startup-script from the workspace module

### DIFF
--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -169,6 +169,14 @@ in
           '';
           priority = 1;
         };
+        # We add persistence to some keys in order to not reset the themes on
+        # each generation when we use overrideConfig.
+        programs.plasma.configFile.kcminputrc.Mouse.cursorTheme.persistent = lib.mkDefault (cfg.workspace.cursorTheme != null);
+        programs.plasma.configFile.kdeglobals.General.ColorScheme.persistent = lib.mkDefault (cfg.workspace.colorScheme != null);
+        programs.plasma.configFile.kdeglobals.General.ColorSchemeHash.persistent = lib.mkDefault (cfg.workspace.colorScheme != null);
+        programs.plasma.configFile.kdeglobals.Icons.Theme.persistent = lib.mkDefault (cfg.workspace.iconTheme != null);
+        programs.plasma.configFile.kdeglobals.KDE.LookAndFeelPackage.persistent = lib.mkDefault (cfg.workspace.lookAndFeel != null);
+        programs.plasma.configFile.plasmarc.Theme.name.persistent = lib.mkDefault (cfg.workspace.theme != null);
       })
     (lib.mkIf (cfg.workspace.wallpaper != null) {
       # We need to set the wallpaper after the panels are created in order for


### PR DESCRIPTION
This makes it so that certain keys are persistent by default when certain theme options in the `workspace` module is set. These are modified by the startup-scripts and thus don't need to be removed by `plasma-manager` on each activation. Not resetting these keys on each activation leads to more stability in the themes when using `overrideConfig`, both at startup and between a new generation and re-logging back in.

This is not perfect however, as some themes will still be reset after activation. Finding out which keys should be persistent and not will be considered more in the future, and how to best implement this. For now though this should at the very least in some cases improve theme-experiences.

Wallpapers are also not included in this pr due to not setting any fixed keys. Finding out similar support for wallpapers will be a challenge for the future.