### PR TITLE
Add settings option for all widget-specific options

### DIFF
--- a/modules/widgets/application-title-bar.nix
+++ b/modules/widgets/application-title-bar.nix
@@ -437,7 +437,7 @@ in
           titleReplacementsTypes = map (r: r.type) replacements;
         };
       };
-      extraConfig = mkOption {
+      settings = mkOption {
         type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
         default = null;
         example = {
@@ -450,7 +450,7 @@ in
 
           See available options at https://github.com/antroids/application-title-bar/blob/main/package/contents/config/main.xml
         '';
-        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+        apply = settings: if settings == null then {} else settings;
       };
     };
     convert =
@@ -463,7 +463,7 @@ in
       , mouseAreaClick
       , mouseAreaWheel
       , titleReplacements
-      , extraConfig
+      , settings
       }: {
         name = "com.github.antroids.application-title-bar";
         config = lib.recursiveUpdate {
@@ -537,7 +537,7 @@ in
             }
           );
           TitleReplacements = titleReplacements;
-        } extraConfig;
+        } settings;
       };
   };
 }

--- a/modules/widgets/application-title-bar.nix
+++ b/modules/widgets/application-title-bar.nix
@@ -437,6 +437,21 @@ in
           titleReplacementsTypes = map (r: r.type) replacements;
         };
       };
+      extraConfig = mkOption {
+        type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        default = null;
+        example = {
+          General = {
+            launchers = [ "applications:org.kde.dolphin.desktop" "applications:org.kde.konsole.desktop" ];
+          };
+        };
+        description = ''
+          Extra configuration for the widget
+
+          See available options at https://github.com/antroids/application-title-bar/blob/main/package/contents/config/main.xml
+        '';
+        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+      };
     };
     convert =
       { layout
@@ -448,6 +463,7 @@ in
       , mouseAreaClick
       , mouseAreaWheel
       , titleReplacements
+      , extraConfig
       }: {
         name = "com.github.antroids.application-title-bar";
         config = {
@@ -521,7 +537,7 @@ in
             }
           );
           TitleReplacements = titleReplacements;
-        };
+        } // extraConfig;
       };
   };
 }

--- a/modules/widgets/application-title-bar.nix
+++ b/modules/widgets/application-title-bar.nix
@@ -466,7 +466,7 @@ in
       , extraConfig
       }: {
         name = "com.github.antroids.application-title-bar";
-        config = {
+        config = lib.recursiveUpdate {
           Appearance = lib.filterAttrs (_: v: v != null) (
             {
               # Widget layout
@@ -537,7 +537,7 @@ in
             }
           );
           TitleReplacements = titleReplacements;
-        } // extraConfig;
+        } extraConfig;
       };
   };
 }

--- a/modules/widgets/application-title-bar.nix
+++ b/modules/widgets/application-title-bar.nix
@@ -441,8 +441,8 @@ in
         type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
         default = null;
         example = {
-          General = {
-            launchers = [ "applications:org.kde.dolphin.desktop" "applications:org.kde.konsole.desktop" ];
+          Appearance = {
+            windowTitleUndefined = "Plasma";
           };
         };
         description = ''

--- a/modules/widgets/battery.nix
+++ b/modules/widgets/battery.nix
@@ -24,11 +24,11 @@
 
     convert = { showPercentage, extraConfig }: {
       name = "org.kde.plasma.battery";
-      config = {
+      config = lib.recursiveUpdate {
         General = lib.filterAttrs (_: v: v != null) {
           inherit showPercentage;
         };
-      } // extraConfig;
+      } extraConfig;
     };
   };
 }

--- a/modules/widgets/battery.nix
+++ b/modules/widgets/battery.nix
@@ -3,18 +3,32 @@
     description = "The battery indicator widget.";
 
     # See https://invent.kde.org/plasma/plasma-workspace/-/blob/master/applets/batterymonitor/package/contents/config/main.xml for the accepted raw options
