### PR TITLE
Fix font configuration for Plasma 5

### DIFF
--- a/lib/qfont.nix
+++ b/lib/qfont.nix
@@ -20,15 +20,15 @@
 
     # QFont::Weight
     weight = {
-      thin = 100;
-      extraLight = 200;
-      light = 300;
-      normal = 400;
-      medium = 500;
-      demiBold = 600;
-      bold = 700;
-      extraBold = 800;
-      black = 900;
+      thin = 0;
+      extraLight = 12;
+      light = 25;
+      normal = 50;
+      medium = 57;
+      demiBold = 63;
+      bold = 75;
+      extraBold = 81;
+      black = 87;
     };
 
     # QFont::Style
@@ -168,12 +168,6 @@ in
             (zeroOrOne strikeOut)
             (zeroOrOne fixedPitch)
             "0"
-            (toString enums.capitalization.${capitalization})
-            (toString enums.spacingType.${letterSpacingType})
-            (toString letterSpacing)
-            (toString wordSpacing)
-            (numOrEnum enums.stretch stretch)
-            (toString styleStrategy')
           ]
           ++ lib.optional (styleName != null) styleName);
   }

--- a/modules/fonts.nix
+++ b/modules/fonts.nix
@@ -133,60 +133,6 @@ let
         default = false;
         description = "Whether the font has a fixed pitch.";
       };
-      capitalization = mkOption {
-        type = qfont.capitalization;
-        default = "mixedCase";
-        description = ''
-          The capitalization settings for this font.
-
-          See https://doc.qt.io/qt-6/qfont.html#Capitalization-enum for more.
-        '';
-      };
-      letterSpacingType = mkOption {
-        type = qfont.spacingType;
-        default = "percentage";
-        description = ''
-          Whether to use percentage or absolute spacing for this font.
-
-          See https://doc.qt.io/qt-6/qfont.html#SpacingType-enum for more.
-        '';
-      };
-      letterSpacing = mkOption {
-        type = types.number;
-        default = 0;
-        description = ''
-          The amount of letter spacing for this font.
-
-          Could be a percentage or an absolute spacing change (positive increases spacing, negative decreases spacing),
-          based on the selected `letterSpacingType`.
-        '';
-      };
-      wordSpacing = mkOption {
-        type = types.number;
-        default = 0;
-        description = ''
-          The amount of word spacing for this font, in pixels.
-
-          Positive values increase spacing while negative ones decrease spacing.
-        '';
-      };
-      stretch = mkOption {
-        type = types.either (types.ints.between 1 4000) qfont.stretch;
-        default = "anyStretch";
-        description = ''
-          The stretch factor for this font, as an integral percentage (i.e. 150 means a 150% stretch),
-          or as a pre-defined stretch factor string.
-        '';
-      };
-      styleStrategy = mkOption {
-        type = styleStrategyType;
-        default = { };
-        description = ''
-          The strategy for matching similar fonts to this font.
-
-          See https://doc.qt.io/qt-6/qfont.html#StyleStrategy-enum for more.
-        '';
-      };
       styleName = mkOption {
         type = types.nullOr types.str;
         default = null;


### PR DESCRIPTION
Before the fix, setting the fonts results in a parsing error and the effective font reverting to a default instead.
When running a program, the error is logged by QFont::fromString() in Qt5. 

Refer to: [Qt 5 source](https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/text/qfont.cpp?h=5.15#n2156)
Notice that it will only accept 10 items in the font string (excluding optional style name). 
Compare that to the Qt6 (for Plasma 6): [Qt 6 Source](https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/text/qfont.cpp?h=6.7.1#n2182) we see that the unsupported fields we need to remove are the last 6 of them.

Additionally, the font weight enum changed in Qt6, so we have to fix it be the Qt5 scale.
Qt 5: https://doc.qt.io/qt-5/qfont.html#Weight-enum
Qt 6: https://doc.qt.io/qt-6/qfont.html#Weight-enum

Fixes #168