### PR TITLE
Change lib.mergeAttrsList to lib.attrsets.mergeAttrsList

### DIFF
--- a/modules/widgets/default.nix
+++ b/modules/widgets/default.nix
@@ -4,7 +4,7 @@ let
     widgets = self;
   };
 
-  sources = lib.mergeAttrsList (map (s: import s args') [
+  sources = lib.attrsets.mergeAttrsList (map (s: import s args') [
     ./battery.nix
     ./digital-clock.nix
     ./system-monitor.nix


### PR DESCRIPTION
Hello,

This is a tiny change to use `lib.attrsets.mergeAttrsList` instead of `lib.mergeAttrsList`, because the latter doesn't seem to exist in nixpkgs-23.11. 

Thanks for all the work on this project !