### PR TITLE
Add plasmusic-toolbar widget to extraWidgets option

### DIFF
--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -132,7 +132,7 @@ in
   };
 
   options.programs.plasma.extraWidgets = lib.mkOption {
-    type = with lib.types; listOf (enum [ "application-title-bar" ]);
+    type = with lib.types; listOf (enum [ "application-title-bar" "plasmusic-toolbar" ]);
     default = [];
     example = [ "application-title-bar" ];
     description = ''
@@ -146,7 +146,8 @@ in
   # these should run at the same time.
   config = (lib.mkIf cfg.enable {
     home.packages = with pkgs; []
-      ++ lib.optionals (lib.elem "application-title-bar" cfg.extraWidgets || hasWidget "com.github.antroids.application-title-bar") [ application-title-bar ];
+      ++ lib.optionals (lib.elem "application-title-bar" cfg.extraWidgets || hasWidget "com.github.antroids.application-title-bar") [ application-title-bar ]
+      ++ lib.optionals (lib.elem "plasmusic-toolbar" cfg.extraWidgets || hasWidget "plasmusic-toolbar") [ plasmusic-toolbar ];
 
     programs.plasma.startup.desktopScript."panels_and_wallpaper" = (lib.mkIf anyPanelOrWallpaperSet
       (


### PR DESCRIPTION
[plasmusic-toolbar](https://github.com/NixOS/nixpkgs/pull/319671) was finally merged into NixOS master. So we can finally add plasmusic-toolbar to plasma-manager when it reaches nixos-unstable: https://nixpk.gs/pr-tracker.html?pr=319671

Later today, I will start writing the widget-specific options for plasmusic-toolbar.