### PR TITLE
Add a few desktop folder settings

### DIFF
--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -161,7 +161,8 @@ let
   anyDesktopFolderSettingsSet = (
     (cfg.workspace.desktop.icons.arrangement != null) ||
     (cfg.workspace.desktop.icons.size != null) ||
-    (cfg.workspace.desktop.icons.folderPreviewPopups != null)
+    (cfg.workspace.desktop.icons.folderPreviewPopups != null) ||
+    (cfg.workspace.desktop.icons.previewPlugins != null)
   );
 in
 {
@@ -248,6 +249,7 @@ in
                 ${lib.optionalString (cfg.workspace.desktop.icons.arrangement == "topToBottom") ''desktop.writeConfig("arrangement", 1);''}
                 ${stringIfNotNull cfg.workspace.desktop.icons.size ''desktop.writeConfig("iconSize", ${builtins.toString cfg.workspace.desktop.icons.size});''}
                 ${lib.optionalString (!cfg.workspace.desktop.icons.folderPreviewPopups) ''desktop.writeConfig("popups", false);''}
+                ${stringIfNotNull cfg.workspace.desktop.icons.previewPlugins ''desktop.writeConfig("previewPlugins", "${lib.strings.concatStringsSep "," cfg.workspace.desktop.icons.previewPlugins}");''}
               }
           '' else ""
           );

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -7,8 +7,6 @@ let
   cfg = config.programs.plasma;
   hasWidget = widgetName: builtins.any (panel: builtins.any (widget: widget.name == widgetName) panel.widgets) cfg.panels;
 
-  inherit (widgets.lib) stringIfNotNull;
-
   # An attrset keeping track of the packages which should be added when a
   # widget is present in the config.
   additionalWidgetPackages = with pkgs; {
@@ -157,9 +155,6 @@ let
     (cfg.workspace.wallpaperPictureOfTheDay != null) ||
     (cfg.workspace.wallpaperPlainColor != null) ||
     ((builtins.length cfg.panels) > 0));
