### PR TITLE
Allow bools, ints and floats for widget configs and major refactoring

### DIFF
--- a/modules/widgets/application-title-bar.nix
+++ b/modules/widgets/application-title-bar.nix
@@ -5,7 +5,6 @@ let
   mkBoolOption = description: lib.mkOption {
     type = with lib.types; nullOr bool;
     default = null;
-    example = true;
     inherit description;
   };
 

--- a/modules/widgets/application-title-bar.nix
+++ b/modules/widgets/application-title-bar.nix
@@ -11,10 +11,10 @@ let
   convertHorizontalAlignment = horizontalAlignment:
     let
       mappings = {
-        "left" = "1";
-        "right" = "2";
-        "center" = "4";
-        "justify" = "8";
+        left = 1;
+        right = 2;
+        center = 4;
+        justify = 8;
       };
     in
       mappings.${horizontalAlignment} or (throw "Invalid enum value: ${horizontalAlignment}");
@@ -22,10 +22,10 @@ let
   convertVerticalAlignment = verticalAlignment:
     let
       mappings = {
-        "top" = "1";
-        "center" = "128";
-        "bottom" = "64";
-        "baseline" = "256";
+        top = 1;
+        center = 128;
+        bottom = 64;
+        baseline = 256;
       };
     in
       mappings.${verticalAlignment} or (throw "Invalid enum value: ${verticalAlignment}");

--- a/modules/widgets/application-title-bar.nix
+++ b/modules/widgets/application-title-bar.nix
@@ -11,10 +11,10 @@ let
   convertHorizontalAlignment = horizontalAlignment:
     let
       mappings = {
-        "left" = "1";
-        "right" = "2";
-        "center" = "4";
-        "justify" = "8";
+        "left" = 1;
+        "right" = 2;
+        "center" = 4;
+        "justify" = 8;
       };
     in
       mappings.${horizontalAlignment} or (throw "Invalid enum value: ${horizontalAlignment}");
@@ -22,23 +22,35 @@ let
   convertVerticalAlignment = verticalAlignment:
     let
       mappings = {
-        "top" = "1";
-        "center" = "128";
-        "bottom" = "64";
-        "baseline" = "256";
+        "top" = 1;
+        "center" = 128;
+        "bottom" = 64;
+        "baseline" = 256;
       };
     in
       mappings.${verticalAlignment} or (throw "Invalid enum value: ${verticalAlignment}");
 
