### PR TITLE
Add powerdevil module

### DIFF
--- a/examples/home.nix
+++ b/examples/home.nix
@@ -212,6 +212,18 @@
       }
     ];
 
+    powerdevil = {
+      powerButtonAction = "lockScreen";
+      autoSuspend = {
+        action = "shutDown";
+        idleTimeout = 1000;
+      };
+      turnOffDisplay = {
+        idleTimeout = 1000;
+        idleTimeoutWhenLocked = "immediately";
+      };
+    };
+
 
     #
     # Some mid-level settings:

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -9,10 +9,10 @@
     ./kscreenlocker.nix
     ./kwin.nix
     ./panels.nix
+    ./powerdevil.nix
     ./shortcuts.nix
     ./spectacle.nix
     ./startup.nix
-    ./windows.nix
     ./window-rules.nix
     ./workspace.nix
   ];

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -57,6 +57,7 @@ let
     "plasmanotifyrc"
     "plasmarc"
     "plasmashellrc"
+    "powerdevilrc"
     "systemsettingsrc"
   ] else lib.optional (builtins.length plasmaCfg.window-rules > 0) "kwinrulesrc");
 in

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -100,8 +100,8 @@ in
         AutoSuspendIdleTimeoutSec = cfg.powerdevil.autoSuspend.idleTimeout;
       };
       "AC/Display" = {
-        TunOffDisplayIdleTimeoutSec = cfg.powerdevil.turnOffDisplay.idleTimeout;
-        TunOffDisplayIdleTimeoutWhenLockedSec = cfg.powerdevil.turnOffDisplay.idleTimeoutWhenLocked;
+        TurnOffDisplayIdleTimeoutSec = cfg.powerdevil.turnOffDisplay.idleTimeout;
+        TurnOffDisplayIdleTimeoutWhenLockedSec = cfg.powerdevil.turnOffDisplay.idleTimeoutWhenLocked;
       };
     };
   };

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -1,0 +1,108 @@
+{ config, lib, ... }:
+let
+  cfg = config.programs.plasma;
+
+  powerButtonActions = {
+    nothing = 0;
+    sleep = 1;
+    shutDown = 8;
+    lockScreen = 32;
+    showLogoutScreen = null;
+    turnOffScreen = 64;
+  };
+
+  autoSuspendActions = {
+    nothing = 0;
+    sleep = null;
+    shutDown = 8;
+  };
+in
+{
+  config.assertions = [
+    {
+      assertion = (cfg.powerdevil.autoSuspend.action != autoSuspendActions.nothing || cfg.powerdevil.autoSuspend.idleTimeout == null);
+      message = "Setting programs.plasma.powerdevil.autoSuspend.idleTimeout for autosuspend-action \"nothing\" is not supported.";
+    }
+    {
+      assertion = (cfg.powerdevil.turnOffDisplay.idleTimeout != -1 || cfg.powerdevil.turnOffDisplay.idleTimeoutWhenLocked == null);
+      message = "Setting programs.plasma.powerdevil.turnOffDisplay.idleTimeoutWhenLocked for when idleTimeout is \"never\" is not supported.";
+    }
+  ];
+
+  options = {
+    programs.plasma.powerdevil = {
+      powerButtonAction = lib.mkOption {
+        type = with lib.types; nullOr (enum (builtins.attrNames powerButtonActions));
+        default = null;
+        example = "nothing";
+        description = ''
+          The action to perform when the power button is pressed.
+        '';
+        apply = action: if (action == null) then null else powerButtonActions."${action}";
+      };
+      autoSuspend = {
+        action = lib.mkOption {
+          type = with lib.types; nullOr (enum (builtins.attrNames autoSuspendActions));
+          default = null;
+          example = "nothing";
+          description = ''
+            The action to perform after a certain period of inactivity.
+          '';
+          apply = action: if (action == null) then null else autoSuspendActions."${action}";
+        };
+        idleTimeout = lib.mkOption {
+          type = with lib.types; nullOr (ints.between 60 600000);
+          default = null;
+          example = 600;
+          description = ''
+            The duration (in seconds) the computer must be idle until the
+            auto-suspend action is executed.
+          '';
+        };
+      };
+      turnOffDisplay = {
+        idleTimeout = lib.mkOption {
+          type = with lib.types; nullOr (either (enum [ "never" ]) (ints.between 30 600000));
+          default = null;
+          example = 300;
+          description = ''
+            The duration (in seconds) the computer must be idle (when unlocked)
+            until the display turns off.
+          '';
+          apply = timeout:
+            if (timeout == null) then null else
+            if (timeout == "never") then -1
+            else timeout;
+        };
+        idleTimeoutWhenLocked = lib.mkOption {
+          type = with lib.types; nullOr (either (enum [ "whenLockedAndUnlocked" "immediately" ]) (ints.between 20 600000));
+          default = null;
+          example = 60;
+          description = ''
+            The duration (in seconds) the computer must be idle (when locked)
+            until the display turns off.
+          '';
+          apply = timeout:
+            if (timeout == null) then null else
+            if (timeout == "whenLockedAndUnlocked") then -2 else
+            if (timeout == "immediately") then 0
+            else timeout;
+        };
+      };
+    };
+  };
+
+  config.programs.plasma.configFile = lib.mkIf cfg.enable {
+    powerdevilrc = lib.filterAttrs (k: v: v != null) {
+      "AC/SuspendAndShutdown" = {
+        PowerButtonAction = cfg.powerdevil.powerButtonAction;
+        AutoSuspendAction = cfg.powerdevil.autoSuspend.action;
+        AutoSuspendIdleTimeoutSec = cfg.powerdevil.autoSuspend.idleTimeout;
+      };
+      "AC/Display" = {
+        TunOffDisplayIdleTimeoutSec = cfg.powerdevil.turnOffDisplay.idleTimeout;
+        TunOffDisplayIdleTimeoutWhenLockedSec = cfg.powerdevil.turnOffDisplay.idleTimeoutWhenLocked;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Adds a new powerdevil-module to initially be able to configure suspending and display/brightness options contained in the power-management section of the setting gui. I haven't tested the functionality of this at all so far (but have confirmed that it seemingly writes the correct keys to `powerdevilrc`), but will do some checking tomorrow and hopefully merge quickly then. Also closes #194.