### PR TITLE
Add more kwin effects

### DIFF
--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -40,7 +40,7 @@ let
           else
             null;
         example = "fit";
-        description = "(Plasma 6 only) The length mode of the panel. Defaults to `custom` if either `minLength` or `maxLength` is set.";
+        description = "The length mode of the panel. Defaults to `custom` if either `minLength` or `maxLength` is set.";
       };
       location = lib.mkOption {
         type = lib.types.str;
@@ -74,7 +74,7 @@ let
           plasma 6 only.
         '';
       };
-      floating = lib.mkEnableOption "Enable or disable floating style (plasma 6 only).";
+      floating = lib.mkEnableOption "Enable or disable floating style.";
       widgets = lib.mkOption {
         type = lib.types.listOf widgets.type;
         default = [


### PR DESCRIPTION
Adds quite a lot more of the kwin effects into `programs.plasma.kwin.effects`. A lot of the most important ones are now included, but some are still missing. A lot of the effects also support further customizations, and this hasn't been the focus of this PR, that can come later (though I added one additional option for the minimization effect).