-
-  # Becomes true if any option under "cfg.workspace.desktop.icons" is set to something other than null.
-  anyDesktopFolderSettingsSet = lib.any (v: v != null) (builtins.attrValues cfg.workspace.desktop.icons);
 in
 {
   imports = [
@@ -236,25 +231,12 @@ in
                 desktop.currentConfigGroup = Array("Wallpaper", "org.kde.color", "General");
                 desktop.writeConfig("Color", "${cfg.workspace.wallpaperPlainColor}");
             }
-          '' else "");
-          desktopFolderSettings = (if anyDesktopFolderSettingsSet then ''
-            // Desktop folder settings
-            let allDesktops = desktops();
-            for (const desktop of allDesktops) {
-                desktop.currentConfigGroup = ["General"];
-                ${lib.optionalString (cfg.workspace.desktop.icons.arrangement == "topToBottom") ''desktop.writeConfig("arrangement", 1);''}
-                ${lib.optionalString (cfg.workspace.desktop.icons.alignment == "right") ''desktop.writeConfig("alignment", 1);''}
-                ${lib.optionalString (cfg.workspace.desktop.icons.lockInPlace) ''desktop.writeConfig("locked", true);''}
-                ${stringIfNotNull cfg.workspace.desktop.icons.size ''desktop.writeConfig("iconSize", ${builtins.toString cfg.workspace.desktop.icons.size});''}
-                ${lib.optionalString (!cfg.workspace.desktop.icons.folderPreviewPopups) ''desktop.writeConfig("popups", false);''}
-                ${stringIfNotNull cfg.workspace.desktop.icons.previewPlugins ''desktop.writeConfig("previewPlugins", "${lib.strings.concatStringsSep "," cfg.workspace.desktop.icons.previewPlugins}");''}
-              }
           '' else ""
           );
         in
         {
           preCommands = panelPreCMD;
-          text = panelLayoutStr + wallpaperDesktopScript + wallpaperSlideShow + wallpaperPOTD + wallpaperPlainColor + desktopFolderSettings;
+          text = panelLayoutStr + wallpaperDesktopScript + wallpaperSlideShow + wallpaperPOTD + wallpaperPlainColor;
           postCommands = panelPostCMD + wallpaperPostCMD;
           restartServices =
             (lib.unique (if anyNonDefaultScreens then [ "plasma-plasmashell" ] else [ ])

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -155,6 +155,10 @@ let
     (cfg.workspace.wallpaperPictureOfTheDay != null) ||
     (cfg.workspace.wallpaperPlainColor != null) ||
     ((builtins.length cfg.panels) > 0));
+
+  anyDesktopFolderSettingsSet = (
+    (cfg.workspace.desktop.icons.arrangement != null)
+  );
 in
 {
   imports = [
@@ -231,12 +235,20 @@ in
                 desktop.currentConfigGroup = Array("Wallpaper", "org.kde.color", "General");
                 desktop.writeConfig("Color", "${cfg.workspace.wallpaperPlainColor}");
             }
+          '' else "");
+          desktopFolderSettings = (if anyDesktopFolderSettingsSet then ''
+            // Desktop folder settings
+            let allDesktops = desktops();
+            for (const desktop of allDesktops) {
+                desktop.currentConfigGroup = ["General"];
+                ${lib.optionalString (cfg.workspace.desktop.icons.arrangement == "topToBottom") ''desktop.writeConfig("arrangement", 1);''}
+              }
           '' else ""
           );
         in
         {
           preCommands = panelPreCMD;
-          text = panelLayoutStr + wallpaperDesktopScript + wallpaperSlideShow + wallpaperPOTD + wallpaperPlainColor;
+          text = panelLayoutStr + wallpaperDesktopScript + wallpaperSlideShow + wallpaperPOTD + wallpaperPlainColor + desktopFolderSettings;
           postCommands = panelPostCMD + wallpaperPostCMD;
           restartServices =
             (lib.unique (if anyNonDefaultScreens then [ "plasma-plasmashell" ] else [ ])

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -160,7 +160,8 @@ let
 
   anyDesktopFolderSettingsSet = (
     (cfg.workspace.desktop.icons.arrangement != null) ||
-    (cfg.workspace.desktop.icons.size != null)
+    (cfg.workspace.desktop.icons.size != null) ||
+    (cfg.workspace.desktop.icons.folderPreviewPopups != null)
   );
 in
 {
@@ -246,6 +247,7 @@ in
                 desktop.currentConfigGroup = ["General"];
                 ${lib.optionalString (cfg.workspace.desktop.icons.arrangement == "topToBottom") ''desktop.writeConfig("arrangement", 1);''}
                 ${stringIfNotNull cfg.workspace.desktop.icons.size ''desktop.writeConfig("iconSize", ${builtins.toString cfg.workspace.desktop.icons.size});''}
+                ${lib.optionalString (!cfg.workspace.desktop.icons.folderPreviewPopups) ''desktop.writeConfig("popups", false);''}
               }
           '' else ""
           );

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -158,12 +158,8 @@ let
     (cfg.workspace.wallpaperPlainColor != null) ||
     ((builtins.length cfg.panels) > 0));
 
-  anyDesktopFolderSettingsSet = (
-    (cfg.workspace.desktop.icons.arrangement != null) ||
-    (cfg.workspace.desktop.icons.size != null) ||
-    (cfg.workspace.desktop.icons.folderPreviewPopups != null) ||
-    (cfg.workspace.desktop.icons.previewPlugins != null)
-  );
+  # Becomes true if any option under "cfg.workspace.desktop.icons" is set to something other than null.
+  anyDesktopFolderSettingsSet = lib.any (v: v != null) (builtins.attrValues cfg.workspace.desktop.icons);
 in
 {
   imports = [

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -243,6 +243,8 @@ in
             for (const desktop of allDesktops) {
                 desktop.currentConfigGroup = ["General"];
                 ${lib.optionalString (cfg.workspace.desktop.icons.arrangement == "topToBottom") ''desktop.writeConfig("arrangement", 1);''}
+                ${lib.optionalString (cfg.workspace.desktop.icons.alignment == "right") ''desktop.writeConfig("alignment", 1);''}
+                ${lib.optionalString (cfg.workspace.desktop.icons.lockInPlace) ''desktop.writeConfig("locked", true);''}
                 ${stringIfNotNull cfg.workspace.desktop.icons.size ''desktop.writeConfig("iconSize", ${builtins.toString cfg.workspace.desktop.icons.size});''}
                 ${lib.optionalString (!cfg.workspace.desktop.icons.folderPreviewPopups) ''desktop.writeConfig("popups", false);''}
                 ${stringIfNotNull cfg.workspace.desktop.icons.previewPlugins ''desktop.writeConfig("previewPlugins", "${lib.strings.concatStringsSep "," cfg.workspace.desktop.icons.previewPlugins}");''}

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -7,6 +7,8 @@ let
   cfg = config.programs.plasma;
   hasWidget = widgetName: builtins.any (panel: builtins.any (widget: widget.name == widgetName) panel.widgets) cfg.panels;
 
+  inherit (widgets.lib) stringIfNotNull;
+
   # An attrset keeping track of the packages which should be added when a
   # widget is present in the config.
   additionalWidgetPackages = with pkgs; {
@@ -157,7 +159,8 @@ let
     ((builtins.length cfg.panels) > 0));
 
   anyDesktopFolderSettingsSet = (
-    (cfg.workspace.desktop.icons.arrangement != null)
+    (cfg.workspace.desktop.icons.arrangement != null) ||
+    (cfg.workspace.desktop.icons.size != null)
   );
 in
 {
@@ -242,6 +245,7 @@ in
             for (const desktop of allDesktops) {
                 desktop.currentConfigGroup = ["General"];
                 ${lib.optionalString (cfg.workspace.desktop.icons.arrangement == "topToBottom") ''desktop.writeConfig("arrangement", 1);''}
+                ${stringIfNotNull cfg.workspace.desktop.icons.size ''desktop.writeConfig("iconSize", ${builtins.toString cfg.workspace.desktop.icons.size});''}
               }
           '' else ""
           );

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -363,8 +363,6 @@ in
         priority = 1;
       });
 
-      # Creates a startup script to set the desktop folder settings defined
-      # in the options under "cfg.workspace.desktop.icons".
       "set_desktop_folder_settings" = (lib.mkIf anyDesktopFolderSettingsSet {
         text = ''
           // Desktop folder settings

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -348,8 +348,8 @@ in
     # kde tools. We then run this using an autostart script, where this is
     # run only on the first login (unless overrideConfig is enabled),
     # granted all the commands succeed (until we change the settings again).
-    programs.plasma.startup.startupScript = {
-      "apply_themes" = (lib.mkIf anyThemeSet {
+    programs.plasma.startup = {
+      startupScript."apply_themes" = (lib.mkIf anyThemeSet {
         text = ''
           ${if cfg.workspace.lookAndFeel != null then "plasma-apply-lookandfeel -a ${cfg.workspace.lookAndFeel}" else ""}
           ${if cfg.workspace.theme != null then "plasma-apply-desktoptheme ${cfg.workspace.theme}" else ""}
@@ -363,7 +363,7 @@ in
         priority = 1;
       });
 
-      "set_desktop_folder_settings" = (lib.mkIf anyDesktopFolderSettingsSet {
+      desktopScript."set_desktop_folder_settings" = (lib.mkIf anyDesktopFolderSettingsSet {
         text = ''
           // Desktop folder settings
           let allDesktops = desktops();
@@ -371,9 +371,9 @@ in
             desktop.currentConfigGroup = ["General"];
             ${lib.optionalString (cfg.workspace.desktop.icons.arrangement == "topToBottom") ''desktop.writeConfig("arrangement", 1);''}
             ${lib.optionalString (cfg.workspace.desktop.icons.alignment == "right") ''desktop.writeConfig("alignment", 1);''}
-            ${lib.optionalString (cfg.workspace.desktop.icons.lockInPlace) ''desktop.writeConfig("locked", true);''}
+            ${lib.optionalString (cfg.workspace.desktop.icons.lockInPlace == true) ''desktop.writeConfig("locked", true);''}
             ${stringIfNotNull cfg.workspace.desktop.icons.size ''desktop.writeConfig("iconSize", ${builtins.toString cfg.workspace.desktop.icons.size});''}
-            ${lib.optionalString (!cfg.workspace.desktop.icons.folderPreviewPopups) ''desktop.writeConfig("popups", false);''}
+            ${lib.optionalString (cfg.workspace.desktop.icons.folderPreviewPopups == false) ''desktop.writeConfig("popups", false);''}
             ${stringIfNotNull cfg.workspace.desktop.icons.previewPlugins ''desktop.writeConfig("previewPlugins", "${lib.strings.concatStringsSep "," cfg.workspace.desktop.icons.previewPlugins}");''}
           }
         '';

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -212,6 +212,17 @@ in
             The fourth position (3) is the default.
           '';
         };
+
+        folderPreviewPopups = lib.mkOption {
+          type = with lib.types; nullOr bool;
+          default = null;
+          example = false;
+          description = ''
+            Enables the arrow button when hovering over a folder on the desktop
+            which shows a preview popup of the folder’s contents.
+            Is enabled by default.
+          '';
+        };
       };
     };
   };

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -190,6 +190,19 @@ in
         '';
       };
     };
+
+    desktop = {
+      icons = {
+        arrangement = lib.mkOption {
+          type = with lib.types; nullOr (enum [ "leftToRight" "topToBottom" ]);
+          default = null;
+          example = "topToBottom";
+          description = ''
+            The direction, in which desktop icons are to be arranged.
+          '';
+        };
+      };
+    };
   };
 
   config = (lib.mkIf cfg.enable {

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -25,10 +25,10 @@ let
 
   desktopIconSortingModeId = {
     manual = -1;
-    name   = 0;
-    size   = 1;
-    date   = 2;
-    type   = 6;
+    name = 0;
+    size = 1;
+    date = 2;
+    type = 6;
   }.${cfg.workspace.desktop.icons.sorting.mode};
 
   anyThemeSet = (cfg.workspace.theme != null ||
@@ -42,7 +42,7 @@ let
     let
       recurse = l: lib.any (v: if builtins.isAttrs v then recurse v else v != null) (builtins.attrValues l);
     in
-      recurse cfg.workspace.desktop.icons;
+    recurse cfg.workspace.desktop.icons;
 
   splashScreenEngineDetect = theme: (if (theme == "None") then "none" else "KSplashQML");
 in
@@ -259,7 +259,7 @@ in
             '';
           };
 
-          foldersFirst  = lib.mkOption {
+          foldersFirst = lib.mkOption {
             type = with lib.types; nullOr bool;
             default = null;
             example = false;

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -223,6 +223,15 @@ in
             Is enabled by default.
           '';
         };
+
+        previewPlugins = lib.mkOption {
+          type = with lib.types; nullOr (listOf str);
+          default = null;
+          example = ["audiothumbnail" "fontthumbnail"];
+          description = ''
+            Configures the preview plugins used to preview desktop files and folders.
+          '';
+        };
       };
     };
   };

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -202,6 +202,27 @@ in
           '';
         };
 
+        alignment = lib.mkOption {
+          type = with lib.types; nullOr (enum [ "left" "right" ]);
+          default = null;
+          example = "right";
+          description = ''
+            Whether to align the icons on the left (the default) or right
+            side of the screen.
+          '';
+        };
+
+        lockInPlace = lib.mkOption {
+          type = with lib.types; nullOr bool;
+          default = null;
+          example = true;
+          description = ''
+            Locks the position of all desktop icons to the order and placement
+            defined by "arrangement", "alignment" and sorting rules (which
+            don’t have options yet) so they can’t be manually moved.
+          '';
+        };
+
         size = lib.mkOption {
           type = (lib.types.ints.between 0 6);
           default = null;

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -201,6 +201,17 @@ in
             The direction, in which desktop icons are to be arranged.
           '';
         };
+
+        size = lib.mkOption {
+          type = (lib.types.ints.between 0 6);
+          default = null;
+          example = 2;
+          description = ''
+            The desktop icon size, which is normally configured via a slider
+            with seven possible values ranging from small (0) to large (6).
+            The fourth position (3) is the default.
+          '';
+        };
       };
     };
   };

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -29,7 +29,7 @@ let
     size = 1;
     date = 2;
     type = 6;