-    opts.showPercentage = lib.mkOption {
-      type = with lib.types; nullOr bool;
-      default = null;
-      example = true;
-      description = "Enable to show the battery percentage as a small label over the battery icon.";
+    opts = {
+      showPercentage = lib.mkOption {
+        type = with lib.types; nullOr bool;
+        default = null;
+        example = true;
+        description = "Enable to show the battery percentage as a small label over the battery icon.";
+      };
+      extraConfig = lib.mkOption {
+        type = with lib.types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        default = null;
+        example = {
+          General = {
+            showPercentage = true;
+          };
+        };
+        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+      };
     };
 
-    convert = { showPercentage }: {
+    convert = { showPercentage, extraConfig }: {
       name = "org.kde.plasma.battery";
-      config.General = lib.filterAttrs (_: v: v != null) {
-        inherit showPercentage;
-      };
+      config = {
+        General = lib.filterAttrs (_: v: v != null) {
+          inherit showPercentage;
+        };
+      } // extraConfig;
     };
   };
 }

--- a/modules/widgets/battery.nix
+++ b/modules/widgets/battery.nix
@@ -10,7 +10,7 @@
         example = true;
         description = "Enable to show the battery percentage as a small label over the battery icon.";
       };
-      extraConfig = lib.mkOption {
+      settings = lib.mkOption {
         type = with lib.types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
         default = null;
         example = {
@@ -18,17 +18,17 @@
             showPercentage = true;
           };
         };
-        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+        apply = settings: if settings == null then {} else settings;
       };
     };
 
-    convert = { showPercentage, extraConfig }: {
+    convert = { showPercentage, settings }: {
       name = "org.kde.plasma.battery";
       config = lib.recursiveUpdate {
         General = lib.filterAttrs (_: v: v != null) {
           inherit showPercentage;
         };
-      } extraConfig;
+      } settings;
     };
   };
 }

--- a/modules/widgets/digital-clock.nix
+++ b/modules/widgets/digital-clock.nix
@@ -219,7 +219,7 @@ in
             fontSize = font.size;
           };
       };
-      extraConfig = mkOption {
+      settings = mkOption {
         type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
         default = null;
         example = {
@@ -232,7 +232,7 @@ in
 
           See https://develop.kde.org/docs/plasma/scripting/keys/ for an list of options
         '';
-        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+        apply = settings: if settings == null then {} else settings;
       };
     };
 
@@ -242,7 +242,7 @@ in
       , timeZone
       , calendar
       , font
-      , extraConfig
+      , settings
       }: {
         name = "org.kde.plasma.digitalclock";
         config = lib.recursiveUpdate {
@@ -267,7 +267,7 @@ in
             // date.format
             // font
           );
-        } extraConfig;
+        } settings;
       };
   };
 }

--- a/modules/widgets/digital-clock.nix
+++ b/modules/widgets/digital-clock.nix
@@ -219,6 +219,21 @@ in
             fontSize = font.size;
           };
       };
+      extraConfig = mkOption {
+        type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        default = null;
+        example = {
+          Appearance = {
+            showDate = true;
+          };
+        };
+        description = ''
+          Extra configuration options for the widget.
+
+          See https://develop.kde.org/docs/plasma/scripting/keys/ for an list of options
+        '';
+        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+      };
     };
 
     convert =
@@ -227,29 +242,32 @@ in
       , timeZone
       , calendar
       , font
+      , extraConfig
       }: {
         name = "org.kde.plasma.digitalclock";
-        config.Appearance = lib.filterAttrs (_: v: v != null) (
-          {
-            showDate = date.enable;
-            dateDisplayFormat = date.position;
+        config = {
+          Appearance = lib.filterAttrs (_: v: v != null) (
+            {
+              showDate = date.enable;
+              dateDisplayFormat = date.position;
 
-            showSeconds = time.showSeconds;
-            use24hFormat = time.format;
+              showSeconds = time.showSeconds;
+              use24hFormat = time.format;
 
-            selectedTimeZones = timeZone.selected;
-            lastSelectedTimezone = timeZone.lastSelected;
-            wheelChangesTimezone = timeZone.changeOnScroll;
-            displayTimezoneFormat = timeZone.format;
-            showLocalTimezone = timeZone.alwaysShow;
+              selectedTimeZones = timeZone.selected;
+              lastSelectedTimezone = timeZone.lastSelected;
+              wheelChangesTimezone = timeZone.changeOnScroll;
+              displayTimezoneFormat = timeZone.format;
+              showLocalTimezone = timeZone.alwaysShow;
 
-            firstDayOfWeek = calendar.firstDayOfWeek;
-            enabledCalendarPlugins = calendar.plugins;
-            showWeekNumbers = calendar.showWeekNumbers;
-          }
-          // date.format
-          // font
-        );
+              firstDayOfWeek = calendar.firstDayOfWeek;
+              enabledCalendarPlugins = calendar.plugins;
+              showWeekNumbers = calendar.showWeekNumbers;
+            }
+            // date.format
+            // font
+          );
+        } // extraConfig;
       };
   };
 }

