### PR TITLE
Add plasma-panel-spacer-extended to additionalWidgetPackages

### DIFF
--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -13,6 +13,7 @@ let
     "com.github.antroids.application-title-bar" = [ application-title-bar ];
     plasmusic-toolbar = [ plasmusic-toolbar ];
     "org.kde.windowbuttons" = [ kdePackages.applet-window-buttons6 ];
+    "luisbocanegra.panelspacer.extended" = [ plasma-panel-spacer-extended ];
   };
   # An attrset of service-names and widgets/conditions. If any of the
   # conditions (given in cond) evaluate to true for any of the widgets with the


### PR DESCRIPTION
We will need to wait the widget package get merged and reach `nixos-unstable`
- PR: NixOS/nixpkgs#335447
- Tracker: https://nixpk.gs/pr-tracker.html?pr=335447