### PR TITLE
Add immutableByDefault option

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, config, ... }:
 let
   ##############################################################################
   # Types for storing settings.
@@ -13,7 +13,7 @@ let
       };
       immutable = lib.mkOption {
         type = bool;
-        default = false;
+        default = config.programs.plasma.immutableByDefault;
         description = ''
           Whether to make the key immutable. This corresponds to adding [$i] to
           the end of the key.

--- a/lib/writeconfig.nix
+++ b/lib/writeconfig.nix
@@ -23,9 +23,10 @@ let
           resetFilesList ++ [ "${config.xdg.dataHome}/plasma-manager/last_run_*" ]
         else
           resetFilesList);
+      immutableByDefault = (builtins.toString config.programs.plasma.immutableByDefault);
     in
     ''
-      ${writeConfigScript}/bin/write_config ${jsonFile} "${resetFilesStr}"
+      ${writeConfigScript}/bin/write_config ${jsonFile} "${resetFilesStr}" "${immutableByDefault}"
     '';
 in
 {

--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -1,6 +1,6 @@
 { config, lib, pkgs, ... }:
 let
-  inherit (import ../../lib/types.nix { inherit lib; }) basicSettingsType;
+  inherit (import ../../lib/types.nix { inherit lib; inherit config; }) basicSettingsType;
 
   # used as shown in the example in the library docs:
   # https://ryantm.github.io/nixpkgs/functions/library/attrsets/#function-library-lib.attrsets.mapAttrs-prime

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -3,7 +3,7 @@
 
 let
   inherit (import ../lib/writeconfig.nix { inherit lib pkgs config; }) writeConfig;
-  inherit (import ../lib/types.nix { inherit lib; }) coercedSettingsType;
+  inherit (import ../lib/types.nix { inherit lib; inherit config; }) coercedSettingsType;
 
   # Helper function to prepend the appropriate path prefix (e.g. XDG_CONFIG_HOME) to file
   prependPath = prefix: attrset:
@@ -114,6 +114,7 @@ in
         Config-files which explicitly should not be deleted on each generation.
       '';
     };