--- a/modules/widgets/digital-clock.nix
+++ b/modules/widgets/digital-clock.nix
@@ -245,7 +245,7 @@ in
       , extraConfig
       }: {
         name = "org.kde.plasma.digitalclock";
-        config = {
+        config = lib.recursiveUpdate {
           Appearance = lib.filterAttrs (_: v: v != null) (
             {
               showDate = date.enable;
@@ -267,7 +267,7 @@ in
             // date.format
             // font
           );
-        } // extraConfig;
+        } extraConfig;
       };
   };
 }

--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -132,7 +132,7 @@ in
           apply = positionToReverse;
         };
       };
-      extraConfig = mkOption {
+      settings = mkOption {
         type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
         default = null;
         example = {
@@ -141,14 +141,14 @@ in
           };
         };
         description = "Extra configuration options for the widget.";
-        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+        apply = settings: if settings == null then {} else settings;
       };
     };
     convert =
       { appearance
       , behavior
       , launchers
-      , extraConfig
+      , settings
       }: {
         name = "org.kde.plasma.icontasks";
         config = lib.recursiveUpdate {
@@ -186,7 +186,7 @@ in
               reverseMode = behavior.newTasksAppearOn;
             }
           );
-        } extraConfig;
+        } settings;
       };
   };
 }

--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -151,7 +151,7 @@ in
       , extraConfig
       }: {
         name = "org.kde.plasma.icontasks";
-        config = {
+        config = lib.recursiveUpdate {
           General = lib.filterAttrs (_: v: v != null) (
             {
               launchers = launchers;
@@ -186,7 +186,7 @@ in
               reverseMode = behavior.newTasksAppearOn;
             }
           );
-        } // extraConfig;
+        } extraConfig;
       };
   };
 }

--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -132,47 +132,61 @@ in
           apply = positionToReverse;
         };
       };
+      extraConfig = mkOption {
+        type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        default = null;
+        example = {
+          General = {
+            launchers = [ "applications:org.kde.dolphin.desktop" "applications:org.kde.konsole.desktop" ];
+          };
+        };
+        description = "Extra configuration options for the widget.";
+        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+      };
     };
     convert =
       { appearance
       , behavior
       , launchers
+      , extraConfig
       }: {
         name = "org.kde.plasma.icontasks";
-        config.General = lib.filterAttrs (_: v: v != null) (
-          {
-            launchers = launchers;
+        config = {
+          General = lib.filterAttrs (_: v: v != null) (
+            {
+              launchers = launchers;
 
-            # Appearance
-            showToolTips = appearance.showTooltips;
-            highlightWindows = appearance.highlightWindows;
-            indicateAudioStreams = appearance.indicateAudioStreams;
-            fill = appearance.fill;
+              # Appearance
+              showToolTips = appearance.showTooltips;
+              highlightWindows = appearance.highlightWindows;
+              indicateAudioStreams = appearance.indicateAudioStreams;
+              fill = appearance.fill;
 
-            forceStripes = appearance.rows.multirowView;
-            maxStripes = appearance.rows.maximum;
+              forceStripes = appearance.rows.multirowView;
+              maxStripes = appearance.rows.maximum;
 
-            iconSpacing = appearance.iconSpacing;
+              iconSpacing = appearance.iconSpacing;
 
-            # Behavior
-            groupingStrategy = behavior.grouping.method;
-            groupedTaskVisualization = behavior.grouping.clickAction;
-            sortingStrategy = behavior.sortingMethod;
-            minimizeActiveTaskOnClick = behavior.minimizeActiveTaskOnClick;
-            middleClickAction = behavior.middleClickAction;
+              # Behavior
+              groupingStrategy = behavior.grouping.method;
+              groupedTaskVisualization = behavior.grouping.clickAction;
+              sortingStrategy = behavior.sortingMethod;
+              minimizeActiveTaskOnClick = behavior.minimizeActiveTaskOnClick;
+              middleClickAction = behavior.middleClickAction;
 
-            wheelEnabled = behavior.wheel.switchBetweenTasks;
-            wheelSkipMinimized = behavior.wheel.ignoreMinimizedTasks;
+              wheelEnabled = behavior.wheel.switchBetweenTasks;
+              wheelSkipMinimized = behavior.wheel.ignoreMinimizedTasks;
 
-            showOnlyCurrentScreen = behavior.showTasks.onlyInCurrentScreen;
-            showOnlyCurrentDesktop = behavior.showTasks.onlyInCurrentDesktop;
-            showOnlyCurrentActivity = behavior.showTasks.onlyInCurrentActivity;
-            showOnlyMinimized = behavior.showTasks.onlyMinimized;
+              showOnlyCurrentScreen = behavior.showTasks.onlyInCurrentScreen;
+              showOnlyCurrentDesktop = behavior.showTasks.onlyInCurrentDesktop;
+              showOnlyCurrentActivity = behavior.showTasks.onlyInCurrentActivity;
+              showOnlyMinimized = behavior.showTasks.onlyMinimized;
 
-            unhideOnAttention = behavior.unhideOnAttentionNeeded;
-            reverseMode = behavior.newTasksAppearOn;
-          }
-        );
+              unhideOnAttention = behavior.unhideOnAttentionNeeded;
+              reverseMode = behavior.newTasksAppearOn;
+            }
+          );
+        } // extraConfig;
       };
   };
 }

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -78,6 +78,17 @@ in
         };
       showActionButtonCaptions = mkBoolOption "Whether to display captions ('shut down', 'log out', etc.) for the footer action buttons";
       pin = mkBoolOption "Whether the popup should remain open when another window is activated.";
