### PR TITLE
system-monitor widget: Add label parameter for sensors

### DIFF
--- a/modules/widgets/system-monitor.nix
+++ b/modules/widgets/system-monitor.nix
@@ -31,10 +31,20 @@ let
   toColorKV =
     { name
     , color
+    , label
     ,
     }: {
       inherit name;
       value = color;
+    };
+  toLabelKV =
+    { name
+    , color
+    , label
+    ,
+    }: {
+      inherit name;
+      value = label;
     };
 in
 {
@@ -68,6 +78,11 @@ in
               example = "255,255,255";
               description = "The color of the sensor, as a string containing 8-bit integral RGB values separated by commas";
             };
+            label = mkOption {
+              type = types.str;
+              example = "CPU %";
+              description = "The label of the sensor.";
+            };
           };
         }));
         default = null;
@@ -75,6 +90,7 @@ in
           {
             name = "gpu/gpu1/usage";
             color = "180,190,254";
+            label = "GPU %";
           }
         ];
         description = ''
@@ -82,6 +98,7 @@ in
         '';
         apply = sensors: lib.optionalAttrs (sensors != null) {
           SensorColors = builtins.listToAttrs (map toColorKV sensors);
+          SensorLabels = builtins.listToAttrs (map toLabelKV sensors);
           Sensors.highPrioritySensorIds = toEscapedList (map (s: s.name) sensors);
         };
       };


### PR DESCRIPTION
Hello, thank you everyone for your work!

This is a small change to allow adding a label for a system monitor panel widget.

I did it by copying the code pattern currently used for colors (I'm sure it could be done better by creating re-usable modules etc for lines 40 and 101, but I'm new to Nix so I wouldn't know how to do it yet :sweat_smile: )