+  getIndexFromEnum = enum: value:
+    if value == null
+    then null
+    else
+      lib.lists.findFirstIndex
+        (x: x == value)
+        (throw "getIndexFromEnum (application-title-bar widget): Value ${value} isn't present in the enum. This is a bug")
+        enum;
+
   fontType = types.submodule {
     options = {
       bold = mkBoolOption "Enable bold text.";
-      fit = mkOption {
-        type = with types; nullOr (enum [ "fixedSize" "horizontalFit" "verticalFit" "fit" ]);
-        default = null;
-        example = "fixedSize";
-        description = "The mode of the size of the font.";
-      };
+      fit =
+        let enumVals = [ "fixedSize" "horizontalFit" "verticalFit" "fit" ];
+        in mkOption {
+          type = with types; nullOr (enum enumVals);
+          default = null;
+          example = "fixedSize";
+          description = "The mode of the size of the font.";
+          apply = getIndexFromEnum enumVals;
+        };
       size = mkOption {
         type = types.ints.positive;
         default = 10;
@@ -100,12 +112,15 @@ in
           description = "The vertical alignment of the widget.";
           apply = convertVerticalAlignment;
         };
-        showDisabledElements = mkOption {
-          type = with types; nullOr (enum [ "deactivated" "hideKeepSpace" "hide" ]);
-          default = null;
-          example = "deactivated";
-          description = "How to show the elements when the widget is disabled.";
-        };
+        showDisabledElements =
+          let enumVals = [ "deactivated" "hideKeepSpace" "hide" ];
+          in mkOption {
+            type = with types; nullOr (enum enumVals);
+            default = null;
+            example = "deactivated";
+            description = "How to show the elements when the widget is disabled.";
+            apply = getIndexFromEnum enumVals;
+          };
         fillFreeSpace = mkBoolOption "Whether the widget should fill the free space on the panel.";
         elements = mkOption {
           type = types.nullOr (types.listOf (types.enum [
@@ -127,19 +142,22 @@ in
         };
       };
       windowControlButtons = {
-        iconSource = mkOption {
-          type = with types; nullOr (enum [ "plasma" "breeze" "aurorae" "oxygen" ]);
-          default = null;
-          example = "plasma";
-          description = ''
-            The icon source for the control buttons.
+        iconSource =
+          let enumVals = [ "plasma" "breeze" "aurorae" "oxygen" ];
+          in mkOption {
+            type = with types; nullOr (enum enumVals);
+            default = null;
+            example = "plasma";
+            description = ''
+              The icon source for the control buttons.
 
-            - Plasma: Global icon theme
-            - Breeze: Implicit Breeze icons
-            - Aurorae: Window decorations theme
-            - Oxygen: Implicit Oxygen icons
-          '';
-        };
+              - Plasma: Global icon theme
+              - Breeze: Implicit Breeze icons
+              - Aurorae: Window decorations theme
+              - Oxygen: Implicit Oxygen icons
+            '';
+            apply = getIndexFromEnum enumVals;
+          };
         auroraeTheme = mkOption {
           type = types.nullOr types.str;
           default = null;
@@ -193,19 +211,22 @@ in
           default = null;
           description = "The text to show when the window title is undefined.";
         };
-        source = mkOption {
-          type = with types; nullOr (enum [ "appName" "decoration" "genericAppName" "alwaysUndefined" ]);
-          default = null;
-          example = "appName";
-          description = ''
-            The source of the window title.
+        source =
+          let enumVals = [ "appName" "decoration" "genericAppName" "alwaysUndefined" ];
+          in mkOption {
+            type = with types; nullOr (enum enumVals);
+            default = null;
+            example = "appName";
+            description = ''
+              The source of the window title.
 
-            - appName: The name of the application
-            - decoration: The title of the window decoration
-            - genericAppName: The generic name of the application
-            - alwaysUndefined: Always show the undefined title
-          '';
-        };
+              - appName: The name of the application
+              - decoration: The title of the window decoration
+              - genericAppName: The generic name of the application
+              - alwaysUndefined: Always show the undefined title
+            '';
+            apply = getIndexFromEnum enumVals;
+          };
         margins = mkOption {
           type = types.nullOr marginType;
           default = null;
@@ -244,33 +265,41 @@ in
             The elements to show in the widget for maximized windows.
           '';
         };
-        source = mkOption {
-          type = with types; nullOr (enum [ "appName" "decoration" "genericAppName" "alwaysUndefined" ]);
-          default = null;
-          example = "appName";
-          description = ''
-            The source of the window title for maximized windows.
+        source =
+          let
+            enumVals = [ "appName" "decoration" "genericAppName" "alwaysUndefined" ];
+          in
+          mkOption {
+            type = with types; nullOr (enum enumVals);
+            default = null;
+            example = "appName";
+            description = ''
+              The source of the window title for maximized windows.
 
-            - appName: The name of the application
-            - decoration: The title of the window decoration
-            - genericAppName: The generic name of the application
-            - alwaysUndefined: Always show the undefined title
-          '';
-        };
+              - appName: The name of the application
+              - decoration: The title of the window decoration
+              - genericAppName: The generic name of the application
+              - alwaysUndefined: Always show the undefined title
+            '';
+            apply = getIndexFromEnum enumVals;
+          };
       };
       behavior = {
-        activeTaskSource = mkOption {
-          type = with types; nullOr (enum [ "activeTask" "lastActiveTask" "lastActiveMaximized" ]);
-          default = null;
-          example = "activeTask";
-          description = ''
-            The source of the active task.
+        activeTaskSource =
+          let enumVals = [ "activeTask" "lastActiveTask" "lastActiveMaximized" ];
+          in mkOption {
+            type = with types; nullOr (enum enumVals);
+            default = null;
+            example = "activeTask";
+            description = ''
+              The source of the active task.
 
-            - activeTask: The active task
-            - lastActiveTask: The last active task
-            - lastActiveMaximized: The last active maximized task
-          '';
-        };
+              - activeTask: The active task
+              - lastActiveTask: The last active task
+              - lastActiveMaximized: The last active maximized task
+            '';
+            apply = getIndexFromEnum enumVals;
+          };
         filterByActivity = mkBoolOption "Whether to filter the tasks by activity.";
         filterByScreen = mkBoolOption "Whether to filter the tasks by screen.";
         filterByVirtualDesktop = mkBoolOption "Whether to filter the tasks by virtual desktop.";

--- a/modules/widgets/application-title-bar.nix
+++ b/modules/widgets/application-title-bar.nix
@@ -1,32 +1,42 @@
-{ lib, widgets, ... }:
+{ lib, ... }:
 let
   inherit (lib) mkOption types;
-  inherit (widgets.lib) mkBoolOption mkEnumOption;
 
-  convertHorizontalAlignment = horizontalAlignment: let
-    mappings = {
-      "left" = "1";
-      "right" = "2";
-      "center" = "4";
-      "justify" = "8";
-    };
-  in
-    mappings.${horizontalAlignment} or (throw "Invalid enum value: ${horizontalAlignment}");
+  mkBoolOption = description: lib.mkOption {
+    type = with lib.types; nullOr bool;
+    default = null;
+    example = true;
+    inherit description;
+  };
 
-  convertVerticalAlignment = verticalAlignment: let
-    mappings = {
-      "top" = "1";
-      "center" = "128";
-      "bottom" = "64";
-      "baseline" = "256";
-    };
-  in
-    mappings.${verticalAlignment} or (throw "Invalid enum value: ${verticalAlignment}");
+  convertHorizontalAlignment = horizontalAlignment:
+    let
+      mappings = {
+        "left" = "1";
+        "right" = "2";
+        "center" = "4";
+        "justify" = "8";
+      };
+    in
+      mappings.${horizontalAlignment} or (throw "Invalid enum value: ${horizontalAlignment}");
+
+  convertVerticalAlignment = verticalAlignment:
+    let
+      mappings = {
+        "top" = "1";
+        "center" = "128";
+        "bottom" = "64";
+        "baseline" = "256";
+      };
+    in
+      mappings.${verticalAlignment} or (throw "Invalid enum value: ${verticalAlignment}");
 
   fontType = types.submodule {
     options = {
       bold = mkBoolOption "Enable bold text.";
-      fit = mkEnumOption [ "fixedSize" "horizontalFit" "verticalFit" "fit" ] // {
+      fit = mkOption {
+        type = with types; nullOr (enum [ "fixedSize" "horizontalFit" "verticalFit" "fit" ]);
+        default = null;
         example = "fixedSize";
         description = "The mode of the size of the font.";
       };
@@ -34,7 +44,6 @@ let
         type = types.ints.positive;
         default = 10;
         description = "The size of the font.";
-        apply = builtins.toString;
       };
     };
   };
@@ -45,25 +54,21 @@ let
         type = types.ints.unsigned;
         default = 10;
         description = "The left margin.";
-        apply = builtins.toString;
       };
       right = mkOption {
         type = types.ints.unsigned;
         default = 10;
         description = "The right margin.";
-        apply = builtins.toString;
       };
       top = mkOption {
         type = types.ints.unsigned;
         default = 0;
         description = "The top margin.";
-        apply = builtins.toString;
       };
       bottom = mkOption {
         type = types.ints.unsigned;
         default = 0;
         description = "The bottom margin.";
-        apply = builtins.toString;
       };
     };
   };
@@ -78,13 +83,11 @@ in
           type = types.nullOr types.ints.unsigned;
           default = null;
           description = "The margins around the widget.";
-          apply = builtins.toString;
         };
         spacingBetweenElements = mkOption {
           type = types.nullOr types.ints.unsigned;
           default = null;
           description = "The spacing between elements.";
-          apply = builtins.toString;
         };
         horizontalAlignment = mkOption {
           type = types.enum [ "left" "right" "center" "justify" ];
@@ -98,7 +101,9 @@ in
           description = "The vertical alignment of the widget.";
           apply = convertVerticalAlignment;
         };
-        showDisabledElements = mkEnumOption [ "deactivated" "hideKeepSpace" "hide" ] // {
+        showDisabledElements = mkOption {
+          type = with types; nullOr (enum [ "deactivated" "hideKeepSpace" "hide" ]);
+          default = null;
           example = "deactivated";
           description = "How to show the elements when the widget is disabled.";
         };
@@ -123,7 +128,9 @@ in
         };
       };
       windowControlButtons = {
-        iconSource = mkEnumOption [ "plasma" "breeze" "aurorae" "oxygen" ] // {
+        iconSource = mkOption {
+          type = with types; nullOr (enum [ "plasma" "breeze" "aurorae" "oxygen" ]);
+          default = null;
           example = "plasma";
           description = ''
             The icon source for the control buttons.
@@ -143,19 +150,16 @@ in
           type = types.nullOr types.ints.unsigned;
           default = null;
           description = "The margin around the buttons.";
-          apply = builtins.toString;
         };
         buttonsAspectRatio = mkOption {
           type = types.nullOr types.ints.unsigned;
           default = null;
           description = "The ratio of button width in percent to 100% of its height. If you need wider buttons, the value should be >100, otherwise less.";
-          apply = builtins.toString;
         };
         buttonsAnimationSpeed = mkOption {
           type = types.nullOr types.ints.unsigned;
           default = null;
           description = "The speed of the buttons animation in milliseconds.";
-          apply = builtins.toString;
         };
       };
       windowTitle = {
@@ -163,13 +167,11 @@ in
           type = types.nullOr types.ints.unsigned;
           default = null;
           description = "The minimum width of the window title.";
-          apply = builtins.toString;
         };
         maximumWidth = mkOption {
           type = types.nullOr types.ints.unsigned;
           default = null;
           description = "The maximum width of the window title.";
-          apply = builtins.toString;
         };
         font = mkOption {
           type = types.nullOr fontType;
@@ -192,7 +194,9 @@ in
           default = null;
           description = "The text to show when the window title is undefined.";
         };
