### PR TITLE
Fix bug with panels and wallpaper script not being generated when no theme-settings are specified

### DIFF
--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -1,7 +1,10 @@
 { lib
+, config
 , ...
 } @ args:
 let
+  cfg = config.programs.plasma;
+
   widgets = import ./widgets args;
 
   panelType = lib.types.submodule ({ config, ... }: {
@@ -113,6 +116,11 @@ let
       };
     };
   });
+
+  anyPanelOrWallpaperSet = ((cfg.workspace.wallpaper != null) ||
+    (cfg.workspace.wallpaperSlideShow != null) ||
+    (cfg.workspace.wallpaperPictureOfTheDay != null) ||
+    ((builtins.length cfg.panels) > 0));
 in
 {
   options.programs.plasma.panels = lib.mkOption {
@@ -120,7 +128,70 @@ in
     default = [ ];
   };
 
-  # The config-part of this module is located in workspace due to the need for
-  # having wallpaper and panels in the same script.
+  # Wallpaper and panels are in the same script since the resetting of the
+  # panels in the panels-script also has a tendency to reset the wallpaper, so
+  # these should run at the same time.
+  config = (lib.mkIf cfg.enable {
+    programs.plasma.startup.desktopScript."panels_and_wallpaper" = (lib.mkIf anyPanelOrWallpaperSet
+      (
+        let
+          anyPanels = ((builtins.length cfg.panels) > 0);
+          anyNonDefaultScreens = ((builtins.any (panel: panel.screen != 0)) cfg.panels);
+          panelPreCMD = (if anyPanels then ''
+            # We delete plasma-org.kde.plasma.desktop-appletsrc to hinder it
+            # growing indefinitely. See:
+            # https://github.com/pjones/plasma-manager/issues/76
+            [ -f ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc ] && rm ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc
+          '' else "");
+          panelLayoutStr = (if anyPanels then (import ../lib/panel.nix { inherit lib; inherit config; }) else "");
+          panelPostCMD = (if anyNonDefaultScreens then ''
+            if [ -f ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc ]; then
+              sed -i 's/^lastScreen\\x5b$i\\x5d=/lastScreen[$i]=/' ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc
+              # We sleep a second in order to prevent some bugs (like the incorrect height being set)
+              sleep 1; nohup plasmashell --replace &
+            fi
+          '' else "");
+          # This meaningless comment inserts the URL into the desktop-script
+          # which means that when the wallpaper is updated, the sha256 hash
+          # changes and the script will be re-run.
+          wallpaperDesktopScript = (if (cfg.workspace.wallpaper != null) then ''
+            // Wallpaper to set later: ${cfg.workspace.wallpaper}
+          '' else "");
+          wallpaperPostCMD = (if (cfg.workspace.wallpaper != null) then ''
+            plasma-apply-wallpaperimage ${cfg.workspace.wallpaper}
+          '' else "");
+          wallpaperSlideShow = (if (cfg.workspace.wallpaperSlideShow != null) then ''
+            // Wallpaper slideshow
+            let allDesktops = desktops();
+            for (var desktopIndex = 0; desktopIndex < allDesktops.length; desktopIndex++) {
+                var desktop = allDesktops[desktopIndex];
+                desktop.wallpaperPlugin = "org.kde.slideshow";
+                desktop.currentConfigGroup = Array("Wallpaper", "org.kde.slideshow", "General");
+                desktop.writeConfig("SlidePaths", ${if (builtins.isPath cfg.workspace.wallpaperSlideShow.path) then
+                  "\"" + cfg.workspace.wallpaperSlideShow.path + "\"" else
+                  "[" + (builtins.concatStringsSep "," (map (s: "\"" + s + "\"") cfg.workspace.wallpaperSlideShow.path)) + "]"});
+                desktop.writeConfig("SlideInterval", "${builtins.toString cfg.workspace.wallpaperSlideShow.interval}");
+            }
+          '' else "");
+          wallpaperPOTD = (if (cfg.workspace.wallpaperPictureOfTheDay != null) then ''
+            // Wallpaper POTD
+            let allDesktops = desktops();
+            for (const desktop of allDesktops) {
+                desktop.wallpaperPlugin = "org.kde.potd";
+                desktop.currentConfigGroup = ["Wallpaper", "org.kde.potd", "General"];
+                desktop.writeConfig("Provider", "${cfg.workspace.wallpaperPictureOfTheDay.provider}");
+                desktop.writeConfig("UpdateOverMeteredConnection", "${if (cfg.workspace.wallpaperPictureOfTheDay.updateOverMeteredConnection) then "1" else "0"}");
+              }
+          '' else ""
+          );
+        in
+        {
+          preCommands = panelPreCMD;
+          text = panelLayoutStr + wallpaperDesktopScript + wallpaperSlideShow + wallpaperPOTD;
+          postCommands = panelPostCMD + wallpaperPostCMD;
+          priority = 2;
+        }
+      ));
+  });
 }
 

