### PR TITLE
Remove the nix-community transfer snippet from the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,7 @@ nix run github:pjones/plasma-manager
 
 ## Contributions and Maintenance
 
-This is a community project and we welcome all contributions.  If there's enough
-interest we would love to move this into [nix-community] once it has matured.
+This is a community project and we welcome all contributions.
 
 ## Special Thanks
 


### PR DESCRIPTION
Since the project has been successfully transferred to nix-community, we may now proceed to remove this snippet from the README file.

I think we could consider further additions to this section of the README file