-        source = mkEnumOption [ "appName" "decoration" "genericAppName" "alwaysUndefined" ] // {
+        source = mkOption {
+          type = with types; nullOr (enum [ "appName" "decoration" "genericAppName" "alwaysUndefined" ]);
+          default = null;
           example = "appName";
           description = ''
             The source of the window title.
@@ -241,7 +245,9 @@ in
             The elements to show in the widget for maximized windows.
           '';
         };
-        source = mkEnumOption [ "appName" "decoration" "genericAppName" "alwaysUndefined" ] // {
+        source = mkOption {
+          type = with types; nullOr (enum [ "appName" "decoration" "genericAppName" "alwaysUndefined" ]);
+          default = null;
           example = "appName";
           description = ''
             The source of the window title for maximized windows.
@@ -254,7 +260,9 @@ in
         };
       };
       behavior = {
-        activeTaskSource = mkEnumOption [ "activeTask" "lastActiveTask" "lastActiveMaximized" ] // {
+        activeTaskSource = mkOption {
+          type = with types; nullOr (enum [ "activeTask" "lastActiveTask" "lastActiveMaximized" ]);
+          default = null;
           example = "activeTask";
           description = ''
             The source of the active task.
@@ -277,7 +285,6 @@ in
           type = types.nullOr types.ints.unsigned;
           default = null;
           description = "The threshold for dragging the widget.";
-          apply = builtins.toString;
         };
         leftDragAction = mkOption {
           type = types.nullOr types.str;
@@ -329,13 +336,11 @@ in
           type = types.nullOr types.ints.unsigned;
           default = null;
           description = "The distance of the first event.";
-          apply = builtins.toString;
         };
         nextEventDistance = mkOption {
           type = types.nullOr types.ints.unsigned;
           default = null;
           description = "The distance of the next event.";
-          apply = builtins.toString;
         };
         wheelUp = mkOption {
           type = types.nullOr types.str;
@@ -359,88 +364,88 @@ in
         };
       };
     };
-    convert = 
-     { layout
-     , windowControlButtons
-     , windowTitle
-     , overrideForMaximized
-     , behavior
-     , mouseAreaDrag
-     , mouseAreaClick
-     , mouseAreaWheel
-     }: {
-      name = "com.github.antroids.application-title-bar";
-      config = {
-        Appearance = lib.filterAttrs (_: v: v != null) (
-          {
-            # Widget layout
-            widgetMargins = layout.widgetMargins;
-            widgetSpacing = layout.spacingBetweenElements;
-            widgetHorizontalAlignment = layout.horizontalAlignment;
-            widgetVerticalAlignment = layout.verticalAlignment;
-            widgetElementsDisabledMode = layout.showDisabledElements;
-            widgetFillWidth = layout.fillFreeSpace;
-            widgetElements = layout.elements;
+    convert =
+      { layout
+      , windowControlButtons
+      , windowTitle
+      , overrideForMaximized
+      , behavior
+      , mouseAreaDrag
+      , mouseAreaClick
+      , mouseAreaWheel
+      }: {
+        name = "com.github.antroids.application-title-bar";
+        config = {
+          Appearance = lib.filterAttrs (_: v: v != null) (
+            {
+              # Widget layout
+              widgetMargins = layout.widgetMargins;
+              widgetSpacing = layout.spacingBetweenElements;
+              widgetHorizontalAlignment = layout.horizontalAlignment;
+              widgetVerticalAlignment = layout.verticalAlignment;
+              widgetElementsDisabledMode = layout.showDisabledElements;
+              widgetFillWidth = layout.fillFreeSpace;
+              widgetElements = layout.elements;
 
-            # Window control buttons
-            widgetButtonsIconsTheme = windowControlButtons.iconSource;
-            widgetButtonsAuroraeTheme = windowControlButtons.auroraeTheme;
-            widgetButtonsMargins = windowControlButtons.buttonsMargin;
-            widgetButtonsAspectRatio = windowControlButtons.buttonsAspectRatio;
-            widgetButtonsAnimation = windowControlButtons.buttonsAnimationSpeed;
+              # Window control buttons
+              widgetButtonsIconsTheme = windowControlButtons.iconSource;
+              widgetButtonsAuroraeTheme = windowControlButtons.auroraeTheme;
+              widgetButtonsMargins = windowControlButtons.buttonsMargin;
+              widgetButtonsAspectRatio = windowControlButtons.buttonsAspectRatio;
+              widgetButtonsAnimation = windowControlButtons.buttonsAnimationSpeed;
 
-            # Window title
-            windowTitleMinimumWidth = windowTitle.minimumWidth;
-            windowTitleMaximumWidth = windowTitle.maximumWidth;
-            windowTitleHideEmpty = windowTitle.hideEmptyTitle;
-            windowTitleUndefined = windowTitle.undefinedWindowTitle;
-            windowTitleSource = windowTitle.source;
+              # Window title
+              windowTitleMinimumWidth = windowTitle.minimumWidth;
+              windowTitleMaximumWidth = windowTitle.maximumWidth;
+              windowTitleHideEmpty = windowTitle.hideEmptyTitle;
+              windowTitleUndefined = windowTitle.undefinedWindowTitle;
+              windowTitleSource = windowTitle.source;
 
-            # Override for maximized windows
-            overrideElementsMaximized = overrideForMaximized.enable;
-            widgetElementsMaximized = overrideForMaximized.elements;
-            windowTitleSourceMaximized = overrideForMaximized.source;
-          }
-          // windowTitle.font
-          // windowTitle.margins
-        );
-        Behavior = lib.filterAttrs (_: v: v != null) (
-          {
-            # Behavior
-            widgetActiveTaskSource = behavior.activeTaskSource;
-            widgetActiveTaskFilterByActivity = behavior.filterByActivity;
-            widgetActiveTaskFilterByScreen = behavior.filterByScreen;
-            widgetActiveTaskFilterByVirtualDesktop = behavior.filterByVirtualDesktop;
-            widgetActiveTaskFilterNotMaximized = behavior.disableForNotMaximized;
-            disableButtonsForNotHoveredWidget = behavior.disableButtonsForNotHovered;
+              # Override for maximized windows
+              overrideElementsMaximized = overrideForMaximized.enable;
+              widgetElementsMaximized = overrideForMaximized.elements;
+              windowTitleSourceMaximized = overrideForMaximized.source;
+            }
+            // windowTitle.font
+            // windowTitle.margins
+          );
+          Behavior = lib.filterAttrs (_: v: v != null) (
+            {
+              # Behavior
+              widgetActiveTaskSource = behavior.activeTaskSource;
+              widgetActiveTaskFilterByActivity = behavior.filterByActivity;
+              widgetActiveTaskFilterByScreen = behavior.filterByScreen;
+              widgetActiveTaskFilterByVirtualDesktop = behavior.filterByVirtualDesktop;
+              widgetActiveTaskFilterNotMaximized = behavior.disableForNotMaximized;
+              disableButtonsForNotHoveredWidget = behavior.disableButtonsForNotHovered;
 
-            # Mouse area drag
-            windowTitleDragEnabled = mouseAreaDrag.enable;
-            windowTitleDragOnlyMaximized = mouseAreaDrag.onlyMaximized;
-            windowTitleDragThreshold = mouseAreaDrag.threshold;
-            widgetMouseAreaLeftDragAction = mouseAreaDrag.leftDragAction;
-            widgetMouseAreaMiddleDragAction = mouseAreaDrag.middleDragAction;
+              # Mouse area drag
+              windowTitleDragEnabled = mouseAreaDrag.enable;
+              windowTitleDragOnlyMaximized = mouseAreaDrag.onlyMaximized;
+              windowTitleDragThreshold = mouseAreaDrag.threshold;
+              widgetMouseAreaLeftDragAction = mouseAreaDrag.leftDragAction;
+              widgetMouseAreaMiddleDragAction = mouseAreaDrag.middleDragAction;
 
-            # Mouse area click
-            widgetMouseAreaClickEnabled = mouseAreaClick.enable;
-            widgetMouseAreaLeftClickAction = mouseAreaClick.leftButtonClick;
-            widgetMouseAreaLeftDoubleClickAction = mouseAreaClick.leftButtonDoubleClick;
-            widgetMouseAreaLeftLongPressAction = mouseAreaClick.leftButtonLongClick;
-            widgetMouseAreaMiddleClickAction = mouseAreaClick.middleButtonClick;
-            widgetMouseAreaMiddleDoubleClickAction = mouseAreaClick.middleButtonDoubleClick;
-            widgetMouseAreaMiddleLongPressAction = mouseAreaClick.middleButtonLongClick;
+              # Mouse area click
+              widgetMouseAreaClickEnabled = mouseAreaClick.enable;
+              widgetMouseAreaLeftClickAction = mouseAreaClick.leftButtonClick;
+              widgetMouseAreaLeftDoubleClickAction = mouseAreaClick.leftButtonDoubleClick;
+              widgetMouseAreaLeftLongPressAction = mouseAreaClick.leftButtonLongClick;
+              widgetMouseAreaMiddleClickAction = mouseAreaClick.middleButtonClick;
+              widgetMouseAreaMiddleDoubleClickAction = mouseAreaClick.middleButtonDoubleClick;
+              widgetMouseAreaMiddleLongPressAction = mouseAreaClick.middleButtonLongClick;
 
-            # Mouse area wheel
-            widgetMouseAreaWheelEnabled = mouseAreaWheel.enable;
-            widgetMouseAreaWheelFirstEventDistance = mouseAreaWheel.firstEventDistance;
-            widgetMouseAreaWheelNextEventDistance = mouseAreaWheel.nextEventDistance;
-            widgetMouseAreaWheelUpAction = mouseAreaWheel.wheelUp;
-            widgetMouseAreaWheelDownAction = mouseAreaWheel.wheelDown;
-            widgetMouseAreaWheelLeftAction = mouseAreaWheel.wheelLeft;
-            widgetMouseAreaWheelRightAction = mouseAreaWheel.wheelRight;
-          }
-        );
+              # Mouse area wheel
+              widgetMouseAreaWheelEnabled = mouseAreaWheel.enable;
+              widgetMouseAreaWheelFirstEventDistance = mouseAreaWheel.firstEventDistance;
+              widgetMouseAreaWheelNextEventDistance = mouseAreaWheel.nextEventDistance;
+              widgetMouseAreaWheelUpAction = mouseAreaWheel.wheelUp;
+              widgetMouseAreaWheelDownAction = mouseAreaWheel.wheelDown;
+              widgetMouseAreaWheelLeftAction = mouseAreaWheel.wheelLeft;
+              widgetMouseAreaWheelRightAction = mouseAreaWheel.wheelRight;
+            }
+          );
+        };
       };
-    };
   };
 }

