### PR TITLE
add bracket config options for kate

### DIFF
--- a/modules/apps/kate/default.nix
+++ b/modules/apps/kate/default.nix
@@ -232,31 +232,31 @@ in
   #     WRITING THE KATERC
   config.programs.plasma.configFile."katerc" = lib.mkIf cfg.enable {
     "KTextEditor Document" = {
-      "Auto Detect Indent".value = cfg.editor.indent.autodetect;
-      "Indentation Width".value = cfg.editor.indent.width;
+      "Auto Detect Indent" = cfg.editor.indent.autodetect;
+      "Indentation Width" = cfg.editor.indent.width;
       "Tab Handling" = (tabHandlingMode cfg.editor.indent);
-      "Tab Width".value = cfg.editor.tabWidth;
-      "Keep Extra Spaces".value = cfg.editor.indent.keepExtraSpaces;
-      "ReplaceTabsDyn".value = cfg.editor.indent.replaceWithSpaces;
+      "Tab Width" = cfg.editor.tabWidth;
+      "Keep Extra Spaces" = cfg.editor.indent.keepExtraSpaces;
+      "ReplaceTabsDyn" = cfg.editor.indent.replaceWithSpaces;
     };
 
     "KTextEditor Renderer" = {
-      "Show Indentation Lines".value = cfg.editor.indent.showLines;
+      "Show Indentation Lines" = cfg.editor.indent.showLines;
 
-      "Animate Bracket Matching".value = cfg.editor.brackets.flashMatching;
+      "Animate Bracket Matching" = cfg.editor.brackets.flashMatching;
 
       # Do pick the theme if the user chose one,
       # Do not touch the theme settings otherwise
-      "Auto Color Theme Selection".value = lib.mkIf (cfg.editor.theme.name != "") false;
-      "Color Theme".value = lib.mkIf (cfg.editor.theme.name != "") cfg.editor.theme.name;
+      "Auto Color Theme Selection" = lib.mkIf (cfg.editor.theme.name != "") false;
+      "Color Theme" = lib.mkIf (cfg.editor.theme.name != "") cfg.editor.theme.name;
     };
 
     "KTextEditor View" = {
-      "Chars To Enclose Selection".value = cfg.editor.brackets.characters;
-      "Bracket Match Preview".value = cfg.editor.brackets.highlightMatching;
-      "Auto Brackets".value = cfg.editor.brackets.automaticallyAddClosing;
+      "Chars To Enclose Selection" = cfg.editor.brackets.characters;
+      "Bracket Match Preview" = cfg.editor.brackets.highlightMatching;
+      "Auto Brackets" = cfg.editor.brackets.automaticallyAddClosing;
     };
 
-    "UiSettings"."ColorScheme".value = lib.mkIf (cfg.ui.colorScheme != null) cfg.ui.colorScheme;
+    "UiSettings"."ColorScheme" = lib.mkIf (cfg.ui.colorScheme != null) cfg.ui.colorScheme;
   };
 }

--- a/modules/apps/kate/default.nix
+++ b/modules/apps/kate/default.nix
@@ -205,31 +205,23 @@ in
       example = "<>(){}[]'\"\`*_~";
       description = "This options determines which characters kate will treat as brackets.";
     };
-    automaticallyAddClosing = lib.mkEnableOption {
-      description = ''
-        When enabled, a closing bracket is automatically inserted upon typing the opening.
-      '';
-    };
-    highlightRangeBetween = lib.mkEnableOption {
-      description = ''
-        This option enables automatich highlighting of the lines between an opening and a
-        closing bracket when the cursor is adjacent to either.
-      '';
-    };
-    highlightMatching = lib.mkEnableOption {
-      description = ''
-        When enabled, and the cursor is adjacent to a closing bracket, and the corresponding
-        closing bracket is outside of the currently visible area, then the line of the opening
-        bracket and the line directly after will be shown in a small, floating window
-        at the top of the text area.
-      '';
-    };
-    flashMatching = lib.mkEnableOption {
-      description = ''
-        When this option is enabled, then a bracket will quickly flash whenever the cursor
-        moves adjacent to the corresponding bracket.
-      '';
-    };
+    automaticallyAddClosing = lib.mkEnableOption ''
+      When enabled, a closing bracket is automatically inserted upon typing the opening.
+    '';
+    highlightRangeBetween = lib.mkEnableOption ''
+      This option enables automatch highlighting of the lines between an opening and a
+      closing bracket when the cursor is adjacent to either.
+    '';
+    highlightMatching = lib.mkEnableOption ''
+      When enabled, and the cursor is adjacent to a closing bracket, and the corresponding
+      closing bracket is outside of the currently visible area, then the line of the opening
+      bracket and the line directly after will be shown in a small, floating window
+      at the top of the text area.
+    '';
+    flashMatching = lib.mkEnableOption ''
+      When this option is enabled, then a bracket will quickly flash whenever the cursor
+      moves adjacent to the corresponding bracket.
+    '';
   };
 
   # ==================================

--- a/modules/apps/kate/default.nix
+++ b/modules/apps/kate/default.nix
@@ -203,27 +203,31 @@ in
       type = lib.types.str;
       default = "<>(){}[]'\"\`";
       example = "<>(){}[]'\"\`*_~";