+      extraConfig = mkOption {
+        type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        default = null;
+        example = {
+          General = {
+            icon = "nix-snowflake-white";
+          };
+        };
+        description = "Extra configuration options for the widget.";
+        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+      };
     };
     convert =
       { icon
@@ -90,24 +101,27 @@ in
       , showButtonsFor
       , showActionButtonCaptions
       , pin
+      , extraConfig
       }: {
         name = "org.kde.plasma.kickoff";
-        config.General = lib.filterAttrs (_: v: v != null) (
-          {
-            icon = icon;
-            menuLabel = label;
-            alphaSort = sortAlphabetically;
-            compactMode = compactDisplayStyle;
-            paneSwap = sidebarPosition;
-            favoritesDisplay = favoritesDisplayMode;
-            applicationsDisplay = applicationsDisplayMode;
-            primaryActions = showButtonsFor;
-            showActionButtonCaptions = showActionButtonCaptions;
+        config = {
+          General = lib.filterAttrs (_: v: v != null) (
+            {
+              icon = icon;
+              menuLabel = label;
+              alphaSort = sortAlphabetically;
+              compactMode = compactDisplayStyle;
+              paneSwap = sidebarPosition;
+              favoritesDisplay = favoritesDisplayMode;
+              applicationsDisplay = applicationsDisplayMode;
+              primaryActions = showButtonsFor;
+              showActionButtonCaptions = showActionButtonCaptions;
 
-            # Other useful options
-            pin = pin;
-          }
-        );
+              # Other useful options
+              pin = pin;
+            }
+          );
+        } // extraConfig;
       };
   };
 }

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -104,7 +104,7 @@ in
       , extraConfig
       }: {
         name = "org.kde.plasma.kickoff";
-        config = {
+        config = lib.recursiveUpdate {
           General = lib.filterAttrs (_: v: v != null) (
             {
               icon = icon;
@@ -121,7 +121,7 @@ in
               pin = pin;
             }
           );
-        } // extraConfig;
+        } extraConfig;
       };
   };
 }

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -78,7 +78,7 @@ in
         };
       showActionButtonCaptions = mkBoolOption "Whether to display captions ('shut down', 'log out', etc.) for the footer action buttons";
       pin = mkBoolOption "Whether the popup should remain open when another window is activated.";
-      extraConfig = mkOption {
+      settings = mkOption {
         type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
         default = null;
         example = {
@@ -87,7 +87,7 @@ in
           };
         };
         description = "Extra configuration options for the widget.";
-        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+        apply = settings: if settings == null then {} else settings;
       };
     };
     convert =
@@ -101,7 +101,7 @@ in
       , showButtonsFor
       , showActionButtonCaptions
       , pin
-      , extraConfig
+      , settings
       }: {
         name = "org.kde.plasma.kickoff";
         config = lib.recursiveUpdate {
@@ -121,7 +121,7 @@ in
               pin = pin;
             }
           );
-        } extraConfig;
+        } settings;
       };
   };
 }

