### PR TITLE
Add mouse actions

### DIFF
--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -49,7 +49,7 @@ let
     cfg.workspace.iconTheme != null);
 
   # Becomes true if any option under "cfg.workspace.desktop" is set to something other than null.
-  anyDesktopFolderSettingsSet =
+  anyDesktopSettingsSet =
     let
       recurse = l: lib.any (v: if builtins.isAttrs v then recurse v else v != null) (builtins.attrValues l);
     in
@@ -455,7 +455,7 @@ in
         priority = 1;
       });
 
-      desktopScript."set_desktop_folder_settings" = (lib.mkIf anyDesktopFolderSettingsSet {
+      desktopScript."set_desktop_folder_settings" = (lib.mkIf anyDesktopSettingsSet {
         text = ''
           // Desktop folder settings
           let allDesktops = desktops();

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -48,12 +48,15 @@ let
     cfg.workspace.lookAndFeel != null ||
     cfg.workspace.iconTheme != null);
 
-  # Becomes true if any option under "cfg.workspace.desktop" is set to something other than null.
+  # Becomes true if any option under "cfg.workspace.desktop.icons" is set to something other than null.
   anyDesktopFolderSettingsSet =
     let
       recurse = l: lib.any (v: if builtins.isAttrs v then recurse v else v != null) (builtins.attrValues l);
     in
-    recurse cfg.workspace.desktop;
+    recurse cfg.workspace.desktop.icons;
+
+  # Becomes true if any option under "cfg.workspace.desktop.mouseActions" is set to something other than null.
+  anyDesktopMouseActionsSet = lib.any (v: v != null) (builtins.attrValues cfg.workspace.desktop.mouseActions);
 
   splashScreenEngineDetect = theme: (if (theme == "None") then "none" else "KSplashQML");
 in
@@ -470,8 +473,12 @@ in
             ${stringIfNotNull cfg.workspace.desktop.icons.sorting.mode ''desktop.writeConfig("sortMode", ${builtins.toString cfg.workspace.desktop.icons.sorting.mode});''}
             ${lib.optionalString (cfg.workspace.desktop.icons.sorting.descending == true) ''desktop.writeConfig("sortDesc", true);''}
             ${lib.optionalString (cfg.workspace.desktop.icons.sorting.foldersFirst == false) ''desktop.writeConfig("sortDirsFirst", false);''}
-          }
+          }'';
+        priority = 3;
+      });
 
+      desktopScript."set_desktop_mouse_actions" = (lib.mkIf anyDesktopMouseActionsSet {
+        text = ''
           // Mouse actions
           // This is pretty hacky, there has to be a better way to do this.
           // I don’t even know if that works in every setup or just in my specific case,
@@ -504,7 +511,7 @@ in
           ${stringIfNotNull cfg.workspace.desktop.mouseActions.rightClick ''actionPluginSubSection.writeEntry("RightButton;NoModifier", "${cfg.workspace.desktop.mouseActions.rightClick}");''}
           ${stringIfNotNull cfg.workspace.desktop.mouseActions.verticalScroll ''actionPluginSubSection.writeEntry("wheel:Vertical;NoModifier", "${cfg.workspace.desktop.mouseActions.verticalScroll}");''}
         '';
-        priority = 3;
+        priority = 4;
       });
     };
 

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -474,6 +474,10 @@ in
           // differently on two monitors, the UI shows which actions were defined on
           // which monitor, their corresponding settings are all listed under the same
           // section though, in my case [ActionPlugins][0].
+          // Edit: After logout and login the settings in the config file seem to
+          // apply to both monitors and their respective menus represent this config.
+          // So the changes made in one monitor’s desktop settings are kept in memory
+          // and arent’t even read anew when the settings are closed and reopened?
           let configFile = ConfigFile('plasma-org.kde.plasma.desktop-appletsrc');
           configFile.group = 'ActionPlugins';
           // Would return 0 and 1 (unsorted) in case of following sections:
@@ -481,8 +485,12 @@ in
           // [ActionPlugins][1]
           let actionPluginSubSections = configFile.groupList
           // Gets the id of the first [ActionPlugins] section