--- a/modules/widgets/battery.nix
+++ b/modules/widgets/battery.nix
@@ -1,9 +1,14 @@
-{ lib, widgets, ... }: {
+{ lib, ... }: {
   battery = {
     description = "The battery indicator widget.";
 
     # See https://invent.kde.org/plasma/plasma-workspace/-/blob/master/applets/batterymonitor/package/contents/config/main.xml for the accepted raw options
-    opts.showPercentage = widgets.lib.mkBoolOption "Enable to show the battery percentage as a small label over the battery icon.";
+    opts.showPercentage = lib.mkOption {
+      type = with lib.types; nullOr bool;
+      default = null;
+      example = true;
+      description = "Enable to show the battery percentage as a small label over the battery icon.";
+    };
 
     convert = { showPercentage }: {
       name = "org.kde.plasma.battery";

--- a/modules/widgets/default.nix
+++ b/modules/widgets/default.nix
@@ -31,7 +31,7 @@ let
         description = "The name of the widget to add.";
       };
       config = lib.mkOption {
-        type = with lib.types; nullOr (attrsOf (attrsOf (either str (listOf str))));
+        type = (import ./lib.nix (args // { widgets = self; })).configValueType;
         default = null;
         example = {
           General.icon = "nix-snowflake-white";

--- a/modules/widgets/digital-clock.nix
+++ b/modules/widgets/digital-clock.nix
@@ -8,6 +8,15 @@ let
     inherit description;
   };
 
+  getIndexFromEnum = enum: value:
+    if value == null
+    then null
+    else
+      lib.lists.findFirstIndex
+        (x: x == value)
+        (throw "getIndexFromEnum (digital-clock widget): Value ${value} isn't present in the enum. This is a bug")
+        enum;
+
   fontType = types.submodule {
     options = {
       family = mkOption {
@@ -47,12 +56,12 @@ in
 
         format =
           let
-            enum = [ "shortDate" "longDate" "isoDate" ];
+            enumVals = [ "shortDate" "longDate" "isoDate" ];
           in
           mkOption {
-            type = types.nullOr (types.either (types.enum enum) (types.submodule {
+            type = with types; nullOr (either (enum enumVals) (submodule {
               options.custom = mkOption {
-                type = types.str;
+                type = str;
                 example = "ddd d";
                 description = "The custom date format to use.";
               };
@@ -78,44 +87,53 @@ in
 
           };
 
-        position = mkOption {
-          type = with types; nullOr (enum [ "adaptive" "besideTime" "belowTime" ]);
-          default = null;
-          example = "belowTime";
-          description = ''
-            The position where the date is displayed.
+        position =
+          let enumVals = [ "adaptive" "besideTime" "belowTime" ];
+          in mkOption {
+            type = with types; nullOr (enum enumVals);
+            default = null;
+            example = "belowTime";
+            description = ''
+              The position where the date is displayed.
 
-            Could be adaptive, always beside the displayed time, or below the displayed time.
-          '';
-        };
+              Could be adaptive, always beside the displayed time, or below the displayed time.
+            '';
+            apply = getIndexFromEnum enumVals;
+          };
       };
 
       time = {
-        showSeconds = mkOption {
-          type = with types; nullOr (enum [ "never" "onlyInTooltip" "always" ]);
-          default = null;
-          example = "always";
-          description = ''
-            When and where the seconds should be shown on the clock.
+        showSeconds =
+          let enumVals = [ "never" "onlyInTooltip" "always" ];
+          in mkOption {
+            type = with types; nullOr (enum enumVals);
+            default = null;
+            example = "always";
+            description = ''
+              When and where the seconds should be shown on the clock.
 
-            Could be never, only in the tooltip on hover, or always.
-          '';
-        };
-        format = mkOption {
-          type = with types; nullOr (enum [ "12h" "default" "24h" ]);
-          default = null;
-          example = "24h";
-          description = ''
-            The time format used for this clock.
+              Could be never, only in the tooltip on hover, or always.
+            '';
+            apply = getIndexFromEnum enumVals;
+          };
+        format =
+          let enumVals = [ "12h" "default" "24h" ];
+          in mkOption {
+            type = with types; nullOr (enum enumVals);
+            default = null;
+            example = "24h";
+            description = ''
+              The time format used for this clock.
 
-            Could be 12-hour, the default for your locale, or 24-hour.
-          '';
-        };
+              Could be 12-hour, the default for your locale, or 24-hour.
+            '';
+            apply = getIndexFromEnum enumVals;
+          };
       };
 
       timeZone = {
         selected = mkOption {
-          type = types.nullOr (types.listOf types.str);
+          type = with types; nullOr (listOf str);
           default = null;
           example = [ "Europe/Berlin" "Asia/Shanghai" ];
           description = ''
@@ -125,7 +143,7 @@ in
           '';
         };
         lastSelected = mkOption {
-          type = types.nullOr types.str;
+          type = with types; nullOr str;
           default = null;
           description = ''
             The timezone to show upon widget restore.
@@ -134,33 +152,39 @@ in
           '';
         };
         changeOnScroll = mkBoolOption "Allow changing the displayed timezone by scrolling on the widget with the mouse wheel.";
-        format = mkOption {
-          type = with types; nullOr (enum [ "code" "city" "offset" ]);
-          default = null;
-          example = "code";
-          description = ''
-            The format of the timezone displayed, whether as a
-            code, full name of the city that the timezone belongs to,
-            or as an UTC offset.
+        format =
+          let enumVals = [ "code" "city" "offset" ];
+          in mkOption {
+            type = with types; nullOr (enum enumVals);
+            default = null;
+            example = "code";
+            description = ''
+              The format of the timezone displayed, whether as a
+              code, full name of the city that the timezone belongs to,
+              or as an UTC offset.
 
-            For example, for the timezone Asia/Shanghai, the three formats
-            listed above would display "CST", "Shanghai" and "+8" respectively.
-          '';
-        };
+              For example, for the timezone Asia/Shanghai, the three formats
+              listed above would display "CST", "Shanghai" and "+8" respectively.
+            '';
+            apply = getIndexFromEnum enumVals;
+          };
         alwaysShow = mkBoolOption "Always show the selected timezone, when it's the same with the system timezone";
       };
 
       calendar = {
-        firstDayOfWeek = mkOption {
-          type = with types; nullOr (enum [ "sunday" "monday" "tuesday" "wednesday" "thursday" "friday" "saturday" ]);
-          default = null;
-          example = "monday";
-          description = ''
-            The first day of the week that the calendar uses.
+        firstDayOfWeek =
+          let enumVals = [ "sunday" "monday" "tuesday" "wednesday" "thursday" "friday" "saturday" ];
+          in mkOption {
+            type = with types; nullOr (enum enumVals);
+            default = null;
+            example = "monday";
+            description = ''
+              The first day of the week that the calendar uses.
 
-            If null, then the default for the user locale is used.
-          '';
-        };
+              If null, then the default for the user locale is used.
+            '';
+            apply = getIndexFromEnum enumVals;
+          };
         plugins = mkOption {
           type = types.nullOr (types.listOf types.str);
           default = null;

--- a/modules/widgets/digital-clock.nix
+++ b/modules/widgets/digital-clock.nix
@@ -1,7 +1,12 @@
-{ lib, widgets, ... }:
+{ lib, ... }:
 let
   inherit (lib) mkOption types;
-  inherit (widgets.lib) mkBoolOption mkEnumOption boolToString';
+
+  mkBoolOption = description: mkOption {
+    type = with types; nullOr bool;
+    default = null;
+    inherit description;
+  };
 
   fontType = types.submodule {
     options = {
@@ -16,7 +21,6 @@ let
         type = types.ints.between 1 1000;
         default = 50;
         description = "The weight of the font.";
-        apply = builtins.toString;
       };
       style = mkOption {
         type = types.nullOr types.str;
@@ -27,7 +31,6 @@ let
         type = types.ints.positive;
         default = 10;
         description = "The size of the font.";
-        apply = builtins.toString;
       };
     };
   };
@@ -75,7 +78,9 @@ in
 
           };
 
-        position = mkEnumOption [ "adaptive" "besideTime" "belowTime" ] // {
+        position = mkOption {
+          type = with types; nullOr (enum [ "adaptive" "besideTime" "belowTime" ]);
+          default = null;
           example = "belowTime";
           description = ''
             The position where the date is displayed.
@@ -86,7 +91,9 @@ in
       };
 
       time = {
-        showSeconds = mkEnumOption [ "never" "onlyInTooltip" "always" ] // {
+        showSeconds = mkOption {
+          type = with types; nullOr (enum [ "never" "onlyInTooltip" "always" ]);
+          default = null;
           example = "always";
           description = ''
             When and where the seconds should be shown on the clock.
@@ -94,7 +101,9 @@ in
             Could be never, only in the tooltip on hover, or always.
           '';
         };
-        format = mkEnumOption [ "12h" "default" "24h" ] // {
+        format = mkOption {
+          type = with types; nullOr (enum [ "12h" "default" "24h" ]);
+          default = null;
           example = "24h";
           description = ''
             The time format used for this clock.
@@ -125,7 +134,9 @@ in
           '';
         };
         changeOnScroll = mkBoolOption "Allow changing the displayed timezone by scrolling on the widget with the mouse wheel.";
-        format = mkEnumOption [ "code" "city" "offset" ] // {
+        format = mkOption {
+          type = with types; nullOr (enum [ "code" "city" "offset" ]);
+          default = null;
           example = "code";
           description = ''
             The format of the timezone displayed, whether as a
@@ -140,7 +151,9 @@ in
       };
 
       calendar = {
-        firstDayOfWeek = mkEnumOption [ "sunday" "monday" "tuesday" "wednesday" "thursday" "friday" "saturday" ] // {
+        firstDayOfWeek = mkOption {
+          type = with types; nullOr (enum [ "sunday" "monday" "tuesday" "wednesday" "thursday" "friday" "saturday" ]);
+          default = null;
           example = "monday";
           description = ''
             The first day of the week that the calendar uses.
@@ -171,7 +184,7 @@ in
         '';
         apply = font:
           {
-            autoFontAndSize = boolToString' (font == null);
+            autoFontAndSize = (font == null);
           }
           // lib.optionalAttrs (font != null) {
             fontFamily = font.family;

--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -30,7 +30,7 @@ let
 
   positionToReverse = position:
     let
-      mappings = { "left" = "true"; "right" = "false"; };
+      mappings = { "left" = true; "right" = false; };
     in
       mappings.${position} or (throw "Invalid position: ${position}");
 in
@@ -56,14 +56,13 @@ in
             default = "never";
             example = "lowSpace";
             description = "When to use multi-row view.";
-            apply = multirowView: if multirowView == "never" then "false" else (if multirowView == "always" then "true" else null);
+            apply = multirowView: if multirowView == "never" then false else (if multirowView == "always" then true else null);
           };
           maximum = mkOption {
             type = types.nullOr types.ints.positive;
             default = null;
             example = 5;
             description = "The maximum number of rows (in a horizontal-orientation containment, i.e. panel) or columns (in a vertical-orientation containment) to layout task buttons in.";
-            apply = builtins.toString;
           };
         };
         iconSpacing = mkOption {

--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -1,19 +1,28 @@
-{ lib, widgets, ... }:
+{ lib, ... }:
 let
   inherit (lib) mkOption types;
-  inherit (widgets.lib) mkBoolOption mkEnumOption;
 
-  convertSpacing = spacing: let
-    mappings = {
-      "small" = "0";
-      "medium" = "1";
-      "large" = "3";
-    };
-  in mappings.${spacing} or (throw "Invalid spacing: ${spacing}");
+  mkBoolOption = description: mkOption {
+    type = with types; nullOr bool;
+    default = null;
+    inherit description;
+  };
 
-  positionToReverse = position: let
-    mappings = { "left" = "true"; "right" = "false"; };
-  in mappings.${position} or (throw "Invalid position: ${position}");
+  convertSpacing = spacing:
+    let
+      mappings = {
+        "small" = "0";
+        "medium" = "1";
+        "large" = "3";
+      };
+    in
+      mappings.${spacing} or (throw "Invalid spacing: ${spacing}");
+
+  positionToReverse = position:
+    let
+      mappings = { "left" = "true"; "right" = "false"; };
+    in
+      mappings.${position} or (throw "Invalid position: ${position}");
 in
 {
   iconTasks = {
@@ -57,21 +66,29 @@ in
       };
       behavior = {
         grouping = {
-          method = mkEnumOption [ "none" "byProgramName" ] // {
+          method = mkOption {
+            type = with types; nullOr (enum [ "none" "byProgramName" ]);
+            default = null;
             example = "none";
             description = "How tasks are grouped";
-          };  
-          clickAction = mkEnumOption [ "cycle" "showTooltips" "showPresentWindowsEffect" "showTextualList" ] // {
+          };
+          clickAction = mkOption {
+            type = with types; nullOr (enum [ "cycle" "showTooltips" "showPresentWindowsEffect" "showTextualList" ]);
+            default = null;
             example = "cycle";
             description = "What happens when clicking on a grouped task";
           };
         };
-        sortingMethod = mkEnumOption [ "none" "manually" "alphabetically" "byDesktop" "byActivity" ] // {
+        sortingMethod = mkOption {
+          type = with types; nullOr (enum [ "none" "manually" "alphabetically" "byDesktop" "byActivity" ]);
+          default = null;
           example = "manually";
           description = "How to sort tasks";
         };
         minimizeActiveTaskOnClick = mkBoolOption "Whether to minimize the currently-active task when clicked. If false, clicking on the currently-active task will do nothing.";
-        middleClickAction = mkEnumOption [ "none" "close" "newInstance" "toggleMinimized" "toggleGrouping" "bringToCurrentDesktop" ] // {
+        middleClickAction = mkOption {
+          type = with types; nullOr (enum [ "none" "close" "newInstance" "toggleMinimized" "toggleGrouping" "bringToCurrentDesktop" ]);
+          default = null;
           example = "bringToCurrentDesktop";
           description = "What to do on middle-mouse click on a task button.";
         };
@@ -98,9 +115,10 @@ in
     convert =
       { appearance
       , behavior
-      , launchers }: {
-      name = "org.kde.plasma.icontasks";
-      config.General = lib.filterAttrs (_: v: v != null) (
+      , launchers
+      }: {
+        name = "org.kde.plasma.icontasks";
+        config.General = lib.filterAttrs (_: v: v != null) (
           {
             launchers = launchers;
 
@@ -134,6 +152,6 @@ in
             reverseMode = behavior.newTasksAppearOn;
           }
         );
-    };
+      };
   };
 }

--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -11,16 +11,16 @@ let
   convertSpacing = spacing:
     let
       mappings = {
-        "small" = "0";
-        "medium" = "1";
-        "large" = "3";
+        small = 0;
+        medium = 1;
+        large = 3;
       };
     in
       mappings.${spacing} or (throw "Invalid spacing: ${spacing}");
 
   positionToReverse = position:
     let
-      mappings = { "left" = "true"; "right" = "false"; };
+      mappings = { left = "true"; right = "false"; };
     in
       mappings.${position} or (throw "Invalid position: ${position}");
 in

--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -11,12 +11,22 @@ let
   convertSpacing = spacing:
     let
       mappings = {
-        "small" = "0";
-        "medium" = "1";
-        "large" = "3";
+        "small" = 0;
+        "medium" = 1;
+        "large" = 3;
       };
     in
       mappings.${spacing} or (throw "Invalid spacing: ${spacing}");
+
+
+  getIndexFromEnum = enum: value:
+    if value == null
+    then null
+    else
+      lib.lists.findFirstIndex
+        (x: x == value)
+        (throw "getIndexFromEnum (icon-tasks widget): Value ${value} isn't present in the enum. This is a bug")
+        enum;
 
   positionToReverse = position:
     let
@@ -66,32 +76,44 @@ in
       };
       behavior = {
         grouping = {
-          method = mkOption {
-            type = with types; nullOr (enum [ "none" "byProgramName" ]);
-            default = null;
-            example = "none";
-            description = "How tasks are grouped";
-          };
-          clickAction = mkOption {
-            type = with types; nullOr (enum [ "cycle" "showTooltips" "showPresentWindowsEffect" "showTextualList" ]);
-            default = null;
-            example = "cycle";
-            description = "What happens when clicking on a grouped task";
-          };
+          method =
+            let enumVals = [ "none" "byProgramName" ];
+            in mkOption {
+              type = with types; nullOr (enum enumVals);
+              default = null;
+              example = "none";
+              description = "How tasks are grouped";
+              apply = getIndexFromEnum enumVals;
+            };
+          clickAction =
+            let enumVals = [ "cycle" "showTooltips" "showPresentWindowsEffect" "showTextualList" ];
+            in mkOption {
+              type = with types; nullOr (enum enumVals);
+              default = null;
+              example = "cycle";
+              description = "What happens when clicking on a grouped task";
+              apply = getIndexFromEnum enumVals;
+            };
         };
-        sortingMethod = mkOption {
-          type = with types; nullOr (enum [ "none" "manually" "alphabetically" "byDesktop" "byActivity" ]);
-          default = null;
-          example = "manually";
-          description = "How to sort tasks";
-        };
+        sortingMethod =
+          let enumVals = [ "none" "manually" "alphabetically" "byDesktop" "byActivity" ];
+          in mkOption {
+            type = with types; nullOr (enum enumVals);
+            default = null;
+            example = "manually";
+            description = "How to sort tasks";
+            apply = getIndexFromEnum enumVals;
+          };
         minimizeActiveTaskOnClick = mkBoolOption "Whether to minimize the currently-active task when clicked. If false, clicking on the currently-active task will do nothing.";
-        middleClickAction = mkOption {
-          type = with types; nullOr (enum [ "none" "close" "newInstance" "toggleMinimized" "toggleGrouping" "bringToCurrentDesktop" ]);
-          default = null;
-          example = "bringToCurrentDesktop";
-          description = "What to do on middle-mouse click on a task button.";
-        };
+        middleClickAction =
+          let enumVals = [ "none" "close" "newInstance" "toggleMinimized" "toggleGrouping" "bringToCurrentDesktop" ];
+          in mkOption {
+            type = with types; nullOr (enum enumVals);
+            default = null;
+            example = "bringToCurrentDesktop";
+            description = "What to do on middle-mouse click on a task button.";
+            apply = getIndexFromEnum enumVals;
+          };
         wheel = {
           switchBetweenTasks = mkBoolOption "Whether using the mouse wheel with the mouse pointer above the widget should switch between tasks.";
           ignoreMinimizedTasks = mkBoolOption "Whether to skip minimized tasks when switching between them using the mouse wheel.";

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -1,16 +1,23 @@
-{ lib, widgets, ...}:
+{ lib, ... }:
 let
   inherit (lib) mkOption types;
-  inherit (widgets.lib) mkBoolOption mkEnumOption;
 
-  convertSidebarPosition = sidebarPosition: let
-    mappings = { "left" = "false"; "right" = "true"; };
-  in mappings.${sidebarPosition} or (throw "Invalid sidebar position: ${sidebarPosition}");
+  mkBoolOption = description: mkOption {
+    type = with types; nullOr bool;
+    default = null;
+    inherit description;
+  };
+
+  convertSidebarPosition = sidebarPosition:
+    let
+      mappings = { "left" = "false"; "right" = "true"; };
+    in
+      mappings.${sidebarPosition} or (throw "Invalid sidebar position: ${sidebarPosition}");
 in
 {
   kickoff = {
     description = "Kickoff is the default application launcher of the Plasma desktop.";
-    
+
     opts = {
       icon = mkOption {
         type = types.nullOr types.str;
@@ -33,15 +40,21 @@ in
         description = "The position of the sidebar.";
         apply = convertSidebarPosition;
       };
-      favoritesDisplayMode = mkEnumOption [ "grid" "list" ] // {
+      favoritesDisplayMode = mkOption {
+        type = with types; nullOr (enum [ "grid" "list" ]);
+        default = null;
         example = "list";
         description = "How to display favorites.";
       };
-      applicationsDisplayMode = mkEnumOption [ "grid" "list" ] // {
+      applicationsDisplayMode = mkOption {
+        type = with types; nullOr (enum [ "grid" "list" ]);
+        default = null;
         example = "grid";
         description = "How to display applications.";
       };
-      showButtonsFor = mkEnumOption [ "power" "session" "custom" "powerAndSession" ] // {
+      showButtonsFor = mkOption {
+        type = with types; nullOr (enum [ "power" "session" "custom" "powerAndSession" ]);
+        default = null;
         example = "powerAndSession";
         description = "Which actions should be displayed in the footer.";
       };
@@ -72,7 +85,7 @@ in
             applicationsDisplay = applicationsDisplayMode;
             primaryActions = showButtonsFor;
             showActionButtonCaptions = showActionButtonCaptions;
-            
+
             # Other useful options
             pin = pin;
           }

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -8,6 +8,15 @@ let
     inherit description;
   };
 
+  getIndexFromEnum = enum: value:
+    if value == null
+    then null
+    else
+      lib.lists.findFirstIndex
+        (x: x == value)
+        (throw "getIndexFromEnum (kickoff widget): Value ${value} isn't present in the enum. This is a bug")
+        enum;
+
   convertSidebarPosition = sidebarPosition:
     let
       mappings = { "left" = "false"; "right" = "true"; };
@@ -40,24 +49,33 @@ in
         description = "The position of the sidebar.";
         apply = convertSidebarPosition;
       };
-      favoritesDisplayMode = mkOption {
-        type = with types; nullOr (enum [ "grid" "list" ]);
-        default = null;
-        example = "list";
-        description = "How to display favorites.";
-      };
-      applicationsDisplayMode = mkOption {
-        type = with types; nullOr (enum [ "grid" "list" ]);
-        default = null;
-        example = "grid";
-        description = "How to display applications.";
-      };
-      showButtonsFor = mkOption {
-        type = with types; nullOr (enum [ "power" "session" "custom" "powerAndSession" ]);
-        default = null;
-        example = "powerAndSession";
-        description = "Which actions should be displayed in the footer.";
-      };
+      favoritesDisplayMode =
+        let enumVals = [ "grid" "list" ];
+        in mkOption {
+          type = with types; nullOr (enum enumVals);
+          default = null;
+          example = "list";
+          description = "How to display favorites.";
+          apply = getIndexFromEnum enumVals;
+        };
+      applicationsDisplayMode =
+        let enumVals = [ "grid" "list" ];
+        in mkOption {
+          type = with types; nullOr (enum enumVals);
+          default = null;
+          example = "grid";
+          description = "How to display applications.";
+          apply = getIndexFromEnum enumVals;
+        };
+      showButtonsFor =
+        let enumVals = [ "power" "session" "custom" "powerAndSession" ];
+        in mkOption {
+          type = with types; nullOr (enum enumVals);
+          default = null;
+          example = "powerAndSession";
+          description = "Which actions should be displayed in the footer.";
+          apply = getIndexFromEnum enumVals;
+        };
       showActionButtonCaptions = mkBoolOption "Whether to display captions ('shut down', 'log out', etc.) for the footer action buttons";
       pin = mkBoolOption "Whether the popup should remain open when another window is activated.";
     };

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -10,7 +10,7 @@ let
 
   convertSidebarPosition = sidebarPosition:
     let
-      mappings = { "left" = "false"; "right" = "true"; };
+      mappings = { left = "false"; right = "true"; };
     in
       mappings.${sidebarPosition} or (throw "Invalid sidebar position: ${sidebarPosition}");
 in

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -19,7 +19,7 @@ let
 
   convertSidebarPosition = sidebarPosition:
     let
-      mappings = { "left" = "false"; "right" = "true"; };
+      mappings = { "left" = false; "right" = true; };
     in
       mappings.${sidebarPosition} or (throw "Invalid sidebar position: ${sidebarPosition}");
 in

--- a/modules/widgets/plasmusic-toolbar.nix
+++ b/modules/widgets/plasmusic-toolbar.nix
@@ -36,7 +36,6 @@ in
             default = null;
             example = 8;
             description = "Radius of the album cover icon.";
-            apply = builtins.toString;
           };
         };
       };
@@ -55,7 +54,6 @@ in
           default = null;
           example = 200;
           description = "Maximum width of the song text.";
-          apply = builtins.toString;
         };
         scrolling = {
           behavior =
@@ -74,7 +72,6 @@ in
             default = null;
             example = 3;
             description = "Speed of the scrolling text.";
-            apply = builtins.toString;
           };
         };
         displayInSeparateLines = mkBoolOption "Whether to display song information (title and artist) in separate lines or not.";

--- a/modules/widgets/plasmusic-toolbar.nix
+++ b/modules/widgets/plasmusic-toolbar.nix
@@ -1,7 +1,21 @@
-{lib, widgets, ...}: 
+{ lib, ... }:
 let
   inherit (lib) mkOption types;
-  inherit (widgets.lib) mkBoolOption mkEnumOption;
+
+  mkBoolOption = description: lib.mkOption {
+    type = with lib.types; nullOr bool;
+    default = null;
+    inherit description;
+  };
+
+  getIndexFromEnum = enum: value:
+    if value == null
+    then null
+    else
+      lib.lists.findFirstIndex
+        (x: x == value)
+        (throw "getIndexFromEnum (plasmusic-toolbar widget): Value ${value} isn't present in the enum. This is a bug")
+        enum;
 in
 {
   plasmusicToolbar = {
@@ -26,10 +40,15 @@ in
           };
         };
       };
-      preferredSource = mkEnumOption [ "any" "spotify" "vlc" ] // {
-        example = "any";
-        description = "Preferred source for song information.";
-      };
+      preferredSource =
+        let enumVals = [ "any" "spotify" "vlc" ];
+        in mkOption {
+          type = with types; nullOr (enum enumVals);
+          default = null;
+          example = "any";
+          description = "Preferred source for song information.";
+          apply = getIndexFromEnum enumVals;
+        };
       songText = {
         maximumWidth = mkOption {
           type = types.nullOr types.ints.unsigned;
@@ -39,10 +58,17 @@ in
           apply = builtins.toString;
         };
         scrolling = {
-          behavior = mkEnumOption [ "alwaysScroll" "scrollOnHover" "alwaysScrollExceptOnHover" ] // {
-            example = "alwaysScroll";
-            description = "Scrolling behavior of the song text.";
-          };
+          behavior =
+            let
+              enumVals = [ "alwaysScroll" "scrollOnHover" "alwaysScrollExceptOnHover" ];
+            in
+            mkOption {
+              type = with types; nullOr (enum enumVals);
+              default = null;
+              example = "alwaysScroll";
+              description = "Scrolling behavior of the song text.";
+              apply = getIndexFromEnum enumVals;
+            };
           speed = mkOption {
             type = types.nullOr (types.ints.between 1 10);
             default = null;
@@ -55,7 +81,7 @@ in
       };
       showPlaybackControls = mkBoolOption "Whether to show playback controls or not.";
     };
-    convert = 
+    convert =
       { panelIcon
       , preferredSource
       , songText

--- a/modules/widgets/system-monitor.nix
+++ b/modules/widgets/system-monitor.nix
@@ -1,7 +1,6 @@
-{ lib, widgets, ... }:
+{ lib, ... }:
 let
   inherit (lib) mkOption types;
-  inherit (widgets.lib) mkBoolOption;
 
   # KDE expects a key/value pair like this:
   # ```ini
@@ -60,7 +59,11 @@ in
         default = null;
         description = "The title of this system monitor.";
       };
-      showTitle = mkBoolOption "Show or hide the title.";
+      showTitle = mkOption {
+        type = with types; nullOr bool;
+        default = null;
+        description = "Show or hide the title.";
+      };
       displayStyle = mkOption {
         type = with types; nullOr str;
         default = null;
@@ -116,6 +119,18 @@ in
           The list of text-only sensors, displayed in the pop-up upon clicking the widget.
         '';
       };
+      range = {
+        from = mkOption {
+          type = with lib.types; nullOr (ints.between 0 100);
+          default = null;
+          description = "The lower range the sensors can take.";
+        };
+        to = mkOption {
+          type = with lib.types; nullOr (ints.between 0 100);
+          default = null;
+          description = "The upper range the sensors can take.";
+        };
+      };
     };
 
     convert =
@@ -125,21 +140,28 @@ in
       , totalSensors
       , sensors
       , textOnlySensors
+      , range
       }: {
         name = "org.kde.plasma.systemmonitor";
-        config = lib.filterAttrsRecursive (_: v: v != null) (lib.recursiveUpdate
-          {
-            Appearance = {
-              inherit title;
-              inherit showTitle;
-              chartFace = displayStyle;
-            };
-            Sensors = {
-              lowPrioritySensorIds = textOnlySensors;
-              totalSensors = totalSensors;
-            };
-          }
-          sensors);
+        config = lib.filterAttrsRecursive (_: v: v != null)
+          (lib.recursiveUpdate
+            ({
+              Appearance = {
+                inherit title;
+                inherit showTitle;
+                chartFace = displayStyle;
+              };
+              Sensors = {
+                lowPrioritySensorIds = textOnlySensors;
+                totalSensors = totalSensors;
+              };
+              "org.kde.ksysguard.piechart/General" = {
+                rangeAuto = (range.from == null && range.to == null);
+                rangeFrom = range.from;
+                rangeTo = range.to;
+              };
+            })
+            sensors);
       };
   };
 }

--- a/modules/widgets/system-tray.nix
+++ b/modules/widgets/system-tray.nix
@@ -34,9 +34,9 @@ in
               (if (spacing == null) then null
               else
                 (if builtins.isInt spacing then
-                  toString spacing
+                  spacing
                 else
-                  builtins.elemAt [ "1" "2" "6" ] (
+                  builtins.elemAt [ 1 2 6 ] (
                     lib.lists.findFirstIndex
                       (x: x == spacing)
                       (throw "systemTray: nonexistent spacing ${spacing}! This is a bug!")

--- a/modules/widgets/system-tray.nix
+++ b/modules/widgets/system-tray.nix
@@ -1,7 +1,12 @@
 { lib, widgets, ... }:
 let
   inherit (lib) mkOption types;
-  inherit (widgets.lib) mkBoolOption;
+
+  mkBoolOption = description: mkOption {
+    type = with types; nullOr bool;
+    default = null;
+    inherit description;
+  };
 in
 {
   systemTray = {

--- a/modules/window-rules.nix
+++ b/modules/window-rules.nix
@@ -1,10 +1,9 @@
 { lib
-, pkgs
 , config
 , ...
 }:
 with lib.types; let
-  inherit (builtins) length listToAttrs foldl' toString attrNames getAttr hasAttr concatStringsSep add isAttrs;
+  inherit (builtins) length listToAttrs foldl' toString attrNames getAttr concatStringsSep add isAttrs;
   inherit (lib) mkOption mkIf;
   inherit (lib.trivial) mergeAttrs;
   inherit (lib.lists) imap0;


### PR DESCRIPTION
Allows setting for example:
```nix
{
  name = "org.kde.plasma.kickerdash";
  config.General.someval = 8;
}
```
in widgets, where we before the value had to be `"8"`. Same support is also added for bools and floats. Also refactored the widgets massively as the special types aren't needed anymore after this. Most of the pr consists of refactors as such.

Also adds `range` attributes to the system-monitor widget, so it should close #247.
Probably will need some more testing since it is a big pr, so if anyone have any time to test and see if everything works and report whether they run into any problems or not that would be great as I can merge quicker then.
