### PR TITLE
Add widget-specific options for Kickoff

### DIFF
--- a/modules/widgets/default.nix
+++ b/modules/widgets/default.nix
@@ -8,6 +8,7 @@ let
     ./application-title-bar.nix
     ./battery.nix
     ./digital-clock.nix
+    ./kickoff.nix
     ./system-monitor.nix
     ./system-tray.nix
   ]);

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -6,19 +6,6 @@ let
   convertSidebarPosition = sidebarPosition: let
     mappings = { "Left" = "false"; "Right" = "true"; };
   in mappings.${sidebarPosition} or (throw "Invalid sidebar position: ${sidebarPosition}");
-
-  convertAppDisplay = appDisplay: let
-    mappings = { "Grid" = "0"; "List" = "1"; };
-  in mappings.${appDisplay} or (throw "Invalid app display mode: ${appDisplay}");
-
-  convertActions = actions: let
-    mappings = {
-      "Power" = "0";
-      "Session" = "1";
-      "Custom" = "2"; 
-      "PowerAndSession" = "3";
-    };
-  in mappings.${actions} or (throw "Invalid actions: ${actions}");
 in
 {
   kickoff = {
@@ -57,26 +44,17 @@ in
           document URLs and KPeople contact URIs.
         '';
       };
-      favoritesDisplayMode = mkOption {
-        type = types.enum [ "Grid" "List" ];
-        default = "Grid";
+      favoritesDisplayMode = mkEnumOption [ "Grid" "List" ] // {
         example = "List";
         description = "How to display favorites.";
-        apply = convertAppDisplay;
       };
-      applicationsDisplayMode = mkOption {
-        type = types.enum [ "Grid" "List" ];
-        default = "List";
+      applicationsDisplayMode = mkEnumOption [ "Grid" "List" ] // {
         example = "Grid";
         description = "How to display applications.";
-        apply = convertAppDisplay;
       };
-      showButtonsFor = mkOption {
-        type = types.enum [ "Power" "Session" "PowerAndSession" ];
-        default = "Power";
-        example = "Session";
-        description = "Which actions should be displayed in the footer";
-        apply = convertActions;
+      showButtonsFor = mkEnumOption [ "Power" "Session" "Custom" "PowerAndSession" ] // {
+        example = "PowerAndSession";
+        description = "Which actions should be displayed in the footer.";
       };
       showActionButtonCaptions = mkBoolOption "Whether to display captions ('shut down', 'log out', etc.) for the footer action buttons";
       pin = mkBoolOption "Whether the popup should remain open when another window is activated.";

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -1,0 +1,117 @@
+{ lib, widgets, ...}:
+let
+  inherit (lib) mkOption types;
+  inherit (widgets.lib) mkBoolOption;
+
+  convertSidebarPosition = sidebarPosition: let
+    mappings = { "Left" = "false"; "Right" = "true"; };
+  in mappings.${sidebarPosition} or (throw "Invalid sidebar position: ${sidebarPosition}");
+
+  convertAppDisplay = appDisplay: let
+    mappings = { "Grid" = "0"; "List" = "1"; };
+  in mappings.${appDisplay} or (throw "Invalid app display mode: ${appDisplay}");
+
+  convertActions = actions: let
+    mappings = {
+      "Power" = "0";
+      "Session" = "1";
+      "Custom" = "2"; 
+      "PowerAndSession" = "3";
+    };
+  in mappings.${actions} or (throw "Invalid actions: ${actions}");
+in
+{
+  kickoff = {
+    description = "Kickoff is the default application launcher of the Plasma desktop.";
+    
+    opts = {
+      icon = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "start-here-kde-symbolic";
+        description = "The icon to use for the kickoff button.";
+      };
+      label = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "Menu";
+        description = "The label to use for the kickoff button.";
+      };
+      sortAlphabetically = mkBoolOption "Whether to sort menu contents alphabetically or use manual/system sort order.";
+      compactDisplayStyle = mkBoolOption "Whether to use a compact display style for list items.";
+      sidebarPosition = mkOption {
+        type = types.enum [ "Left" "Right" ];
+        default = "Left";
+        example = "Right";
+        description = "The position of the sidebar.";
+        apply = convertSidebarPosition;
+      };
+      favorites = mkOption {
+        type = types.nullOr (types.listOf types.str);
+        default = null;
+        example = [ "preferred://browser" "org.kde.dolphin.desktop" "org.kde.konsole.desktop" ];
+        description = ''
+          List of general favorites.
+          Supported values are menu id's (usually .desktop file names),
+          special URLs that expand into default applications (e.g. preferred://browser),
+          document URLs and KPeople contact URIs.
+        '';
+      };
+      favoritesDisplayMode = mkOption {
+        type = types.enum [ "Grid" "List" ];
+        default = "Grid";
+        example = "List";
+        description = "How to display favorites.";
+        apply = convertAppDisplay;
+      };
+      applicationsDisplayMode = mkOption {
+        type = types.enum [ "Grid" "List" ];
+        default = "List";
+        example = "Grid";
+        description = "How to display applications.";
+        apply = convertAppDisplay;
+      };
+      showButtonsFor = mkOption {
+        type = types.enum [ "Power" "Session" "PowerAndSession" ];
+        default = "Power";
+        example = "Session";
+        description = "Which actions should be displayed in the footer";
+        apply = convertActions;
+      };
+      showActionButtonCaptions = mkBoolOption "Whether to display captions ('shut down', 'log out', etc.) for the footer action buttons";
+      pin = mkBoolOption "Whether the popup should remain open when another window is activated.";
+    };
+    convert =
+      { icon
+      , label
+      , sortAlphabetically
+      , compactDisplayStyle
+      , sidebarPosition
+      , favorites
+      , favoritesDisplayMode
+      , applicationsDisplayMode
+      , showButtonsFor
+      , showActionButtonCaptions
+      , pin
+      }: {
+        name = "org.kde.plasma.kickoff";
+        config.General = lib.filterAttrs (_: v: v != null) (
+          {
+            icon = icon;
+            menuLabel = label;
+            alphaSort = sortAlphabetically;
+            compactMode = compactDisplayStyle;
+            paneSwap = sidebarPosition;
+            favoritesDisplay = favoritesDisplayMode;
+            applicationsDisplay = applicationsDisplayMode;
+            primaryActions = showButtonsFor;
+            showActionButtonCaptions = showActionButtonCaptions;
+            
+            # Other useful options
+            pin = pin;
+            favorites = favorites;
+          }
+        );
+      };
+  };
+}

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -4,7 +4,7 @@ let
   inherit (widgets.lib) mkBoolOption mkEnumOption;
 
   convertSidebarPosition = sidebarPosition: let
