### PR TITLE
support custom konsole colorSchemes

### DIFF
--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -4,9 +4,10 @@ let
 
   # used as shown in the example in the library docs:
   # https://ryantm.github.io/nixpkgs/functions/library/attrsets/#function-library-lib.attrsets.mapAttrs-prime
-  createSchemes = name: value: lib.attrsets.nameValuePair
-    ( "konsole/${name}.colorscheme" )
-    ( { source = value; } );
+  createColorSchemes = lib.attrsets.mapAttrs' (name: value: lib.attrsets.nameValuePair
+    ("konsole/${name}.colorscheme")
+    ( { enable = true; source = value; })
+  );
 
   cfg = config.programs.konsole;
   profilesSubmodule = {
@@ -133,9 +134,10 @@ in
       )
     ];
 
-    xdg.dataFile = lib.mkIf (cfg.profiles != { })
-      (
-        lib.mkMerge ([
+    xdg.dataFile = lib.mkMerge [
+      (lib.mkIf (cfg.profiles != { })
+        (
+          lib.mkMerge ([
           (
             lib.mkMerge (
               lib.mapAttrsToList
@@ -174,9 +176,10 @@ in
                 cfg.profiles
             )
           )
-        ])
+          ])
+        )
       )
-      //
-      lib.mapAttrs' createSchemes cfg.customColorSchemes;
+      (createColorSchemes cfg.customColorSchemes)
+    ];
   };
 }

--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -2,6 +2,12 @@
 let
   inherit (import ../../lib/types.nix { inherit lib; }) basicSettingsType;
 
+  # used as shown in the example in the library docs:
+  # https://ryantm.github.io/nixpkgs/functions/library/attrsets/#function-library-lib.attrsets.mapAttrs-prime
+  createSchemes = name: value: lib.attrsets.nameValuePair
+    ( "konsole/${name}.colorscheme" )
+    ( { source = value; } );
+
   cfg = config.programs.konsole;
   profilesSubmodule = {
     options = {
@@ -18,7 +24,9 @@ let
         example = "Catppuccin-Mocha";
         description = ''
           Color scheme the profile will use. You can check the files you can
-          use in ~/.local/share/konsole or /run/current-system/share/konsole
+          use in ~/.local/share/konsole or /run/current-system/share/konsole.
+          You might also add a custom color scheme using
+          `programs.konsole.customColorSchemes`.
         '';
       };
       command = lib.mkOption {
@@ -92,6 +100,15 @@ in
       '';
     };
 
+    customColorSchemes = lib.mkOption {
+      type = with lib.types; attrsOf path;
+      default = {};
+      description = ''
+        Custom color schemes to be added to the installation. The key is their name.
+        Choose them in any profile with `profiles.<profile>.colorScheme = <name>`;
+      '';
+    };
+
     extraConfig = lib.mkOption {
       type = with lib.types; nullOr (attrsOf (attrsOf (basicSettingsType)));
       default = null;
@@ -158,6 +175,8 @@ in
             )
           )
         ])
-      );
+      )
+      //
+      lib.mapAttrs' createSchemes cfg.customColorSchemes;
   };
 }


### PR DESCRIPTION
These changes allow users to add custom colorSchemes for konsole. (These are the themes deciding *what the terminal looks like*, NOT *what the UI looks like*, where "terminal" refers to "the big black box in the center", and UI refers to "all the buttons and menus around it".)