### PR TITLE
Add escapeValue option and fix brackets.characters option for kate

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -35,6 +35,15 @@ let
           plasma-manager will leave it unchanged after activation.
         '';
       };
+      escapeValue = lib.mkOption {
+        type = bool;
+        default = true;
+        description = ''
+          Whether to escape the value according to kde's escape-format. See:
+          https://github.com/KDE/kconfig/blob/44f98ff5cb9008436ba5ba385cae03bbd0ab33e6/src/core/kconfigini.cpp#L882
+          for info about this format.
+        '';
+      };
     };
   });
   coercedSettingsType = with lib.types;

--- a/modules/apps/kate/default.nix
+++ b/modules/apps/kate/default.nix
@@ -306,15 +306,17 @@ in
         type = lib.types.bool;
       };
 
-      inputMode = let
-        enumVals = [ "normal" "vi" ];
-      in lib.mkOption {
-        type = lib.types.enum enumVals;
-        description = "The input mode for the editor.";
-        default = "normal";
-        example = "vi";
-        apply = getIndexFromEnum enumVals;
-      };
+      inputMode =
+        let
+          enumVals = [ "normal" "vi" ];
+        in
+        lib.mkOption {
+          type = lib.types.enum enumVals;
+          description = "The input mode for the editor.";
+          default = "normal";
+          example = "vi";
+          apply = getIndexFromEnum enumVals;
+        };
 
       font = lib.mkOption {
         type = fontType;
@@ -476,7 +478,7 @@ in
     };
 
     "KTextEditor View" = {
-      "Chars To Enclose Selection" = cfg.editor.brackets.characters;
+      "Chars To Enclose Selection" = { value = cfg.editor.brackets.characters; escapeValue = false; };
       "Bracket Match Preview" = cfg.editor.brackets.highlightMatching;
       "Auto Brackets" = cfg.editor.brackets.automaticallyAddClosing;
       "Input Mode" = cfg.editor.inputMode;

--- a/script/write_config.py
+++ b/script/write_config.py
@@ -109,7 +109,7 @@ class ConfigValue:
             else str(value["value"]).lower()
         )
         return cls(
-            value=escape(key_value),
+            value=escape(key_value) if value["escapeValue"] else key_value,
             immutable=value["immutable"],
             shellExpand=value["shellExpand"],
         )


### PR DESCRIPTION
Adds `escapeValue` option to the `files` module (enabled by default), which allows us to disable escaping certain characters when writing to the config-file. When disabled, we can for example add `[]` to values in the config without resulting in `\x5b\x5d`. I used this option to disable this escaping by default in `editor.brackets.characters` option for the kate-module and thus this closes #296.