-    mappings = { "Left" = "false"; "Right" = "true"; };
+    mappings = { "left" = "false"; "right" = "true"; };
   in mappings.${sidebarPosition} or (throw "Invalid sidebar position: ${sidebarPosition}");
 in
 {
@@ -27,9 +27,9 @@ in
       sortAlphabetically = mkBoolOption "Whether to sort menu contents alphabetically or use manual/system sort order.";
       compactDisplayStyle = mkBoolOption "Whether to use a compact display style for list items.";
       sidebarPosition = mkOption {
-        type = types.enum [ "Left" "Right" ];
-        default = "Left";
-        example = "Right";
+        type = types.enum [ "left" "right" ];
+        default = "left";
+        example = "right";
         description = "The position of the sidebar.";
         apply = convertSidebarPosition;
       };
@@ -44,16 +44,16 @@ in
           document URLs and KPeople contact URIs.
         '';
       };
-      favoritesDisplayMode = mkEnumOption [ "Grid" "List" ] // {
-        example = "List";
+      favoritesDisplayMode = mkEnumOption [ "grid" "list" ] // {
+        example = "list";
         description = "How to display favorites.";
       };
-      applicationsDisplayMode = mkEnumOption [ "Grid" "List" ] // {
-        example = "Grid";
+      applicationsDisplayMode = mkEnumOption [ "grid" "list" ] // {
+        example = "grid";
         description = "How to display applications.";
       };
-      showButtonsFor = mkEnumOption [ "Power" "Session" "Custom" "PowerAndSession" ] // {
-        example = "PowerAndSession";
+      showButtonsFor = mkEnumOption [ "power" "session" "custom" "powerAndSession" ] // {
+        example = "powerAndSession";
         description = "Which actions should be displayed in the footer.";
       };
       showActionButtonCaptions = mkBoolOption "Whether to display captions ('shut down', 'log out', etc.) for the footer action buttons";

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -1,7 +1,7 @@
 { lib, widgets, ...}:
 let
   inherit (lib) mkOption types;
-  inherit (widgets.lib) mkBoolOption;
+  inherit (widgets.lib) mkBoolOption mkEnumOption;
 
   convertSidebarPosition = sidebarPosition: let
     mappings = { "Left" = "false"; "Right" = "true"; };

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -33,17 +33,6 @@ in
         description = "The position of the sidebar.";
         apply = convertSidebarPosition;
       };
-      favorites = mkOption {
-        type = types.nullOr (types.listOf types.str);
-        default = null;
-        example = [ "preferred://browser" "org.kde.dolphin.desktop" "org.kde.konsole.desktop" ];
-        description = ''
-          List of general favorites.
-          Supported values are menu id's (usually .desktop file names),
-          special URLs that expand into default applications (e.g. preferred://browser),
-          document URLs and KPeople contact URIs.
-        '';
-      };
       favoritesDisplayMode = mkEnumOption [ "grid" "list" ] // {
         example = "list";
         description = "How to display favorites.";
@@ -65,7 +54,6 @@ in
       , sortAlphabetically
       , compactDisplayStyle
       , sidebarPosition
-      , favorites
       , favoritesDisplayMode
       , applicationsDisplayMode
       , showButtonsFor
@@ -87,7 +75,6 @@ in
             
             # Other useful options
             pin = pin;
-            favorites = favorites;
           }
         );
       };


### PR DESCRIPTION
Did not put some options such as: `favoritesPortedToKAstats`, `systemApplications`, `systemFavorites`. As probably it is not needed to be set. And there is not enough documentation on these options. Maybe i will look into it in the future, and maybe add it