### PR TITLE
Refactor panels and add showLegend option for systemMonitor widget

### DIFF
--- a/examples/home.nix
+++ b/examples/home.nix
@@ -4,7 +4,6 @@
 
   programs.plasma = {
     enable = true;
-    extraWidgets = [ "application-title-bar" "plasmusic-toolbar" ];
 
     #
     # Some high-level settings:

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -7,6 +7,31 @@ let
   cfg = config.programs.plasma;
   hasWidget = widgetName: builtins.any (panel: builtins.any (widget: widget.name == widgetName) panel.widgets) cfg.panels;
 
+  # An attrset keeping track of the packages which should be added when a
+  # widget is present in the config.
+  additionalWidgetPackages = with pkgs; {
+    "com.github.antroids.application-title-bar" = [ application-title-bar ];
+    plasmusic-toolbar = [ plasmusic-toolbar ];
+  };
+  # An attrset of service-names and widgets/conditions. If any of the
+  # conditions (given in cond) evaluate to true for any of the widgets with the
+  # name given in the widget attribute, the service is marked for restart in
+  # the panel-script.
+  serviceRestarts = {
+    "plasma-plasmashell" = [
+      {
+        widget = "org.kde.plasma.systemmonitor";
+        cond = widget: ((builtins.hasAttr "org.kde.ksysguard.piechart/General" widget.config) && (builtins.hasAttr "showLegend" widget.config."org.kde.ksysguard.piechart/General"));
+      }
+    ];
+  };
+  widgetsOfName = name: (lib.filter (w: w.name == name) (lib.flatten (map (panel: panel.widgets) cfg.panels)));
+  shouldRestart = service:
+    (
+      let candidates = serviceRestarts."${service}";
+      in (builtins.any (x: x) (map (v: (builtins.any v.cond (widgetsOfName v.widget))) candidates))
+    );
+
   widgets = import ./widgets args;
 
   panelType = lib.types.submodule ({ config, ... }: {
@@ -131,28 +156,23 @@ let
     ((builtins.length cfg.panels) > 0));
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [ "programs" "plasma" "extraWidgets" ] "Place the widget packages in home.packages or environment.systemPackages instead.")
+  ];
+
   options.programs.plasma.panels = lib.mkOption {
     type = lib.types.listOf panelType;
     default = [ ];
-  };
-
-  options.programs.plasma.extraWidgets = lib.mkOption {
-    type = with lib.types; listOf (enum [ "application-title-bar" "plasmusic-toolbar" ]);
-    default = [ ];
-    example = [ "application-title-bar" ];
-    description = ''
-      Additional third-party widgets to be installed, that can be included in the panels.
-      The names of the supported third-party widget packages can be found in the share/plasma/plasmoids folder of the corresponding Nix package.
-    '';
   };
 
   # Wallpaper and panels are in the same script since the resetting of the
   # panels in the panels-script also has a tendency to reset the wallpaper, so
   # these should run at the same time.
   config = (lib.mkIf cfg.enable {
-    home.packages = with pkgs; [ ]
-      ++ lib.optionals (lib.elem "application-title-bar" cfg.extraWidgets || hasWidget "com.github.antroids.application-title-bar") [ application-title-bar ]
-      ++ lib.optionals (lib.elem "plasmusic-toolbar" cfg.extraWidgets || hasWidget "plasmusic-toolbar") [ plasmusic-toolbar ];
+    home.packages = (lib.flatten (lib.filter (x: x != null)
+      (lib.mapAttrsToList
+        (widgetName: packages: if (hasWidget widgetName) then packages else null)
+        additionalWidgetPackages)));
 
     programs.plasma.startup.desktopScript."panels_and_wallpaper" = (lib.mkIf anyPanelOrWallpaperSet
       (
@@ -217,10 +237,11 @@ in
           preCommands = panelPreCMD;
           text = panelLayoutStr + wallpaperDesktopScript + wallpaperSlideShow + wallpaperPOTD + wallpaperPlainColor;
           postCommands = panelPostCMD + wallpaperPostCMD;
-          restartServices = (if anyNonDefaultScreens then [ "plasma-plasmashell" ] else [ ]);
+          restartServices =
+            (lib.unique (if anyNonDefaultScreens then [ "plasma-plasmashell" ] else [ ])
+              ++ (lib.filter (service: shouldRestart service) (builtins.attrNames serviceRestarts)));
           priority = 2;
         }
       ));
   });
 }
-

--- a/modules/widgets/system-monitor.nix
+++ b/modules/widgets/system-monitor.nix
@@ -64,6 +64,11 @@ in
         default = null;
         description = "Show or hide the title.";
       };
+      showLegend = mkOption {
+        type = with types; nullOr bool;
+        default = null;
+        description = "Show or hide the legend.";
+      };
       displayStyle = mkOption {
         type = with types; nullOr str;
         default = null;
@@ -136,6 +141,7 @@ in
     convert =
       { title
       , showTitle
+      , showLegend
       , displayStyle
       , totalSensors
       , sensors
@@ -156,6 +162,7 @@ in
                 totalSensors = totalSensors;
               };
               "org.kde.ksysguard.piechart/General" = {
+                inherit showLegend;
                 rangeAuto = (range.from == null && range.to == null);
                 rangeFrom = range.from;
                 rangeTo = range.to;


### PR DESCRIPTION
Adds for panels a more extensible interface for adding custom widget packages by adding them into the `additionalWidgetPackages` attrset in `panels.nix`. Also adds the possibility of restarting certain services when certain widget configurations are present in some panel, namely by adding the appropriate `servicename = [{ "widget" = ...; cond = ...;  }]` in `serviceRestarts`, also in `panels.nix`. This way, if `cond` evaluates to `true` for any of the widgets with the name given in the widget attribute, the service this is placed under will be restarted after all the startup-scripts have run. This is a list so it is possible to add multiple tests.

I used this to restart `plasmashell` in the cases where `showLegend` is set in the systemmonitor widget, which for some reason is needed for it to correctly apply. As such this closes #196.

During refactoring, I also removed `programs.plasma.extraWidgets` as I didn't really see a use for it which couldn't be satisfied by just adding the widget packages to `home.packages` or `environment.systemPackages` manually. Imo the widgets can be automatically installed if the widget is in a panel, and I think that beyond this `extraWidgets` doesn't really make much sense (it only really makes sense if you plan on adding a widget which you configure via the GUI, but in that case I reckon installing it manually through nix is more than adequate). I don't know if there are other views on this though @HeitorAugustoLN.