### PR TITLE
Fix documentation for showing a panel on all screens

### DIFF
--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -136,7 +136,7 @@ let
         description = ''
           The screen the panel should appear on. Can be an int, or a list of ints,
           starting from 0, representing the ID of the screen the panel should
-          appear on. Alternatively it can be set to "any" if the panel should
+          appear on. Alternatively it can be set to "all" if the panel should
           appear on all the screens.
         '';
       };


### PR DESCRIPTION
The description of the `programs.plasma.panels..screen` option previously stated to use "any" as the value to show the panel on all screens, while the actual option type specified "all".

This pull request updates the description to match the type.