--- a/modules/startup.nix
+++ b/modules/startup.nix
@@ -98,7 +98,9 @@ in
   };
 
   config.xdg = lib.mkIf
-    (cfg.enable && builtins.length (builtins.attrNames cfg.startup.startupScript) != 0)
+    (cfg.enable &&
+      (builtins.length (builtins.attrNames cfg.startup.startupScript) != 0 ||
+        (builtins.length (builtins.attrNames cfg.startup.desktopScript)) != 0))
     {
       dataFile = lib.mkMerge [
         # Autostart scripts

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -143,23 +143,23 @@ in
         KDE.SingleClick = (cfg.workspace.clickItemTo == "open");
       });
     }
-    (lib.mkIf (cfg.workspace.tooltipDelay != null) {
-      programs.plasma.configFile.plasmarc = {
+    {
+      programs.plasma.configFile.plasmarc = (lib.mkIf (cfg.workspace.tooltipDelay != null) {
         PlasmaToolTips.Delay = cfg.workspace.tooltipDelay;
-      };
-    })
-    (lib.mkIf
-      (cfg.workspace.theme != null ||
-        cfg.workspace.colorScheme != null ||
-        cfg.workspace.cursorTheme != null ||
-        cfg.workspace.lookAndFeel != null ||
-        cfg.workspace.iconTheme != null)
-      {
-        # We create a script which applies the different theme settings using
-        # kde tools. We then run this using an autostart script, where this is
-        # run only on the first login (unless overrideConfig is enabled),
-        # granted all the commands succeed (until we change the settings again).
-        programs.plasma.startup.startupScript."apply_themes" = {
+      });
+    }
+    {
+      # We create a script which applies the different theme settings using
+      # kde tools. We then run this using an autostart script, where this is
+      # run only on the first login (unless overrideConfig is enabled),
+      # granted all the commands succeed (until we change the settings again).
+      programs.plasma.startup.startupScript."apply_themes" = (lib.mkIf
+        (cfg.workspace.theme != null ||
+          cfg.workspace.colorScheme != null ||
+          cfg.workspace.cursorTheme != null ||
+          cfg.workspace.lookAndFeel != null ||
+          cfg.workspace.iconTheme != null)
+        {
           text = ''
             ${if cfg.workspace.lookAndFeel != null then "plasma-apply-lookandfeel -a ${cfg.workspace.lookAndFeel}" else ""}
             ${if cfg.workspace.theme != null then "plasma-apply-desktoptheme ${cfg.workspace.theme}" else ""}
@@ -168,36 +168,36 @@ in
             ${if cfg.workspace.iconTheme != null then "${pkgs.kdePackages.plasma-workspace}/libexec/plasma-changeicons ${cfg.workspace.iconTheme}" else ""}
           '';
           priority = 1;
-        };
-        # We add persistence to some keys in order to not reset the themes on
-        # each generation when we use overrideConfig.
-        programs.plasma.configFile = lib.mkIf (cfg.overrideConfig) (
-          let
-            colorSchemeIgnore = if (cfg.workspace.colorScheme != null) then (import ../lib/colorscheme.nix { inherit lib; }) else { };
-          in
-          (lib.mkMerge
-            [
-              {
-                kcminputrc.Mouse.cursorTheme.persistent = lib.mkDefault (cfg.workspace.cursorTheme != null);
-                kdeglobals.General.ColorScheme.persistent = lib.mkDefault (cfg.workspace.colorScheme != null);
-                kdeglobals.Icons.Theme.persistent = lib.mkDefault (cfg.workspace.iconTheme != null);
-                kdeglobals.KDE.LookAndFeelPackage.persistent = lib.mkDefault (cfg.workspace.lookAndFeel != null);
-                plasmarc.Theme.name.persistent = lib.mkDefault (cfg.workspace.theme != null);
-              }
-              colorSchemeIgnore
-            ])
-        );
-      })
+        });
+      # We add persistence to some keys in order to not reset the themes on
+      # each generation when we use overrideConfig.
+      programs.plasma.configFile = (lib.mkIf (cfg.overrideConfig) (
+        let
+          colorSchemeIgnore = if (cfg.workspace.colorScheme != null) then (import ../lib/colorscheme.nix { inherit lib; }) else { };
+        in
+        (lib.mkMerge
+          [
+            {
+              kcminputrc.Mouse.cursorTheme.persistent = lib.mkDefault (cfg.workspace.cursorTheme != null);
+              kdeglobals.General.ColorScheme.persistent = lib.mkDefault (cfg.workspace.colorScheme != null);
+              kdeglobals.Icons.Theme.persistent = lib.mkDefault (cfg.workspace.iconTheme != null);
+              kdeglobals.KDE.LookAndFeelPackage.persistent = lib.mkDefault (cfg.workspace.lookAndFeel != null);
+              plasmarc.Theme.name.persistent = lib.mkDefault (cfg.workspace.theme != null);
+            }
+            colorSchemeIgnore
+          ])
+      ));
+    }
     # Wallpaper and panels are in the same script since the resetting of the
     # panels in the panels-script also has a tendency to reset the wallpaper, so
     # these should run at the same time.
