### PR TITLE
Add more options for panel.screen

### DIFF
--- a/lib/panel.nix
+++ b/lib/panel.nix
@@ -4,7 +4,7 @@ let
   panelToLayout = panel:
     let
       inherit (widgets.lib) addWidgetStmts stringIfNotNull;
-      inherit (lib) boolToString optionalString;
+      inherit (lib) boolToString;
       inherit (builtins) toString;
 
       plasma6OnlyCmd = cmd: ''
@@ -14,6 +14,9 @@ let
       '';
     in
     ''
+      ${if (panel.screen == "all") then "for (screenID = 0; screenID < screenCount; screenID++)"
+        else if (builtins.isList panel.screen) then "for (var screenID in [${builtins.concatStringsSep "," (map builtins.toString panel.screen)}])"
+        else ""}
       {
         const panel = new Panel();
         panel.height = ${toString panel.height};
@@ -25,7 +28,7 @@ let
         ${stringIfNotNull panel.maxLength "panel.maximumLength = ${toString panel.maxLength};"}
         ${stringIfNotNull panel.minLength "panel.minimumLength = ${toString panel.minLength};"}
         ${stringIfNotNull panel.offset "panel.offset = ${toString panel.offset};"}
-        ${stringIfNotNull panel.screen ''panel.writeConfig("lastScreen[$i]", ${toString panel.screen});''}
+        ${stringIfNotNull panel.screen ''panel.writeConfig("lastScreen[$i]", ${if ((panel.screen == "all") || (builtins.isList panel.screen)) then "screenID" else toString panel.screen});''}
 
         ${addWidgetStmts "panel" "panelWidgets" panel.widgets}
         ${stringIfNotNull panel.extraSettings panel.extraSettings}

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -104,9 +104,14 @@ let
         apply = map widgets.convert;
       };
       screen = lib.mkOption {
-        type = with lib.types; nullOr int;
+        type = with lib.types; nullOr (oneOf [ ints.unsigned (listOf ints.unsigned) (enum [ "all" ]) ]);
         default = null;
-        description = "The screen the panel should appear on";
+        description = ''
+          The screen the panel should appear on. Can be an int, or a list of ints,
+          starting from 0, representing the ID of the screen the panel should
+          appear on. Alternatively it can be set to "any" if the panel should
+          appear on all the screens.
+        '';
       };
       extraSettings = lib.mkOption {
         type = with lib.types; nullOr str;
@@ -133,7 +138,7 @@ in
 
   options.programs.plasma.extraWidgets = lib.mkOption {
     type = with lib.types; listOf (enum [ "application-title-bar" "plasmusic-toolbar" ]);
-    default = [];
+    default = [ ];
     example = [ "application-title-bar" ];
     description = ''
       Additional third-party widgets to be installed, that can be included in the panels.
@@ -145,7 +150,7 @@ in
   # panels in the panels-script also has a tendency to reset the wallpaper, so
   # these should run at the same time.
   config = (lib.mkIf cfg.enable {
-    home.packages = with pkgs; []
+    home.packages = with pkgs; [ ]
       ++ lib.optionals (lib.elem "application-title-bar" cfg.extraWidgets || hasWidget "com.github.antroids.application-title-bar") [ application-title-bar ]
       ++ lib.optionals (lib.elem "plasmusic-toolbar" cfg.extraWidgets || hasWidget "plasmusic-toolbar") [ plasmusic-toolbar ];
 


### PR DESCRIPTION
Closes #258. Also adds the possibility of specifying multiple screens each panel should appear on through a list.

On a side-note I have found out that specifying the `screen` attribute for panels works much better (quicker) when running on an SSD, but was quite slow when running on an hdd. On an SSD it is quite a good experience nowadays :)