--- a/modules/widgets/plasmusic-toolbar.nix
+++ b/modules/widgets/plasmusic-toolbar.nix
@@ -77,30 +77,48 @@ in
         displayInSeparateLines = mkBoolOption "Whether to display song information (title and artist) in separate lines or not.";
       };
       showPlaybackControls = mkBoolOption "Whether to show playback controls or not.";
+      extraConfig = mkOption {
+        type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        default = null;
+        example = {
+          General = {
+            useCustomFont = true;
+          };
+        };
+        description = ''
+          Extra configuration for the widget options.
+          
+          See available options at https://github.com/ccatterina/plasmusic-toolbar/blob/main/src/contents/config/main.xml
+        '';
+        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+      };
     };
     convert =
       { panelIcon
       , preferredSource
       , songText
       , showPlaybackControls
+      , extraConfig
       }: {
         name = "plasmusic-toolbar";
-        config.General = lib.filterAttrs (_: v: v != null) (
-          {
-            panelIcon = panelIcon.icon;
-            useAlbumCoverAsPanelIcon = panelIcon.albumCover.useAsIcon;
-            albumCoverRadius = panelIcon.albumCover.radius;
+        config = {
+          General = lib.filterAttrs (_: v: v != null) (
+            {
+              panelIcon = panelIcon.icon;
+              useAlbumCoverAsPanelIcon = panelIcon.albumCover.useAsIcon;
+              albumCoverRadius = panelIcon.albumCover.radius;
 
-            sourceIndex = preferredSource;
+              sourceIndex = preferredSource;
 
-            maxSongWidthInPanel = songText.maximumWidth;
-            textScrollingSpeed = songText.scrolling.speed;
-            separateText = songText.displayInSeparateLines;
-            textScrollingBehaviour = songText.scrolling.behavior;
+              maxSongWidthInPanel = songText.maximumWidth;
+              textScrollingSpeed = songText.scrolling.speed;
+              separateText = songText.displayInSeparateLines;
+              textScrollingBehaviour = songText.scrolling.behavior;
 
-            commandsInPanel = showPlaybackControls;
-          }
-        );
+              commandsInPanel = showPlaybackControls;
+            }
+          );
+        } // extraConfig;
       };
   };
 }

--- a/modules/widgets/plasmusic-toolbar.nix
+++ b/modules/widgets/plasmusic-toolbar.nix
@@ -101,7 +101,7 @@ in
       , extraConfig
       }: {
         name = "plasmusic-toolbar";
-        config = {
+        config = lib.recursiveUpdate {
           General = lib.filterAttrs (_: v: v != null) (
             {
               panelIcon = panelIcon.icon;
@@ -118,7 +118,7 @@ in
               commandsInPanel = showPlaybackControls;
             }
           );
-        } // extraConfig;
+        } extraConfig;
       };
   };
 }

--- a/modules/widgets/plasmusic-toolbar.nix
+++ b/modules/widgets/plasmusic-toolbar.nix
@@ -77,7 +77,7 @@ in
         displayInSeparateLines = mkBoolOption "Whether to display song information (title and artist) in separate lines or not.";
       };
       showPlaybackControls = mkBoolOption "Whether to show playback controls or not.";
-      extraConfig = mkOption {
+      settings = mkOption {
         type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
         default = null;
         example = {
@@ -90,7 +90,7 @@ in
           
           See available options at https://github.com/ccatterina/plasmusic-toolbar/blob/main/src/contents/config/main.xml
         '';
-        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+        apply = settings: if settings == null then {} else settings;
       };
     };
     convert =
@@ -98,7 +98,7 @@ in
       , preferredSource
       , songText
       , showPlaybackControls
-      , extraConfig
+      , settings
       }: {
         name = "plasmusic-toolbar";
         config = lib.recursiveUpdate {
@@ -118,7 +118,7 @@ in
               commandsInPanel = showPlaybackControls;
             }
           );
-        } extraConfig;
+        } settings;
       };
   };
 }

