### PR TITLE
Update polonium package name

### DIFF
--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -463,7 +463,7 @@ in
       }
     ];
 
-    home.packages = with pkgs; [ ] ++ optionals (cfg.kwin.scripts.polonium.enable == true) [ libsForQt5.polonium ];
+    home.packages = with pkgs; [ ] ++ optionals (cfg.kwin.scripts.polonium.enable == true) [ polonium ];
 
     programs.plasma.configFile."kwinrc" = (mkMerge [
       # Titlebar buttons


### PR DESCRIPTION
Polonium package name was changed after my pull request.
We will need to wait it to get in `nixos-unstable`

- Tracker: https://nixpk.gs/pr-tracker.html?pr=333050