### PR TITLE
Update number of required arguments in write_config.py error

### DIFF
--- a/script/write_config.py
+++ b/script/write_config.py
@@ -320,7 +320,7 @@ def write_configs(d: Dict, reset_files: Set, immutable_by_default: bool):
 def main():
     if len(sys.argv) != 4:
         raise ValueError(
-            f"Must receive exactly two arguments, got: {len(sys.argv) - 1}"
+            f"Must receive exactly four arguments, got: {len(sys.argv) - 1}"
         )
 
     json_path = sys.argv[1]


### PR DESCRIPTION
I was working on fixing https://github.com/nix-community/plasma-manager/pull/123 after I updated the branch, and I figured out the error message was not updated then the needed arguments were changed from 2 to 4, making the error very confusing
![image](https://github.com/nix-community/plasma-manager/assets/39011842/f5e179ab-7e0e-4d8c-abaa-5a8301341731)