-  }.${cfg.workspace.desktop.icons.sorting.mode};
+  };
 
   anyThemeSet = (cfg.workspace.theme != null ||
     cfg.workspace.colorScheme != null ||
@@ -241,13 +241,14 @@ in
 
         sorting = {
           mode = lib.mkOption {
-            type = with lib.types; nullOr (enum [ "manual" "name" "size" "type" "date" ]);
+            type = with lib.types; nullOr (enum (builtins.attrNames desktopIconSortingModeId));
             default = null;
             example = "type";
             description = ''
               Specifies the sort mode for the desktop icons. By default they are
               sorted by name.
             '';
+            apply = sortMode: if (sortMode == null) then null else desktopIconSortingModeId.${sortMode};
           };
 
           descending = lib.mkOption {
@@ -421,7 +422,7 @@ in
             ${stringIfNotNull cfg.workspace.desktop.icons.size ''desktop.writeConfig("iconSize", ${builtins.toString cfg.workspace.desktop.icons.size});''}
             ${lib.optionalString (cfg.workspace.desktop.icons.folderPreviewPopups == false) ''desktop.writeConfig("popups", false);''}
             ${stringIfNotNull cfg.workspace.desktop.icons.previewPlugins ''desktop.writeConfig("previewPlugins", "${lib.strings.concatStringsSep "," cfg.workspace.desktop.icons.previewPlugins}");''}
-            ${stringIfNotNull cfg.workspace.desktop.icons.sorting.mode ''desktop.writeConfig("sortMode", ${builtins.toString desktopIconSortingModeId});''}
+            ${stringIfNotNull cfg.workspace.desktop.icons.sorting.mode ''desktop.writeConfig("sortMode", ${builtins.toString cfg.workspace.desktop.icons.sorting.mode});''}
             ${lib.optionalString (cfg.workspace.desktop.icons.sorting.descending == true) ''desktop.writeConfig("sortDesc", true);''}
             ${lib.optionalString (cfg.workspace.desktop.icons.sorting.foldersFirst == false) ''desktop.writeConfig("sortDirsFirst", false);''}
           }

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -4,7 +4,7 @@
 let
   cfg = config.programs.plasma;
   inherit (import ../lib/wallpapers.nix { inherit lib; }) wallpaperPictureOfTheDayType wallpaperSlideShowType;
-  inherit (widgets.lib) stringIfNotNull;
+  inherit (import ./widgets/lib.nix {inherit lib; }) stringIfNotNull;
 
   cursorType = with lib.types; submodule {
     options = {

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -4,7 +4,7 @@
 let
   cfg = config.programs.plasma;
   inherit (import ../lib/wallpapers.nix { inherit lib; }) wallpaperPictureOfTheDayType wallpaperSlideShowType;
-  inherit (import ./widgets/lib.nix {inherit lib; }) stringIfNotNull;
+  inherit (import ./widgets/lib.nix { inherit lib; }) stringIfNotNull;
 
   cursorType = with lib.types; submodule {
     options = {
@@ -58,7 +58,7 @@ in
     };
 
     theme = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
+      type = with lib.types; nullOr str;
       default = null;
       example = "breeze-dark";
       description = ''
@@ -67,7 +67,7 @@ in
     };
 
     colorScheme = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
+      type = with lib.types; nullOr str;
       default = null;
       example = "BreezeDark";
       description = ''
@@ -85,7 +85,7 @@ in
     };
 
     lookAndFeel = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
+      type = with lib.types; nullOr str;
       default = null;
       example = "org.kde.breezedark.desktop";
       description = ''
@@ -94,7 +94,7 @@ in
     };
 
     iconTheme = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
+      type = with lib.types; nullOr str;
       default = null;
       example = "Papirus";
       description = ''
@@ -130,7 +130,7 @@ in
     };
 
     wallpaperPlainColor = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
+      type = with lib.types; nullOr str;
       default = null;
       example = "0,64,174,256";
       description = ''
@@ -228,7 +228,7 @@ in
         };
 
         size = lib.mkOption {
-          type = (lib.types.ints.between 0 6);
+          type = with lib.types; nullOr (ints.between 0 6);
           default = null;
           example = 2;
           description = ''
@@ -252,7 +252,7 @@ in
         previewPlugins = lib.mkOption {
           type = with lib.types; nullOr (listOf str);
           default = null;
-          example = ["audiothumbnail" "fontthumbnail"];
+          example = [ "audiothumbnail" "fontthumbnail" ];
           description = ''
             Configures the preview plugins used to preview desktop files and folders.
           '';


### PR DESCRIPTION
This PR adds four options from the `Icons` menu of the `Desktop Folder Settings`. They seem to work (for me at least), but I’m not sure if the implementation is good enough for inclusion here. I’m specifically unsure about the following:

- Is `workspace.nix` the right place for the new options?
- Is it okay to use the `desktop` set?
- Is the implementation via the panel script acceptable?

I’d also like to add a few options for the `Mouse Actions` menu to the `desktop` set, but I suspect [my approach](https://github.com/Morwdan/plasma-manager/commit/2703e2c4709eb2841fdb0ebd755688d65d8a603c) might be a bit to hacky and might also not work in other setups.