### PR TITLE
Never overwrite files in `overrideConfigExclude`

### DIFF
--- a/script/write_config.py
+++ b/script/write_config.py
@@ -171,15 +171,10 @@ class KConfManager:
                     )
                 elif value["persistent"]:
                     base_msg = f'Plasma-manager: Persistency enabled for key "{key}" in group "{group}" in configfile "{self.filepath}"'
-                    # We don't allow persistency when not using overrideConfig,
-                    # the value is set, immutability is enabled, or when
-                    # shell-expansion is enabled.
-                    if not self.override_config:
-                        raise Exception(
-                            f"{base_msg} when overrideConfig is disabled (or using overrideConfigExclude). "
-                            "Persistency without using overrideConfig is not supported"
-                        )
-                    elif value["value"] is not None:
+                    # We don't allow persistency when the value is set,
+                    # immutability is enabled, or when shell-expansion is
+                    # enabled.
+                    if value["value"] is not None:
                         raise Exception(
                             f"{base_msg} with non-null value \"{value['value']}\". "
                             "A value cannot be given when persistency is enabled"

--- a/script/write_config.py
+++ b/script/write_config.py
@@ -176,7 +176,7 @@ class KConfManager:
                     # shell-expansion is enabled.
                     if not self.override_config:
                         raise Exception(
-                            f"{base_msg} when overrideConfig is disabled. "
+                            f"{base_msg} when overrideConfig is disabled (or using overrideConfigExclude). "
                             "Persistency without using overrideConfig is not supported"
                         )
                     elif value["value"] is not None:
@@ -311,9 +311,9 @@ def remove_config_files(d: Dict, reset_files: Set):
                 os.remove(file_to_del)
 
 
-def write_configs(d: Dict, override_config: bool):
+def write_configs(d: Dict, reset_files: Set):
     for filepath, c in d.items():
-        config = KConfManager(filepath, c, override_config)
+        config = KConfManager(filepath, c, filepath in reset_files)
         config.run()
         config.save()
 
@@ -331,7 +331,6 @@ def main():
     # We send in "true" as the second argument if overrideConfig is enabled in
     # plasma-manager.
     override_config = bool(sys.argv[2])
-    # os.system(f"echo '{sys.argv[2]}' > /home/user1/Downloads/test")
     # The files to be reset when we have overrideConfig enabled.
     oc_reset_files = set(sys.argv[3].split(" "))
 
@@ -340,7 +339,7 @@ def main():
     # not configured through plasma-manager.
     if override_config:
         remove_config_files(d, oc_reset_files)
-    write_configs(d, override_config)
+    write_configs(d, oc_reset_files if override_config else {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #184.

I made an effort to make this fix as simple as possible, but there is one change in behavior with this approach: `configFile`s that are not in `overrideConfigFiles` or `overrideConfigExclude` will no longer be overwritten when `overrideConfig` is enabled, whereas previously they would be.

I can change this if it is a problem, just let me know. The documentation seems vague on whether or not the current behavior is intentional, so I wasn't sure.

Also, I haven't done much testing yet; the diff is pretty small so I'm not too worried, but a sanity check would be appreciated. Thanks :)