### PR TITLE
Add more persistent keys for colorschemes in kdeglobals

### DIFF
--- a/lib/colorscheme.nix
+++ b/lib/colorscheme.nix
@@ -1,0 +1,47 @@
+{ lib, ... }:
+let
+  colorEffectsKeys = [
+    "ChangeSelectionColor"
+    "Color"
+    "ColorAmount"
+    "ColorEffect"
+    "ContrastAmount"
+    "ContrastEffect"
+    "Enable"
+    "IntensityAmount"
+    "IntensityEffect"
+  ];
+  colorUIKeys = [
+    "BackgroundAlternate"
+    "BackgroundNormal"
+    "DecorationFocus"
+    "DecorationHover"
+    "ForegroundActive"
+    "ForegroundInactive"
+    "ForegroundLink"
+    "ForegroundNegative"
+    "ForegroundNeutral"
+    "ForegroundNormal"
+    "ForegroundVisited"
+    "regroundPositive"
+  ];
+  ignoreKeys = {
+    "ColorEffects:Disabled" = colorEffectsKeys;
+    "ColorEffects:Inactive" = colorEffectsKeys;
+    "Colors:Button" = colorUIKeys;
+    "Colors:Selection" = colorUIKeys;
+    "Colors:Tooltip" = colorUIKeys;
+    "Colors:View" = colorUIKeys;
+    "Colors:Window" = colorUIKeys;
+  };
+in
+(lib.mkMerge
+  (lib.mapAttrsToList
+    (group: keys: {
+      "kdeglobals"."${group}" = (lib.mkMerge
+        (map
+          (key:
+            { "${key}"."persistent" = (lib.mkDefault true); })
+          keys));
+    })
+    ignoreKeys))

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -171,13 +171,22 @@ in
         };
         # We add persistence to some keys in order to not reset the themes on
         # each generation when we use overrideConfig.
-        programs.plasma.configFile = lib.mkIf (cfg.overrideConfig) {
-          kcminputrc.Mouse.cursorTheme.persistent = lib.mkDefault (cfg.workspace.cursorTheme != null);
-          kdeglobals.General.ColorScheme.persistent = lib.mkDefault (cfg.workspace.colorScheme != null);
-          kdeglobals.Icons.Theme.persistent = lib.mkDefault (cfg.workspace.iconTheme != null);
-          kdeglobals.KDE.LookAndFeelPackage.persistent = lib.mkDefault (cfg.workspace.lookAndFeel != null);
-          plasmarc.Theme.name.persistent = lib.mkDefault (cfg.workspace.theme != null);
-        };
+        programs.plasma.configFile = lib.mkIf (cfg.overrideConfig) (
+          let
+            colorSchemeIgnore = if (cfg.workspace.colorScheme != null) then (import ../lib/colorscheme.nix { inherit lib; }) else { };
+          in
+          (lib.mkMerge
+            [
+              {
+                kcminputrc.Mouse.cursorTheme.persistent = lib.mkDefault (cfg.workspace.cursorTheme != null);
+                kdeglobals.General.ColorScheme.persistent = lib.mkDefault (cfg.workspace.colorScheme != null);
+                kdeglobals.Icons.Theme.persistent = lib.mkDefault (cfg.workspace.iconTheme != null);
+                kdeglobals.KDE.LookAndFeelPackage.persistent = lib.mkDefault (cfg.workspace.lookAndFeel != null);
+                plasmarc.Theme.name.persistent = lib.mkDefault (cfg.workspace.theme != null);
+              }
+              colorSchemeIgnore
+            ])
+        );
       })
     (lib.mkIf (cfg.workspace.wallpaper != null) {
       # We need to set the wallpaper after the panels are created in order for


### PR DESCRIPTION
This should make it so that the theme doesn't break after home-manager activation (i.e. between home-manager activation and next login). This is done by making keys related to the colorscheme in `~/.config/kdeglobals` persistent, so they are left unchanged after the home-manager activation, until they are changed by the autostart script to fit the colorscheme specified.