### PR TITLE
Automatically install third-party widget if it is present in a panel

### DIFF
--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -5,6 +5,7 @@
 } @ args:
 let
   cfg = config.programs.plasma;
+  hasWidget = widgetName: builtins.any (panel: builtins.any (widget: widget.name == widgetName) panel.widgets) cfg.panels;
 
   widgets = import ./widgets args;
 

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -146,7 +146,7 @@ in
   # these should run at the same time.
   config = (lib.mkIf cfg.enable {
     home.packages = with pkgs; []
-      ++ lib.optionals (lib.elem "application-title-bar" cfg.extraWidgets) [ application-title-bar ];
+      ++ lib.optionals (lib.elem "application-title-bar" cfg.extraWidgets || hasWidget "com.github.antroids.application-title-bar") [ application-title-bar ];
 
     programs.plasma.startup.desktopScript."panels_and_wallpaper" = (lib.mkIf anyPanelOrWallpaperSet
       (


### PR DESCRIPTION
As @magnouvean suggested, we could consider adding an option in the future to automatically add the widget to extraWidgets. I had this idea, which I believe could be even better, in my opinion.

I tested it in my configuration, and it is working flawlessly.

### Changes

- Adds `hasWidget` function for checking whether a specific widget, identified by its name `widgetName`, is present in any of the configured panels.
- Use `hasWidget` to automatically install a third-party widget if the user does not specify any in the extraWidgets option.