-          // (as long as no id is grater than 9, that is).
-          // FIXME
+          // FIXME: (as long as no id is grater than 9, that is).
+          // Edit: I don’t know if this is necessary. I have [0] and [1] in my config.
+          // If I move all but one of the actions from [0] to [1] and log in again,
+          // only the actions from [0] are active. If I remove [0] completely, it is
+          // recreated on login with it’s defaults, which then are active. It looks
+          // like one could just hard code [0], but what is the purpose of [1] then?
           let actionPluginSubSectionId = Array.from(actionPluginSubSections).sort()[0]
           let actionPluginSubSection = ConfigFile(configFile, actionPluginSubSectionId)
           ${stringIfNotNull cfg.workspace.desktop.mouseActions.leftClick ''actionPluginSubSection.writeEntry("LeftButton;NoModifier", "${mouseActionNames."${cfg.workspace.desktop.mouseActions.leftClick}"}");''}

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -32,13 +32,15 @@ let
   };
 
   mouseActionNames = {
+    applicationLauncher = "org.kde.applauncher";
     contextMenu = "org.kde.contextmenu";
-    switchWindow = "switchwindow";
+    paste = "org.kde.paste";
+    switchActivity = "switchactivity";
     switchVirtualDesktop = "org.kde.switchdesktop";
-    appLauncher = "org.kde.applauncher";
+    switchWindow = "switchwindow";
   };
 
-  mouseActionValues = lib.types.enum [ "contextMenu" "switchWindow" "switchVirtualDesktop" "appLauncher" ];
+  mouseActionValues = lib.types.enum [ "applicationLauncher" "contextMenu" "paste" "switchActivity" "switchVirtualDesktop" "switchWindow" ];
 
   anyThemeSet = (cfg.workspace.theme != null ||
     cfg.workspace.colorScheme != null ||

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -49,7 +49,7 @@ let
     cfg.workspace.iconTheme != null);
 
   # Becomes true if any option under "cfg.workspace.desktop" is set to something other than null.
-  anyDesktopSettingsSet =
+  anyDesktopFolderSettingsSet =
     let
       recurse = l: lib.any (v: if builtins.isAttrs v then recurse v else v != null) (builtins.attrValues l);
     in
@@ -455,7 +455,7 @@ in
         priority = 1;
       });
 
-      desktopScript."set_desktop_folder_settings" = (lib.mkIf anyDesktopSettingsSet {
+      desktopScript."set_desktop_folder_settings" = (lib.mkIf anyDesktopFolderSettingsSet {
         text = ''
           // Desktop folder settings
           let allDesktops = desktops();

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -473,7 +473,8 @@ in
             ${stringIfNotNull cfg.workspace.desktop.icons.sorting.mode ''desktop.writeConfig("sortMode", ${builtins.toString cfg.workspace.desktop.icons.sorting.mode});''}
             ${lib.optionalString (cfg.workspace.desktop.icons.sorting.descending == true) ''desktop.writeConfig("sortDesc", true);''}
             ${lib.optionalString (cfg.workspace.desktop.icons.sorting.foldersFirst == false) ''desktop.writeConfig("sortDirsFirst", false);''}
-          }'';
+          }
+        '';
         priority = 3;
       });
 

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -480,38 +480,17 @@ in
       desktopScript."set_desktop_mouse_actions" = (lib.mkIf anyDesktopMouseActionsSet {
         text = ''
           // Mouse actions
-          // This is pretty hacky, there has to be a better way to do this.
-          // I don’t even know if that works in every setup or just in my specific case,
-          // as I don’t understand how the [ActionPlugins] sections are populated and
-          // processed, especially in multi-monitor setups. If you configure the actions
-          // differently on two monitors, the UI shows which actions were defined on
-          // which monitor, their corresponding settings are all listed under the same
-          // section though, in my case [ActionPlugins][0].
-          // Edit: After logout and login the settings in the config file seem to
-          // apply to both monitors and their respective menus represent this config.
-          // So the changes made in one monitor’s desktop settings are kept in memory
-          // and arent’t even read anew when the settings are closed and reopened?
           let configFile = ConfigFile('plasma-org.kde.plasma.desktop-appletsrc');
           configFile.group = 'ActionPlugins';
-          // Would return 0 and 1 (unsorted) in case of following sections:
-          // [ActionPlugins][0]
-          // [ActionPlugins][1]
-          let actionPluginSubSections = configFile.groupList
-          // Gets the id of the first [ActionPlugins] section
-          // FIXME: (as long as no id is grater than 9, that is).
-          // Edit: I don’t know if this is necessary. I have [0] and [1] in my config.
-          // If I move all but one of the actions from [0] to [1] and log in again,
-          // only the actions from [0] are active. If I remove [0] completely, it is
-          // recreated on login with it’s defaults, which then are active. It looks
-          // like one could just hard code [0], but what is the purpose of [1] then?
-          let actionPluginSubSectionId = Array.from(actionPluginSubSections).sort()[0]
-          let actionPluginSubSection = ConfigFile(configFile, actionPluginSubSectionId)
+          // References the section [ActionPlugins][0].
+          let actionPluginSubSection = ConfigFile(configFile, 0)
           ${stringIfNotNull cfg.workspace.desktop.mouseActions.leftClick ''actionPluginSubSection.writeEntry("LeftButton;NoModifier", "${cfg.workspace.desktop.mouseActions.leftClick}");''}
           ${stringIfNotNull cfg.workspace.desktop.mouseActions.middleClick ''actionPluginSubSection.writeEntry("MiddleButton;NoModifier", "${cfg.workspace.desktop.mouseActions.middleClick}");''}
           ${stringIfNotNull cfg.workspace.desktop.mouseActions.rightClick ''actionPluginSubSection.writeEntry("RightButton;NoModifier", "${cfg.workspace.desktop.mouseActions.rightClick}");''}
           ${stringIfNotNull cfg.workspace.desktop.mouseActions.verticalScroll ''actionPluginSubSection.writeEntry("wheel:Vertical;NoModifier", "${cfg.workspace.desktop.mouseActions.verticalScroll}");''}
         '';
         priority = 3;
+        restartServices = [ "plasma-plasmashell" ];
       });
     };
 

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -40,7 +40,7 @@ let
     switchWindow = "switchwindow";
   };
 
