### PR TITLE
Fix marginsseparator panel widget typo

### DIFF
--- a/examples/homeManager/home.nix
+++ b/examples/homeManager/home.nix
@@ -32,7 +32,7 @@
         widgets = [
           "org.kde.plasma.kickoff"
           "org.kde.plasma.icontasks"
-          "org.kde.plasma.marginsseperator"
+          "org.kde.plasma.marginsseparator"
           "org.kde.plasma.systemtray"
           "org.kde.plasma.digitalclock"
         ];

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -81,7 +81,7 @@ let
           "org.kde.plasma.kickoff"
           "org.kde.plasma.pager"
           "org.kde.plasma.icontasks"
-          "org.kde.plasma.marginsseperator"
+          "org.kde.plasma.marginsseparator"
           "org.kde.plasma.systemtray"
           "org.kde.plasma.digitalclock"
           "org.kde.plasma.showdesktop"
@@ -89,7 +89,7 @@ let
         example = [
           "org.kde.plasma.kickoff"
           "org.kde.plasma.icontasks"
-          "org.kde.plasma.marginsseperator"
+          "org.kde.plasma.marginsseparator"
           "org.kde.plasma.digitalclock"
         ];
         description = ''


### PR DESCRIPTION
- The margin separator widget is spelled correctly (`"marginsseparator"`) in [this example](https://github.com/nix-community/plasma-manager/blob/a3b881f62eb3aabb97e4fc68041ef34e8029e186/examples/home.nix#L65)
- However it is spelled INcorrectly (`"marginsseperator"`) in:
  - [this example](https://github.com/nix-community/plasma-manager/blob/a3b881f62eb3aabb97e4fc68041ef34e8029e186/examples/homeManager/home.nix#L35)
  - and most importantly in the default and example attributes in [the widgets option](https://github.com/nix-community/plasma-manager/blob/a3b881f62eb3aabb97e4fc68041ef34e8029e186/modules/panels.nix#L78), which leads to a broken, empty widget when the example is followed or when the default attribute is used