-      description = "Which characters kate will treat as brackets.";
+      description = "This options determines which characters kate will treat as brackets.";
     };
     automaticallyAddClosing = lib.mkEnableOption {
-      description = "that a closing bracket is automatically inserted upon typing the opening";
+      description = ''
+        When enabled, a closing bracket is automatically inserted upon typing the opening.
+      '';
     };
     highlightRangeBetween = lib.mkEnableOption {
       description = ''
-        that the range between the brackets is highlighted when the cursor is adjacent
-        to any of the brackets
+        This option enables automatich highlighting of the lines between an opening and a
+        closing bracket when the cursor is adjacent to either.
       '';
     };
     highlightMatching = lib.mkEnableOption {
       description = ''
-        that the first two lines of the matching opening bracket are shown in a small floating window
-        when the cursor is next to the closing bracket and the opening bracket is not in the visible
-        area
+        When enabled, and the cursor is adjacent to a closing bracket, and the corresponding
+        closing bracket is outside of the currently visible area, then the line of the opening
+        bracket and the line directly after will be shown in a small, floating window
+        at the top of the text area.
       '';
     };
     flashMatching = lib.mkEnableOption {
       description = ''
-        that the matching bracket flashes when the cursor moves adjacent to the other
+        When this option is enabled, then a bracket will quickly flash whenever the cursor
+        moves adjacent to the corresponding bracket.
       '';
     };
   };

--- a/modules/apps/kate/default.nix
+++ b/modules/apps/kate/default.nix
@@ -197,24 +197,64 @@ in
   };
 
   # ==================================
+  #     BRACKETS
+  options.programs.kate.editor.brackets = {
+    characters = lib.mkOption {
+      type = lib.types.str;
+      default = "<>(){}[]'\"\`";
+      example = "<>(){}[]'\"\`*_~";
+      description = "Which characters kate will treat as brackets.";
+    };
+    automaticallyAddClosing = lib.mkEnableOption {
+      description = "that a closing bracket is automatically inserted upon typing the opening";
+    };
+    highlightRangeBetween = lib.mkEnableOption {
+      description = ''
+        that the range between the brackets is highlighted when the cursor is adjacent
+        to any of the brackets
+      '';
+    };
+    highlightMatching = lib.mkEnableOption {
+      description = ''
+        that the first two lines of the matching opening bracket are shown in a small floating window
+        when the cursor is next to the closing bracket and the opening bracket is not in the visible
+        area
+      '';
+    };
+    flashMatching = lib.mkEnableOption {
+      description = ''
+        that the matching bracket flashes when the cursor moves adjacent to the other
+      '';
+    };
+  };
+
+  # ==================================
   #     WRITING THE KATERC
   config.programs.plasma.configFile."katerc" = lib.mkIf cfg.enable {
     "KTextEditor Document" = {
-      "Auto Detect Indent" = cfg.editor.indent.autodetect;
-      "Indentation Width" = cfg.editor.indent.width;
+      "Auto Detect Indent".value = cfg.editor.indent.autodetect;
+      "Indentation Width".value = cfg.editor.indent.width;
       "Tab Handling" = (tabHandlingMode cfg.editor.indent);
-      "Tab Width" = cfg.editor.tabWidth;
-      "Keep Extra Spaces" = cfg.editor.indent.keepExtraSpaces;
-      "ReplaceTabsDyn" = cfg.editor.indent.replaceWithSpaces;
+      "Tab Width".value = cfg.editor.tabWidth;
+      "Keep Extra Spaces".value = cfg.editor.indent.keepExtraSpaces;
+      "ReplaceTabsDyn".value = cfg.editor.indent.replaceWithSpaces;
     };
 
     "KTextEditor Renderer" = {
-      "Show Indentation Lines" = cfg.editor.indent.showLines;
+      "Show Indentation Lines".value = cfg.editor.indent.showLines;
+
+      "Animate Bracket Matching".value = cfg.editor.brackets.flashMatching;
 
       # Do pick the theme if the user chose one,
       # Do not touch the theme settings otherwise
-      "Auto Color Theme Selection" = lib.mkIf (cfg.editor.theme.name != "") false;
-      "Color Theme" = lib.mkIf (cfg.editor.theme.name != "") cfg.editor.theme.name;
+      "Auto Color Theme Selection".value = lib.mkIf (cfg.editor.theme.name != "") false;
+      "Color Theme".value = lib.mkIf (cfg.editor.theme.name != "") cfg.editor.theme.name;
+    };
+
+    "KTextEditor View" = {
+      "Chars To Enclose Selection".value = cfg.editor.brackets.characters;
+      "Bracket Match Preview".value = cfg.editor.brackets.highlightMatching;
+      "Auto Brackets".value = cfg.editor.brackets.automaticallyAddClosing;
     };
 
     "UiSettings"."ColorScheme".value = lib.mkIf (cfg.ui.colorScheme != null) cfg.ui.colorScheme;


### PR DESCRIPTION
This adds 5 new options for kate:
* which characters are brackets
* whether closing brackets are automatically added when typing an opening bracket
*  whether the area between 2 brackets shall be highlighted when the cursor is next to one of the brackets
* whether to show the beginning (2 lines) of the opening bracket should be in a small, floating window, when the opening bracket is outside the current screen area and the cursor is next to the closing bracket
* whether the matching bracket should quickly flash when the cursor moves next to the other bracket