### PR TITLE
add ui colorscheme support for kate and konsole

### DIFF
--- a/modules/apps/kate/default.nix
+++ b/modules/apps/kate/default.nix
@@ -112,32 +112,8 @@ in
     }
   ];
 
-  config.programs.plasma.configFile."katerc" = lib.mkIf cfg.enable {
-    "KTextEditor Document" = {
-      "Auto Detect Indent" = cfg.editor.indent.autodetect;
-      "Indentation Width" = cfg.editor.indent.width;
-      "Tab Handling" = (tabHandlingMode cfg.editor.indent);
-      "Tab Width" = cfg.editor.tabWidth;
-      "Keep Extra Spaces" = cfg.editor.indent.keepExtraSpaces;
-      "ReplaceTabsDyn" = cfg.editor.indent.replaceWithSpaces;
-    };
-
-    "KTextEditor Renderer" = {
-      "Show Indentation Lines" = cfg.editor.indent.showLines;
-
-
-      # COLORTHEME (cannot define this below)
-      # Do pick the theme if the user chose one,
-      # Do not touch the theme settings otherwise
-      "Auto Color Theme Selection" = lib.mkIf (cfg.editor.theme.name != "") false;
-      "Color Theme" = lib.mkIf (cfg.editor.theme.name != "") cfg.editor.theme.name;
-    };
-  };
-
-
   # ==================================
   #     COLORTHEME
-
   options.programs.kate.editor.theme = {
     src = lib.mkOption {
       description = ''
@@ -193,7 +169,6 @@ in
 
   # ==================================
   #     LSP Servers
-
   options.programs.kate.lsp.customServers = lib.mkOption {
     default = { };
     type = lib.types.attrs;
@@ -206,5 +181,42 @@ in
 
   config.xdg.configFile."kate/lspclient/settings.json" = {
     text = builtins.toJSON { servers = cfg.lsp.customServers; };
+  };
+
+  # ==================================
+  #     UI
+  options.programs.kate.ui.colorScheme = lib.mkOption {
+    type = lib.types.nullOr lib.types.str;
+    default = null;
+
+    example = "Krita dark orange";
+    description = ''
+      The colour scheme of the UI. Leave this setting at `null` in order to
+      not override the systems default scheme for for this application.
+    '';
+  };
+
+  # ==================================
+  #     WRITING THE KATERC
+  config.programs.plasma.configFile."katerc" = lib.mkIf cfg.enable {
+    "KTextEditor Document" = {
+      "Auto Detect Indent" = cfg.editor.indent.autodetect;
+      "Indentation Width" = cfg.editor.indent.width;
+      "Tab Handling" = (tabHandlingMode cfg.editor.indent);
+      "Tab Width" = cfg.editor.tabWidth;
+      "Keep Extra Spaces" = cfg.editor.indent.keepExtraSpaces;
+      "ReplaceTabsDyn" = cfg.editor.indent.replaceWithSpaces;
+    };
+
+    "KTextEditor Renderer" = {
+      "Show Indentation Lines" = cfg.editor.indent.showLines;
+
+      # Do pick the theme if the user chose one,
+      # Do not touch the theme settings otherwise
+      "Auto Color Theme Selection" = lib.mkIf (cfg.editor.theme.name != "") false;
+      "Color Theme" = lib.mkIf (cfg.editor.theme.name != "") cfg.editor.theme.name;
+    };
+
+    "UiSettings"."ColorScheme".value = lib.mkIf (cfg.ui.colorScheme != null) cfg.ui.colorScheme;
   };
 }

--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -110,6 +110,16 @@ in
       '';
     };
 
+    ui.colorScheme = lib.mkOption {
+      type = with lib.types; nullOr str;
+      default = null;
+      example = "Krita dark orange";
+      description = ''
+        The colour scheme of the UI. Leave this setting at `null` in order to
+        not override the systems default scheme for for this application.
+      '';
+    };
+
     extraConfig = lib.mkOption {
       type = with lib.types; nullOr (attrsOf (attrsOf (basicSettingsType)));
       default = null;
@@ -132,6 +142,9 @@ in
             (lib.mapAttrs (keyName: keyAttrs: { value = keyAttrs; }) groupAttrs))
           cfg.extraConfig)
       )
+      {
+        "UiSettings"."ColorScheme".value = cfg.ui.colorScheme;
+      }
     ];
 
     xdg.dataFile = lib.mkMerge [

--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -143,7 +143,12 @@ in
           cfg.extraConfig)
       )
       {
-        "UiSettings"."ColorScheme".value = lib.mkIf (cfg.ui.colorScheme != null) cfg.ui.colorScheme;
+        "UiSettings"."ColorScheme" = lib.mkIf (cfg.ui.colorScheme != null) {
+          value = cfg.ui.colorScheme;
+          # if this wasn't immutable, it currently doesn't work when overrideConfig is activated
+          # see also: discussion at https://github.com/pjones/plasma-manager/pull/186
+          immutable = lib.mkIf config.programs.plasma.overrideConfig (lib.mkDefault true);
+        };
       }
     ];
 