--- a/modules/widgets/system-monitor.nix
+++ b/modules/widgets/system-monitor.nix
@@ -158,26 +158,24 @@ in
         name = "org.kde.plasma.systemmonitor";
         config = lib.filterAttrsRecursive (_: v: v != null)
           (lib.recursiveUpdate
-            (lib.recursiveUpdate
-              ({
-                Appearance = {
-                  inherit title;
-                  inherit showTitle;
-                  chartFace = displayStyle;
-                };
-                Sensors = {
-                  lowPrioritySensorIds = textOnlySensors;
-                  totalSensors = totalSensors;
-                };
-                "org.kde.ksysguard.piechart/General" = {
-                  inherit showLegend;
-                  rangeAuto = (range.from == null && range.to == null);
-                  rangeFrom = range.from;
-                  rangeTo = range.to;
-                };
-              })
-              sensors)
-            settings);
+            ({
+              Appearance = {
+                inherit title;
+                inherit showTitle;
+                chartFace = displayStyle;
+              };
+              Sensors = {
+                lowPrioritySensorIds = textOnlySensors;
+                totalSensors = totalSensors;
+              };
+              "org.kde.ksysguard.piechart/General" = {
+                inherit showLegend;
+                rangeAuto = (range.from == null && range.to == null);
+                rangeFrom = range.from;
+                rangeTo = range.to;
+              };
+            })
+            (lib.recursiveUpdate sensors settings);
       };
   };
 }

--- a/modules/widgets/system-monitor.nix
+++ b/modules/widgets/system-monitor.nix
@@ -158,24 +158,26 @@ in
         name = "org.kde.plasma.systemmonitor";
         config = lib.filterAttrsRecursive (_: v: v != null)
           (lib.recursiveUpdate
-            ({
-              Appearance = {
-                inherit title;
-                inherit showTitle;
-                chartFace = displayStyle;
-              };
-              Sensors = {
-                lowPrioritySensorIds = textOnlySensors;
-                totalSensors = totalSensors;
-              };
-              "org.kde.ksysguard.piechart/General" = {
-                inherit showLegend;
-                rangeAuto = (range.from == null && range.to == null);
-                rangeFrom = range.from;
-                rangeTo = range.to;
-              };
-            } // extraConfig)
-            sensors);
+            (lib.recursiveUpdate
+              ({
+                Appearance = {
+                  inherit title;
+                  inherit showTitle;
+                  chartFace = displayStyle;
+                };
+                Sensors = {
+                  lowPrioritySensorIds = textOnlySensors;
+                  totalSensors = totalSensors;
+                };
+                "org.kde.ksysguard.piechart/General" = {
+                  inherit showLegend;
+                  rangeAuto = (range.from == null && range.to == null);
+                  rangeFrom = range.from;
+                  rangeTo = range.to;
+                };
+              })
+              sensors);
+            extraConfig);
       };
   };
 }

--- a/modules/widgets/system-monitor.nix
+++ b/modules/widgets/system-monitor.nix
@@ -136,6 +136,12 @@ in
           description = "The upper range the sensors can take.";
         };
       };
+      extraConfig = mkOption {
+        type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        default = null;
+        description = "Extra configuration options for the widget.";
+        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+      };
     };
 
     convert =
@@ -147,6 +153,7 @@ in
       , sensors
       , textOnlySensors
       , range
+      , extraConfig
       }: {
         name = "org.kde.plasma.systemmonitor";
         config = lib.filterAttrsRecursive (_: v: v != null)
@@ -167,7 +174,7 @@ in
                 rangeFrom = range.from;
                 rangeTo = range.to;
               };
-            })
+            } // extraConfig)
             sensors);
       };
   };

--- a/modules/widgets/system-monitor.nix
+++ b/modules/widgets/system-monitor.nix
@@ -176,7 +176,7 @@ in
                   rangeTo = range.to;
                 };
               })
-              sensors);
+              sensors)
             settings);
       };
   };

--- a/modules/widgets/system-monitor.nix
+++ b/modules/widgets/system-monitor.nix
@@ -175,7 +175,7 @@ in
                 rangeTo = range.to;
               };
             })
-            (lib.recursiveUpdate sensors settings)
+            (lib.recursiveUpdate sensors settings));
       };
   };
 }

--- a/modules/widgets/system-monitor.nix
+++ b/modules/widgets/system-monitor.nix
@@ -175,7 +175,7 @@ in
                 rangeTo = range.to;
               };
             })
-            (lib.recursiveUpdate sensors settings);
+            (lib.recursiveUpdate sensors settings)
       };
   };
 }

--- a/modules/widgets/system-monitor.nix
+++ b/modules/widgets/system-monitor.nix
@@ -136,11 +136,11 @@ in
           description = "The upper range the sensors can take.";
         };
       };
-      extraConfig = mkOption {
+      settings = mkOption {
         type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
         default = null;
         description = "Extra configuration options for the widget.";
-        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+        apply = settings: if settings == null then {} else settings;
       };
     };
 
