### PR TITLE
Fix middleButtonEmulation for mice in input module

### DIFF
--- a/modules/input.nix
+++ b/modules/input.nix
@@ -226,7 +226,7 @@ let
           Swap the left and right buttons.
         '';
       };
-      middleMouseEmulation = mkOption {
+      middleButtonEmulation = mkOption {
         type = with types; nullOr bool;
         default = null;
         example = false;
@@ -279,7 +279,7 @@ let
       "Libinput/${mouseVendor}/${mouseProduct}/${mouseName}" = {
         Enabled = mouse.enable;
         LeftHanded = mouse.leftHanded;
-        MiddleMouseEmulation = mouse.middleMouseEmulation;
+        MiddleButtonEmulation = mouse.middleButtonEmulation;
         NaturalScroll = mouse.naturalScroll;
         PointerAcceleration = mouse.acceleration;
         PointerAccelerationProfile = mouse.accelerationProfile;


### PR DESCRIPTION
@magnouvean just found out this was only fixed for touchpads before #123 was merged