--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -143,7 +143,7 @@ in
           cfg.extraConfig)
       )
       {
-        "UiSettings"."ColorScheme".value = cfg.ui.colorScheme;
+        "UiSettings"."ColorScheme".value = lib.mkIf (cfg.ui.colorScheme != null) cfg.ui.colorScheme;
       }
     ];
 

--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -6,7 +6,7 @@ let
   # https://ryantm.github.io/nixpkgs/functions/library/attrsets/#function-library-lib.attrsets.mapAttrs-prime
   createColorSchemes = lib.attrsets.mapAttrs' (name: value: lib.attrsets.nameValuePair
     ("konsole/${name}.colorscheme")
-    ( { enable = true; source = value; })
+    ({ enable = true; source = value; })
   );
 
   cfg = config.programs.konsole;
@@ -103,7 +103,7 @@ in
 
     customColorSchemes = lib.mkOption {
       type = with lib.types; attrsOf path;
-      default = {};
+      default = { };
       description = ''
         Custom color schemes to be added to the installation. The key is their name.
         Choose them in any profile with `profiles.<profile>.colorScheme = <name>`;
@@ -145,8 +145,8 @@ in
       {
         "UiSettings"."ColorScheme" = lib.mkIf (cfg.ui.colorScheme != null) {
           value = cfg.ui.colorScheme;
-          # if this wasn't immutable, it currently doesn't work when overrideConfig is activated
-          # see also: discussion at https://github.com/pjones/plasma-manager/pull/186
+          # The key needs to be immutable to work properly when using overrideConfig.
+          # See discussion at: https://github.com/pjones/plasma-manager/pull/186
           immutable = lib.mkIf config.programs.plasma.overrideConfig (lib.mkDefault true);
         };
       }
@@ -156,44 +156,44 @@ in
       (lib.mkIf (cfg.profiles != { })
         (
           lib.mkMerge ([
-          (
-            lib.mkMerge (
-              lib.mapAttrsToList
-                (
-                  attrName: profile:
-                    let
-                      # Use the name from the name option if it's set
-                      profileName = if builtins.isString profile.name then profile.name else attrName;
-                      fontString = lib.mkIf (profile.font.name != null) "${profile.font.name},${builtins.toString profile.font.size}";
-                    in
-                    {
-                      "konsole/${profileName}.profile".text = lib.generators.toINI { }
-                        (lib.recursiveUpdate
-                          {
-                            "General" = (
-                              {
-                                "Name" = profileName;
-                                # Konsole generated profiles seem to always have this
-                                "Parent" = "FALLBACK/";
-                              } //
-                              (lib.optionalAttrs (profile.command != null) { "Command" = profile.command; })
-                            );
-                            "Appearance" = (
-                              {
-                                # If the font size is not set we leave a comma a the end after the name
-                                # We should fix this probs but konsole doesn't seem to care ¯\_(ツ)_/¯
-                                "Font" = fontString.content;
-                              } //
-                              (lib.optionalAttrs (profile.colorScheme != null) { "ColorScheme" = profile.colorScheme; })
-                            );
-                          }
-                          profile.extraConfig
-                        );
-                    }
-                )
-                cfg.profiles
+            (
+              lib.mkMerge (
+                lib.mapAttrsToList
+                  (
+                    attrName: profile:
+                      let
+                        # Use the name from the name option if it's set
+                        profileName = if builtins.isString profile.name then profile.name else attrName;
+                        fontString = lib.mkIf (profile.font.name != null) "${profile.font.name},${builtins.toString profile.font.size}";
+                      in
+                      {
+                        "konsole/${profileName}.profile".text = lib.generators.toINI { }
+                          (lib.recursiveUpdate
+                            {
+                              "General" = (
+                                {
+                                  "Name" = profileName;
+                                  # Konsole generated profiles seem to always have this
+                                  "Parent" = "FALLBACK/";
+                                } //
+                                (lib.optionalAttrs (profile.command != null) { "Command" = profile.command; })
+                              );
+                              "Appearance" = (
+                                {
+                                  # If the font size is not set we leave a comma a the end after the name
+                                  # We should fix this probs but konsole doesn't seem to care ¯\_(ツ)_/¯
+                                  "Font" = fontString.content;
+                                } //
+                                (lib.optionalAttrs (profile.colorScheme != null) { "ColorScheme" = profile.colorScheme; })
+                              );
+                            }
+                            profile.extraConfig
+                          );
+                      }
+                  )
+                  cfg.profiles
+              )
             )
-          )
           ])
         )
       )


### PR DESCRIPTION
This PR adds 2 new options:
* `programs.kate.ui.colorScheme` and
* `programs.konsole.ui.colorScheme`

and adds the values into `konsolerc`/`katerc`.

The rest of this PR that looks so big is some reordering in the kate file (sry).