-    (lib.mkIf
-      ((cfg.workspace.wallpaper != null) ||
-        (cfg.workspace.wallpaperSlideShow != null) ||
-        (cfg.workspace.wallpaperPictureOfTheDay != null) ||
-        ((builtins.length cfg.panels) > 0))
-      {
-        programs.plasma.startup.desktopScript."panels_and_wallpaper" = (
+    {
+      programs.plasma.startup.desktopScript."panels_and_wallpaper" = (lib.mkIf
+        ((cfg.workspace.wallpaper != null) ||
+          (cfg.workspace.wallpaperSlideShow != null) ||
+          (cfg.workspace.wallpaperPictureOfTheDay != null) ||
+          ((builtins.length cfg.panels) > 0))
+        (
           let
             anyPanels = ((builtins.length cfg.panels) > 0);
             anyNonDefaultScreens = ((builtins.any (panel: panel.screen != 0)) cfg.panels);
@@ -255,8 +255,7 @@ in
             postCommands = panelPostCMD + wallpaperPostCMD;
             priority = 2;
           }
-        );
-      }
-    )
+        ));
+    }
   ]));
 }

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -31,6 +31,12 @@ let
       };
     };
   };
+
+  anyThemeSet = (cfg.workspace.theme != null ||
+    cfg.workspace.colorScheme != null ||
+    cfg.workspace.cursorTheme != null ||
+    cfg.workspace.lookAndFeel != null ||
+    cfg.workspace.iconTheme != null);
 in
 {
   options.programs.plasma.workspace = {
@@ -125,55 +131,36 @@ in
 
   };
 
-  config = (lib.mkIf cfg.enable (lib.mkMerge [
-    {
-      assertions = [
-        {
-          assertion =
-            let
-              wallpapers = with cfg.workspace; [ wallpaperSlideShow wallpaper wallpaperPictureOfTheDay ];
-            in
-            lib.count (x: x != null) wallpapers <= 1;
-          message = "Can set only one of wallpaper, wallpaperSlideShow and wallpaperPictureOfTheDay.";
-        }
-      ];
-    }
-    {
-      programs.plasma.configFile.kdeglobals = (lib.mkIf (cfg.workspace.clickItemTo != null) {
-        KDE.SingleClick = (cfg.workspace.clickItemTo == "open");
-      });
-    }
-    {
-      programs.plasma.configFile.plasmarc = (lib.mkIf (cfg.workspace.tooltipDelay != null) {
-        PlasmaToolTips.Delay = cfg.workspace.tooltipDelay;
-      });
-    }
-    {
-      # We create a script which applies the different theme settings using
-      # kde tools. We then run this using an autostart script, where this is
-      # run only on the first login (unless overrideConfig is enabled),
-      # granted all the commands succeed (until we change the settings again).
-      programs.plasma.startup.startupScript."apply_themes" = (lib.mkIf
-        (cfg.workspace.theme != null ||
-          cfg.workspace.colorScheme != null ||
-          cfg.workspace.cursorTheme != null ||
-          cfg.workspace.lookAndFeel != null ||
-          cfg.workspace.iconTheme != null)
-        {
-          text = ''
-            ${if cfg.workspace.lookAndFeel != null then "plasma-apply-lookandfeel -a ${cfg.workspace.lookAndFeel}" else ""}
-            ${if cfg.workspace.theme != null then "plasma-apply-desktoptheme ${cfg.workspace.theme}" else ""}
-            ${if cfg.workspace.cursorTheme != null then "plasma-apply-cursortheme ${cfg.workspace.cursorTheme}" else ""}
-            ${if cfg.workspace.colorScheme != null then "plasma-apply-colorscheme ${cfg.workspace.colorScheme}" else ""}
-            ${if cfg.workspace.iconTheme != null then "${pkgs.kdePackages.plasma-workspace}/libexec/plasma-changeicons ${cfg.workspace.iconTheme}" else ""}
-          '';
-          priority = 1;
+  config = (lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion =
+          let
+            wallpapers = with cfg.workspace; [ wallpaperSlideShow wallpaper wallpaperPictureOfTheDay ];
+          in
+          lib.count (x: x != null) wallpapers <= 1;
+        message = "Can set only one of wallpaper, wallpaperSlideShow and wallpaperPictureOfTheDay.";
+      }
+    ];
+
+    programs.plasma.configFile = (lib.mkMerge [
+      {
+        kdeglobals = (lib.mkIf (cfg.workspace.clickItemTo != null) {
+          KDE.SingleClick = (cfg.workspace.clickItemTo == "open");
         });
+        plasmarc = (lib.mkIf (cfg.workspace.tooltipDelay != null) {
+          PlasmaToolTips.Delay = cfg.workspace.tooltipDelay;
+        });
+      }
       # We add persistence to some keys in order to not reset the themes on
       # each generation when we use overrideConfig.
-      programs.plasma.configFile = (lib.mkIf (cfg.overrideConfig) (
+      (lib.mkIf (cfg.overrideConfig && anyThemeSet) (
         let
-          colorSchemeIgnore = if (cfg.workspace.colorScheme != null) then (import ../lib/colorscheme.nix { inherit lib; }) else { };
+          colorSchemeIgnore =
+            if (cfg.workspace.colorScheme != null) then
+              (import ../lib/colorscheme.nix {
+                inherit lib;
+              }) else { };
         in
         (lib.mkMerge
           [
@@ -186,76 +173,27 @@ in
             }
             colorSchemeIgnore
           ])
-      ));
-    }
-    # Wallpaper and panels are in the same script since the resetting of the
-    # panels in the panels-script also has a tendency to reset the wallpaper, so
-    # these should run at the same time.
-    {
-      programs.plasma.startup.desktopScript."panels_and_wallpaper" = (lib.mkIf
-        ((cfg.workspace.wallpaper != null) ||
-          (cfg.workspace.wallpaperSlideShow != null) ||
-          (cfg.workspace.wallpaperPictureOfTheDay != null) ||
-          ((builtins.length cfg.panels) > 0))
-        (
-          let
-            anyPanels = ((builtins.length cfg.panels) > 0);
-            anyNonDefaultScreens = ((builtins.any (panel: panel.screen != 0)) cfg.panels);
-            panelPreCMD = (if anyPanels then ''
-              # We delete plasma-org.kde.plasma.desktop-appletsrc to hinder it
-              # growing indefinitely. See:
-              # https://github.com/pjones/plasma-manager/issues/76
-              [ -f ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc ] && rm ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc
-            '' else "");
-            panelLayoutStr = (if anyPanels then (import ../lib/panel.nix { inherit lib; inherit config; }) else "");
-            panelPostCMD = (if anyNonDefaultScreens then ''
-              if [ -f ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc ]; then
-                sed -i 's/^lastScreen\\x5b$i\\x5d=/lastScreen[$i]=/' ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc
-                # We sleep a second in order to prevent some bugs (like the incorrect height being set)
-                sleep 1; nohup plasmashell --replace &
-              fi
-            '' else "");
-            # This meaningless comment inserts the URL into the desktop-script
-            # which means that when the wallpaper is updated, the sha256 hash
-            # changes and the script will be re-run.
-            wallpaperDesktopScript = (if (cfg.workspace.wallpaper != null) then ''
-              // Wallpaper to set later: ${cfg.workspace.wallpaper}
-            '' else "");
-            wallpaperPostCMD = (if (cfg.workspace.wallpaper != null) then ''
-              plasma-apply-wallpaperimage ${cfg.workspace.wallpaper}
-            '' else "");
-            wallpaperSlideShow = (if (cfg.workspace.wallpaperSlideShow != null) then ''
-              // Wallpaper slideshow
-              let allDesktops = desktops();
-              for (var desktopIndex = 0; desktopIndex < allDesktops.length; desktopIndex++) {
-                  var desktop = allDesktops[desktopIndex];
-                  desktop.wallpaperPlugin = "org.kde.slideshow";
-                  desktop.currentConfigGroup = Array("Wallpaper", "org.kde.slideshow", "General");
-                  desktop.writeConfig("SlidePaths", ${if (builtins.isPath cfg.workspace.wallpaperSlideShow.path) then
-                    "\"" + cfg.workspace.wallpaperSlideShow.path + "\"" else
-                    "[" + (builtins.concatStringsSep "," (map (s: "\"" + s + "\"") cfg.workspace.wallpaperSlideShow.path)) + "]"});
-                  desktop.writeConfig("SlideInterval", "${builtins.toString cfg.workspace.wallpaperSlideShow.interval}");
-              }
-            '' else "");
-            wallpaperPOTD = (if (cfg.workspace.wallpaperPictureOfTheDay != null) then ''
-              // Wallpaper POTD
-              let allDesktops = desktops();
-              for (const desktop of allDesktops) {
-                  desktop.wallpaperPlugin = "org.kde.potd";
-                  desktop.currentConfigGroup = ["Wallpaper", "org.kde.potd", "General"];
-                  desktop.writeConfig("Provider", "${cfg.workspace.wallpaperPictureOfTheDay.provider}");
-                  desktop.writeConfig("UpdateOverMeteredConnection", "${if (cfg.workspace.wallpaperPictureOfTheDay.updateOverMeteredConnection) then "1" else "0"}");
-                }
-            '' else ""
-            );
-          in
-          {
-            preCommands = panelPreCMD;
-            text = panelLayoutStr + wallpaperDesktopScript + wallpaperSlideShow + wallpaperPOTD;
-            postCommands = panelPostCMD + wallpaperPostCMD;
-            priority = 2;
-          }
-        ));
-    }
-  ]));
+      ))
+    ]);
+
+    # We create a script which applies the different theme settings using
+    # kde tools. We then run this using an autostart script, where this is
+    # run only on the first login (unless overrideConfig is enabled),
+    # granted all the commands succeed (until we change the settings again).
+    programs.plasma.startup.startupScript."apply_themes" = (lib.mkIf anyThemeSet
+      {
+        text = ''
+          ${if cfg.workspace.lookAndFeel != null then "plasma-apply-lookandfeel -a ${cfg.workspace.lookAndFeel}" else ""}
+          ${if cfg.workspace.theme != null then "plasma-apply-desktoptheme ${cfg.workspace.theme}" else ""}
+          ${if cfg.workspace.cursorTheme != null then "plasma-apply-cursortheme ${cfg.workspace.cursorTheme}" else ""}
+          ${if cfg.workspace.colorScheme != null then "plasma-apply-colorscheme ${cfg.workspace.colorScheme}" else ""}
+          ${if cfg.workspace.iconTheme != null then "${pkgs.kdePackages.plasma-workspace}/libexec/plasma-changeicons ${cfg.workspace.iconTheme}" else ""}
+        '';
+        priority = 1;
+      });
+
+    # The wallpaper configuration can be found in panels.nix due to wallpaper
+    # configuration and panel configuration being stored in the same file, and
+    # thus should be using the same desktop-script.
+  });
 }


### PR DESCRIPTION
Closes #188. The problem seems to have been due to improper us of lib.mkIf and lib.mkMerge together, which just recently became a problem with #187.