### PR TITLE
Revert "Update name of bracket option in kate (#201)"

### DIFF
--- a/modules/apps/kate/default.nix
+++ b/modules/apps/kate/default.nix
@@ -247,7 +247,7 @@ in
     };
 
     "KTextEditor View" = {
-      "User Sets Of Chars To Enclose Selection" = cfg.editor.brackets.characters;
+      "Chars To Enclose Selection" = cfg.editor.brackets.characters;
       "Bracket Match Preview" = cfg.editor.brackets.highlightMatching;
       "Auto Brackets" = cfg.editor.brackets.automaticallyAddClosing;
     };


### PR DESCRIPTION
This reverts commit b12a9715f8fb9303a6fa1b65a8a7488592f0e46b.
See also #203.