-  mouseActionNames = lib.types.enum (builtins.attrNames mouseActions);
+  mouseActionNamesEnum = lib.types.enum (builtins.attrNames mouseActions);
 
   anyThemeSet = (cfg.workspace.theme != null ||
     cfg.workspace.colorScheme != null ||
@@ -319,7 +319,7 @@ in
 
       mouseActions = {
         leftClick = lib.mkOption {
-          type = lib.types.nullOr mouseActionNames;
+          type = lib.types.nullOr mouseActionNamesEnum;
           default = null;
           example = "appLauncher";
           description = "Action for a left click on the desktop.";
@@ -327,7 +327,7 @@ in
         };
 
         middleClick = lib.mkOption {
-          type = lib.types.nullOr mouseActionNames;
+          type = lib.types.nullOr mouseActionNamesEnum;
           default = null;
           example = "switchWindow";
           description = "Action for a click on the desktop with the middle mouse button.";
@@ -335,7 +335,7 @@ in
         };
 
         rightClick = lib.mkOption {
-          type = lib.types.nullOr mouseActionNames;
+          type = lib.types.nullOr mouseActionNamesEnum;
           default = null;
           example = "contextMenu";
           description = "Action for a right click on the desktop.";
@@ -343,7 +343,7 @@ in
         };
 
         verticalScroll = lib.mkOption {
-          type = lib.types.nullOr mouseActionNames;
+          type = lib.types.nullOr mouseActionNamesEnum;
           default = null;
           example = "switchVirtualDesktop";
           description = "Action for scrolling (vertically) while hovering over the desktop.";

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -31,7 +31,7 @@ let
     type = 6;
   };
 
-  mouseActionNames = {
+  mouseActions = {
     applicationLauncher = "org.kde.applauncher";
     contextMenu = "org.kde.contextmenu";
     paste = "org.kde.paste";
@@ -40,7 +40,7 @@ let
     switchWindow = "switchwindow";
   };
 
-  mouseActionValues = lib.types.enum [ "applicationLauncher" "contextMenu" "paste" "switchActivity" "switchVirtualDesktop" "switchWindow" ];
+  mouseActionNames = lib.types.enum (builtins.attrNames mouseActions);
 
   anyThemeSet = (cfg.workspace.theme != null ||
     cfg.workspace.colorScheme != null ||
@@ -319,31 +319,35 @@ in
 
       mouseActions = {
         leftClick = lib.mkOption {
-          type = lib.types.nullOr mouseActionValues;
+          type = lib.types.nullOr mouseActionNames;
           default = null;
           example = "appLauncher";
           description = "Action for a left click on the desktop.";
+          apply = value: if (value == null) then null else mouseActions.${value};
         };
 
         middleClick = lib.mkOption {
-          type = lib.types.nullOr mouseActionValues;
+          type = lib.types.nullOr mouseActionNames;
           default = null;
           example = "switchWindow";
           description = "Action for a click on the desktop with the middle mouse button.";
+          apply = value: if (value == null) then null else mouseActions.${value};
         };
 
         rightClick = lib.mkOption {
-          type = lib.types.nullOr mouseActionValues;
+          type = lib.types.nullOr mouseActionNames;
           default = null;
           example = "contextMenu";
           description = "Action for a right click on the desktop.";
+          apply = value: if (value == null) then null else mouseActions.${value};
         };
 
         verticalScroll = lib.mkOption {
-          type = lib.types.nullOr mouseActionValues;
+          type = lib.types.nullOr mouseActionNames;
           default = null;
           example = "switchVirtualDesktop";
           description = "Action for scrolling (vertically) while hovering over the desktop.";
+          apply = value: if (value == null) then null else mouseActions.${value};
         };
       };
     };
@@ -495,10 +499,10 @@ in
           // like one could just hard code [0], but what is the purpose of [1] then?
           let actionPluginSubSectionId = Array.from(actionPluginSubSections).sort()[0]
           let actionPluginSubSection = ConfigFile(configFile, actionPluginSubSectionId)
-          ${stringIfNotNull cfg.workspace.desktop.mouseActions.leftClick ''actionPluginSubSection.writeEntry("LeftButton;NoModifier", "${mouseActionNames."${cfg.workspace.desktop.mouseActions.leftClick}"}");''}
-          ${stringIfNotNull cfg.workspace.desktop.mouseActions.middleClick ''actionPluginSubSection.writeEntry("MiddleButton;NoModifier", "${mouseActionNames."${cfg.workspace.desktop.mouseActions.middleClick}"}");''}
-          ${stringIfNotNull cfg.workspace.desktop.mouseActions.rightClick ''actionPluginSubSection.writeEntry("RightButton;NoModifier", "${mouseActionNames."${cfg.workspace.desktop.mouseActions.rightClick}"}");''}
-          ${stringIfNotNull cfg.workspace.desktop.mouseActions.verticalScroll ''actionPluginSubSection.writeEntry("wheel:Vertical;NoModifier", "${mouseActionNames."${cfg.workspace.desktop.mouseActions.verticalScroll}"}");''}
+          ${stringIfNotNull cfg.workspace.desktop.mouseActions.leftClick ''actionPluginSubSection.writeEntry("LeftButton;NoModifier", "${cfg.workspace.desktop.mouseActions.leftClick}");''}
+          ${stringIfNotNull cfg.workspace.desktop.mouseActions.middleClick ''actionPluginSubSection.writeEntry("MiddleButton;NoModifier", "${cfg.workspace.desktop.mouseActions.middleClick}");''}
+          ${stringIfNotNull cfg.workspace.desktop.mouseActions.rightClick ''actionPluginSubSection.writeEntry("RightButton;NoModifier", "${cfg.workspace.desktop.mouseActions.rightClick}");''}
+          ${stringIfNotNull cfg.workspace.desktop.mouseActions.verticalScroll ''actionPluginSubSection.writeEntry("wheel:Vertical;NoModifier", "${cfg.workspace.desktop.mouseActions.verticalScroll}");''}
         '';
         priority = 3;
       });

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -511,7 +511,7 @@ in
           ${stringIfNotNull cfg.workspace.desktop.mouseActions.rightClick ''actionPluginSubSection.writeEntry("RightButton;NoModifier", "${cfg.workspace.desktop.mouseActions.rightClick}");''}
           ${stringIfNotNull cfg.workspace.desktop.mouseActions.verticalScroll ''actionPluginSubSection.writeEntry("wheel:Vertical;NoModifier", "${cfg.workspace.desktop.mouseActions.verticalScroll}");''}
         '';
-        priority = 4;
+        priority = 3;
       });
     };
 


