### PR TITLE
Add keyboard layout indicator widget-specific options

### DIFF
--- a/modules/widgets/default.nix
+++ b/modules/widgets/default.nix
@@ -9,6 +9,7 @@ let
     ./battery.nix
     ./digital-clock.nix
     ./icon-tasks.nix
+    ./keyboard-layout.nix
     ./kickoff.nix
     ./plasma-panel-colorizer.nix
     ./plasmusic-toolbar.nix

--- a/modules/widgets/keyboard-layout.nix
+++ b/modules/widgets/keyboard-layout.nix
@@ -1,0 +1,47 @@
+{ lib, ... }:
+let
+  getIndexFromEnum = enum: value:
+    if value == null
+    then null
+    else
+      lib.lists.findFirstIndex
+        (x: x == value)
+        (throw "getIndexFromEnum (keyboard-layout widget): Value ${value} isn't present in the enum. This is a bug")
+        enum;
+in
+{
+  keyboardLayout = {
+    description = "The keyboard layout indicator widget.";
+
+    opts = {
+      displayStyle =
+        let enumVals = [ "label" "flag" "labelOverFlag" ];
+        in lib.mkOption {
+          type = with lib.types; nullOr (enum enumVals);
+          default = null;
+          example = "labelOverFlag";
+          description = "Keyboard layout indicator display style.";
+          apply = getIndexFromEnum enumVals;
+        };
+      settings = lib.mkOption {
+        type = with lib.types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        default = null;
+        example = {
+          General = {
+            displayStyle = 1;
+          };
+        };
+        apply = settings: if settings == null then {} else settings;
+      };
+    };
+
+    convert = { displayStyle, settings }: {
+      name = "org.kde.plasma.keyboardlayout";
+      config = lib.recursiveUpdate {
+        General = lib.filterAttrs (_: v: v != null) {
+          inherit displayStyle;
+        };
+      } settings;
+    };
+  };
+}

--- a/modules/widgets/system-tray.nix
+++ b/modules/widgets/system-tray.nix
@@ -107,6 +107,7 @@ in
           example = {
             # Example of a widget-specific config
             battery.showPercentage = true;
+            keyboardLayout.displayStyle = "label";
 
             # Example of raw config for an untyped widget
             "org.kde.plasma.devicenotifier".config = {


### PR DESCRIPTION
@salko-ua could you test it on your side?

Test it with:
```nix
programa.plasma = {
  enable = true;
  panels = [
    {
      floating = true;
      height = 44;
      widgets = [
        {
          systemTray = {
            items.config = {
              keyboardLayout.displayStyle = "flag"; # or label or labelOverFlag
            };
          };
        }
      ];
    }
  ];
};
```