+    immutableByDefault = lib.mkEnableOption "Make keys written by plasma-manager immutable by default.";
   };
 
   imports = [

--- a/script/write_config.py
+++ b/script/write_config.py
@@ -327,7 +327,7 @@ def main():
     with open(json_path, "r") as f:
         json_str = f.read()
 
-    reset_files = set(sys.argv[2].split(" ")) if sys.argv[2] != "" else {}
+    reset_files = set(sys.argv[2].split(" ")) if sys.argv[2] != "" else set()
     immutable_by_default = bool(sys.argv[3])
     d = json.loads(json_str)
     remove_config_files(d, reset_files)

--- a/script/write_config.py
+++ b/script/write_config.py
@@ -138,7 +138,9 @@ class ConfigValue:
 
 
 class KConfManager:
-    def __init__(self, filepath: str, json_dict: Dict, reset: bool):
+    def __init__(
+        self, filepath: str, json_dict: Dict, reset: bool, immutable_by_default: bool
+    ):
         """
         filepath (str): The full path to the config-file to manage
         json_dict (Dict): The nix-configuration presented in a dictionary (converted from json)
@@ -148,6 +150,7 @@ class KConfManager:
         self.json_dict = json_dict
         self.filepath = filepath
         self.reset = reset
+        self.immutable_by_default = immutable_by_default
         self._json_value_checks()
         # The nix expressions will have / to separate groups, and \/ to escape a /.
         # This parses the groups into tuples of unescaped group names.
@@ -162,35 +165,32 @@ class KConfManager:
     def _json_value_checks(self):
         for group, entry in self.json_dict.items():
             for key, value in entry.items():
+                non_default_immutability = (
+                    value["immutable"] != self.immutable_by_default
+                )
                 if (
-                    value["immutable"]
-                    and value["value"] is None
-                    and value["persistent"] is None
+                    value["value"] is None
+                    and not value["persistent"]
+                    and (non_default_immutability or value["shellExpand"])
                 ):
                     raise Exception(
-                        f'Plasma-manager: Immutability enabled for key "{key}" in group "{group}" in configfile "{self.filepath}"'
-                        " with no value set. Keys without values/persistence cannot be declared immutable"
-                    )
-                if (
-                    value["shellExpand"]
-                    and value["value"] is None
-                    and value["persistent"] is None
-                ):
-                    raise Exception(
-                        f'Plasma-manager: Shell-expansion enabled for key "{key}" in group "{group}" in configfile "{self.filepath}"'
-                        " with no value set. Keys without values/persistence cannot have shell-expansion enabled"
+                        f'Plasma-manager: No value or persistency set for key "{key}" in group "{group}" in configfile "{self.filepath}"'
+                        ", but one of immutability/persistency takes a non-default value. This is not supported"
                     )
                 elif value["persistent"]:
                     base_msg = f'Plasma-manager: Persistency enabled for key "{key}" in group "{group}" in configfile "{self.filepath}"'
-                    # We don't allow persistency when the value is set, as that
-                    # doesn't make sense. Currently we allow for persistency
-                    # when immutability or shellExpansion is enabled, but it's
-                    # worth noting that these settings will be meaningless when
-                    # persistency is enabled.
                     if value["value"] is not None:
                         raise Exception(
                             f"{base_msg} with non-null value \"{value['value']}\". "
                             "A value cannot be given when persistency is enabled"
+                        )
+                    elif non_default_immutability:
+                        raise Exception(
+                            f"{base_msg} with non-default immutability. Persistency with non-default immutability is not supported"
+                        )
+                    elif value["shellExpand"]:
+                        raise Exception(
+                            f"{base_msg} with shell-expansion enabled. Persistency with shell-expansion enabled is not supported"
                         )
 
     def key_is_persistent(self, group, key) -> bool:
@@ -308,15 +308,17 @@ def remove_config_files(d: Dict, reset_files: Set):
                 os.remove(file_to_del)
 
 
-def write_configs(d: Dict, reset_files: Set):
+def write_configs(d: Dict, reset_files: Set, immutable_by_default: bool):
     for filepath, c in d.items():
-        config = KConfManager(filepath, c, filepath in reset_files)
+        config = KConfManager(
+            filepath, c, filepath in reset_files, immutable_by_default
+        )
         config.run()
         config.save()
 
 
 def main():
-    if len(sys.argv) != 3:
+    if len(sys.argv) != 4:
         raise ValueError(
             f"Must receive exactly two arguments, got: {len(sys.argv) - 1}"
         )
@@ -325,10 +327,11 @@ def main():
     with open(json_path, "r") as f:
         json_str = f.read()
 
-    reset_files = set(sys.argv[2].split(" ")) if len(sys.argv) >= 2 else {}
+    reset_files = set(sys.argv[2].split(" ")) if sys.argv[2] != "" else {}
+    immutable_by_default = bool(sys.argv[3])
     d = json.loads(json_str)
     remove_config_files(d, reset_files)
-    write_configs(d, reset_files)
+    write_configs(d, reset_files, immutable_by_default)
 
 
 if __name__ == "__main__":

--- a/script/write_config.py
+++ b/script/write_config.py
@@ -162,35 +162,35 @@ class KConfManager:
     def _json_value_checks(self):
         for group, entry in self.json_dict.items():
             for key, value in entry.items():
-                if value["immutable"] and value["value"] is None:
-                    # We don't allow immutability for keys with no value given (it doesn't make sense).
+                if (
+                    value["immutable"]
+                    and value["value"] is None
+                    and value["persistent"] is None
+                ):
                     raise Exception(
                         f'Plasma-manager: Immutability enabled for key "{key}" in group "{group}" in configfile "{self.filepath}"'
-                        " with no value set. Keys without values cannot be declared immutable"
+                        " with no value set. Keys without values/persistence cannot be declared immutable"
                     )
-                if value["shellExpand"] and value["value"] is None:
-                    # We don't allow immutability for keys with no value given (it doesn't make sense).
+                if (
+                    value["shellExpand"]
+                    and value["value"] is None
+                    and value["persistent"] is None
+                ):
                     raise Exception(
                         f'Plasma-manager: Shell-expansion enabled for key "{key}" in group "{group}" in configfile "{self.filepath}"'
-                        " with no value set. Keys without values cannot have shell-expansion enabled"
+                        " with no value set. Keys without values/persistence cannot have shell-expansion enabled"
                     )
                 elif value["persistent"]:
                     base_msg = f'Plasma-manager: Persistency enabled for key "{key}" in group "{group}" in configfile "{self.filepath}"'
-                    # We don't allow persistency when the value is set,
-                    # immutability is enabled, or when shell-expansion is
-                    # enabled.
+                    # We don't allow persistency when the value is set, as that
+                    # doesn't make sense. Currently we allow for persistency
+                    # when immutability or shellExpansion is enabled, but it's
+                    # worth noting that these settings will be meaningless when
+                    # persistency is enabled.
                     if value["value"] is not None:
                         raise Exception(
                             f"{base_msg} with non-null value \"{value['value']}\". "
                             "A value cannot be given when persistency is enabled"
-                        )
-                    elif value["immutable"]:
-                        raise Exception(
-                            f"{base_msg} with immutability enabled. Persistency and immutability cannot both be enabled"
-                        )
-                    elif value["shellExpand"]:
-                        raise Exception(
-                            f"{base_msg} with shell-expansion enabled. Persistency and shell-expansion cannot both be enabled"
                         )
 
     def key_is_persistent(self, group, key) -> bool:


### PR DESCRIPTION
This adds support for automatically marking all keys written by plasma-manager as immutable by default, including keys written by higher level modules. For this to be possible, immutability (and shellExpansion even though not strictly needed) and persistence have now become allowed for the same key. It's worth noting that immutability will in these cases not have any meaning, so for example:
```nix
group.key = {immutable = true; persistent = true;};
```
will result in the key `key` in group `group` being persistent, not `key[$i]`. I'm not completely settled on this choice, but it comes from the need of marking non-immutable keys as persistent as well. Typically the keys we want to mark as persistent are not immutable so it makes sense in this way (we basically never have to make immutable keys persistent). I would love other's thoughts on this as well. I have not done much testing, but it seems to work fine for me. Probably needs a little more testing to make sure everything works before I'll merge @Asqiir.
Closes #217.