### PR DESCRIPTION
This PR adds  `Mouse Actions` from the `Desktop Folder Settings`. It works in my setup but it has a number of limitations:

- Only for "buttons" are currently supported: the left, middle and right mouse buttons as well as vertically scrolling. There is also horizontal scroll which I can only input with modifiers by holding Alt (and optionally additional modifiers) and scrolling vertically 🤔. I wasn’t sure if I should add it. All additional buttons on my G502 are not recognized.
- Modifiers are not supported. Mainly because I don’t need them but also because that would likely necessitate a different approach\* which I can’t implement. Some modifier-button-combinations don’t work (e. g. `Ctrl+Vertical-Scroll` and `Shift+Vertical-Scroll`; but `Shift+Ctrl+Vertical-Scroll` does). Modifiers that could be used are at least Ctrl, Shift, Alt, Meta and combinations of them.
- The action options, which are available for some actions like the context menu, are not supported. I haven’t looked into them.
- Some button-action-combinations seem to be incompatible (e. g. scrolling and context menu), but they can also be entered in the settings so I don’t know if we should try to catch that.
- There may be two logins required for the settings to take effect, as the settings seem to be read from the config file only on login so the changes made by the script run after the first login aren’t picked up.

Additionally I’m not confident in the way the actions are written to the config file as detailed in the temporary comments. I [haven’t found][1] a native way to write the `ActionPlugins` sections, so I’m loading the file as `ConfigFile` and write the actions inspired by [this post][2]. I’m currently leaning towards hardcoding `[ActionPlugins][0]` if you have no objections.

\* Maybe a list containing a set per action with options for the button, modifiers and action instead of the current options? Then there probably needs to be a check that every modifier-button-combinations is unique.

[1]: https://develop.kde.org/docs/plasma/scripting/
[2]: https://discuss.kde.org/t/plasma-api-scripting-set-mouse-actions-right-button-properties-in-layout-js-of-global-theme/257