### PR TITLE
wallpaperPlainColor for workspace & kscreenlocker

### DIFF
--- a/modules/kscreenlocker.nix
+++ b/modules/kscreenlocker.nix
@@ -30,6 +30,14 @@ in
         to at least one directory.
       '';
     };
+    wallpaperPlainColor = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "0,64,174,256";
+      description = ''
+        Allows you to set wallpaper using a plain color. Color is a comma-seperated R,G,B,A string. Alpha optional (default is 256).
+      '';
+    };
   };
 
   config = {
@@ -37,10 +45,10 @@ in
       {
         assertion =
           let
-            wallpapers = with cfg.workspace; [ wallpaperSlideShow wallpaper wallpaperPictureOfTheDay ];
+            wallpapers = with cfg.workspace; [ wallpaperSlideShow wallpaper wallpaperPictureOfTheDay wallpaperPlainColor ];
           in
           lib.count (x: x != null) wallpapers <= 1;
-        message = "Can set only one of wallpaper, wallpaperSlideShow and wallpaperPictureOfTheDay for kscreenlocker.";
+        message = "Can set only one of wallpaper, wallpaperSlideShow, wallpaperPictureOfTheDay, and wallpaperPlainColor for kscreenlocker.";
       }
     ];
     programs.plasma.configFile.kscreenlockerrc = (lib.mkMerge [
@@ -65,6 +73,10 @@ in
               (builtins.concatStringsSep "," cfg.kscreenlocker.wallpaperSlideShow.path));
           SlideInterval = cfg.kscreenlocker.wallpaperSlideShow.interval;
         };
+      })
+      (lib.mkIf (cfg.kscreenlocker.wallpaperPlainColor != null) {
+        Greeter.WallpaperPlugin = "org.kde.color";
+        "Greeter/Wallpaper/org.kde.color/General".Color = cfg.kscreenlocker.wallpaperPlainColor;
       })
     ]);
   };

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -120,6 +120,7 @@ let
   anyPanelOrWallpaperSet = ((cfg.workspace.wallpaper != null) ||
     (cfg.workspace.wallpaperSlideShow != null) ||
     (cfg.workspace.wallpaperPictureOfTheDay != null) ||
+    (cfg.workspace.wallpaperPlainColor != null) ||
     ((builtins.length cfg.panels) > 0));
 in
 {
@@ -178,12 +179,22 @@ in
                 desktop.writeConfig("Provider", "${cfg.workspace.wallpaperPictureOfTheDay.provider}");
                 desktop.writeConfig("UpdateOverMeteredConnection", "${if (cfg.workspace.wallpaperPictureOfTheDay.updateOverMeteredConnection) then "1" else "0"}");
               }
+          '' else "");
+          wallpaperPlainColor = (if (cfg.workspace.wallpaperPlainColor != null) then ''
+            // Wallpaper plain color
+            let allDesktops = desktops();
+            for (var desktopIndex = 0; desktopIndex < allDesktops.length; desktopIndex++) {
+                var desktop = allDesktops[desktopIndex];
+                desktop.wallpaperPlugin = "org.kde.color";
+                desktop.currentConfigGroup = Array("Wallpaper", "org.kde.color", "General");
+                desktop.writeConfig("Color", "${cfg.workspace.wallpaperPlainColor}");
+            }
           '' else ""
           );
         in
         {
           preCommands = panelPreCMD;
-          text = panelLayoutStr + wallpaperDesktopScript + wallpaperSlideShow + wallpaperPOTD;
+          text = panelLayoutStr + wallpaperDesktopScript + wallpaperSlideShow + wallpaperPOTD + wallpaperPlainColor;
           postCommands = panelPostCMD + wallpaperPostCMD;
           restartServices = (if anyNonDefaultScreens then [ "plasma-plasmashell" ] else [ ]);
           priority = 2;

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -125,6 +125,15 @@ in
       '';
     };
 
+    wallpaperPlainColor = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "0,64,174,256";
+      description = ''
+        Allows you to set wallpaper using a plain color. Color is a comma-seperated R,G,B,A string. Alpha optional (default is 256).
+      '';
+    };
+
     soundTheme = lib.mkOption {
       type = with lib.types; nullOr str;
       default = null;
@@ -188,10 +197,10 @@ in
       {
         assertion =
           let
-            wallpapers = with cfg.workspace; [ wallpaperSlideShow wallpaper wallpaperPictureOfTheDay ];
+            wallpapers = with cfg.workspace; [ wallpaperSlideShow wallpaper wallpaperPictureOfTheDay wallpaperPlainColor ];
           in
           lib.count (x: x != null) wallpapers <= 1;
-        message = "Can set only one of wallpaper, wallpaperSlideShow and wallpaperPictureOfTheDay.";
+        message = "Can set only one of wallpaper, wallpaperSlideShow, wallpaperPictureOfTheDay, and wallpaperPlainColor.";
       }
       {
         assertion = (cfg.workspace.splashScreen.engine == null || cfg.workspace.splashScreen.theme != null);


### PR DESCRIPTION
Adding wallpaperPlainColor for desktop workspace and kscreenlocker.
4th value is alpha, value from 0 to 256. Default is 256 (100% opacity).

```
programs.plasma.workspace.wallpaperPlainColor = "11,44,176";
programs.plasma.kscreenlocker.wallpaperPlainColor = "11,44,176,256";
```
