### PR TITLE
Add more powerdevil options for laptops

### DIFF
--- a/examples/home.nix
+++ b/examples/home.nix
@@ -213,14 +213,23 @@
     ];
 
     powerdevil = {
-      powerButtonAction = "lockScreen";
-      autoSuspend = {
-        action = "shutDown";
-        idleTimeout = 1000;
+      AC = {
+        powerButtonAction = "lockScreen";
+        autoSuspend = {
+          action = "shutDown";
+          idleTimeout = 1000;
+        };
+        turnOffDisplay = {
+          idleTimeout = 1000;
+          idleTimeoutWhenLocked = "immediately";
+        };
       };
-      turnOffDisplay = {
-        idleTimeout = 1000;
-        idleTimeoutWhenLocked = "immediately";
+      battery = {
+        powerButtonAction = "sleep";
+        whenSleepingEnter = "standbyThenHibernate";
+      };
+      lowBattery = {
+        whenLaptopLidClosed = "hibernate";
       };
     };
 


### PR DESCRIPTION
Ports some additional options over to the powerdevil settings, such as hibernation support, low battery configuration options, and events to trigger when closing the laptop lid.