@@ -153,7 +153,7 @@ in
       , sensors
       , textOnlySensors
       , range
-      , extraConfig
+      , settings
       }: {
         name = "org.kde.plasma.systemmonitor";
         config = lib.filterAttrsRecursive (_: v: v != null)
@@ -177,7 +177,7 @@ in
                 };
               })
               sensors);
-            extraConfig);
+            settings);
       };
   };
 }

--- a/modules/widgets/system-tray.nix
+++ b/modules/widgets/system-tray.nix
@@ -166,7 +166,7 @@ in
       , settings
       }:
       let
-        settings = lib.recursiveUpdate {
+        sets = {
           General = lib.filterAttrs (_: v: v != null) {
             inherit pin;
             extraItems = items.extra;
@@ -177,7 +177,8 @@ in
             scaleIconsToFit = icons.scaleToFit;
             iconSpacing = icons.spacing;
           };
-        } settings;
+        };
+        mergedSettings = lib.recursiveUpdate sets settings;
       in
       {
         name = "org.kde.plasma.systemtray";
@@ -186,7 +187,7 @@ in
             const tray = desktopById(widget.readConfig("SystrayContainmentId"));
             if (!tray) return; // if somehow the containment doesn't exist
           
-            ${widgets.lib.setWidgetSettings "tray" settings}
+            ${widgets.lib.setWidgetSettings "tray" mergedSettings}
             ${widgets.lib.addWidgetStmts "tray" "trayWidgets" items.configs}
           }
         '';

--- a/modules/widgets/system-tray.nix
+++ b/modules/widgets/system-tray.nix
@@ -166,7 +166,7 @@ in
       , extraConfig
       }:
       let
-        settings = {
+        settings = lib.recursiveUpdate {
           General = lib.filterAttrs (_: v: v != null) {
             inherit pin;
             extraItems = items.extra;
@@ -177,7 +177,7 @@ in
             scaleIconsToFit = icons.scaleToFit;
             iconSpacing = icons.spacing;
           };
-        } // extraConfig;
+        } extraConfig;
       in
       {
         name = "org.kde.plasma.systemtray";

--- a/modules/widgets/system-tray.nix
+++ b/modules/widgets/system-tray.nix
@@ -151,11 +151,11 @@ in
             );
         };
       };
-      extraConfig = mkOption {
+      settings = mkOption {
         type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
         default = null;
         description = "Extra configuration options for the widget.";
-        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+        apply = settings: if settings == null then {} else settings;
       };
     });
 
@@ -163,7 +163,7 @@ in
       { pin
       , icons
       , items
-      , extraConfig
+      , settings
       }:
       let
         settings = lib.recursiveUpdate {
@@ -177,7 +177,7 @@ in
             scaleIconsToFit = icons.scaleToFit;
             iconSpacing = icons.spacing;
           };
-        } extraConfig;
+        } settings;
       in
       {
         name = "org.kde.plasma.systemtray";

--- a/modules/widgets/system-tray.nix
+++ b/modules/widgets/system-tray.nix
@@ -151,24 +151,33 @@ in
             );
         };
       };
+      extraConfig = mkOption {
+        type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        default = null;
+        description = "Extra configuration options for the widget.";
+        apply = extraConfig: if extraConfig == null then {} else extraConfig;
+      };
     });
 
     convert =
       { pin
       , icons
       , items
+      , extraConfig
       }:
       let
-        settings.General = lib.filterAttrs (_: v: v != null) {
-          inherit pin;
-          extraItems = items.extra;
-          hiddenItems = items.hidden;
-          shownItems = items.shown;
-          showAllItems = items.showAll;
+        settings = {
+          General = lib.filterAttrs (_: v: v != null) {
+            inherit pin;
+            extraItems = items.extra;
+            hiddenItems = items.hidden;
+            shownItems = items.shown;
+            showAllItems = items.showAll;
 
-          scaleIconsToFit = icons.scaleToFit;
-          iconSpacing = icons.spacing;
-        };
+            scaleIconsToFit = icons.scaleToFit;
+            iconSpacing = icons.spacing;
+          };
+        } // extraConfig;
       in
       {
         name = "org.kde.plasma.systemtray";


### PR DESCRIPTION
Could be useful for users that want to configure options that are not covered by the widget-specific options, but don't want to configure the entire widget manually.