### PR TITLE
Support generating top level widget options and use it for popup height and width in kickoff

### DIFF
--- a/modules/widgets/application-title-bar.nix
+++ b/modules/widgets/application-title-bar.nix
@@ -1,6 +1,7 @@
 { lib, ... }:
 let
   inherit (lib) mkOption types;
+  inherit (import ./lib.nix { inherit lib; }) configValueType;
 
   mkBoolOption = description: lib.mkOption {
     type = with lib.types; nullOr bool;
@@ -438,7 +439,7 @@ in
         };
       };
       settings = mkOption {
-        type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        type = configValueType;
         default = null;
         example = {
           Appearance = {

--- a/modules/widgets/application-title-bar.nix
+++ b/modules/widgets/application-title-bar.nix
@@ -439,7 +439,7 @@ in
         };
       };
       settings = mkOption {
-        type = configValueType;
+        type = types.nullOr configValueType;
         default = null;
         example = {
           Appearance = {

--- a/modules/widgets/battery.nix
+++ b/modules/widgets/battery.nix
@@ -14,7 +14,7 @@ in {
         description = "Enable to show the battery percentage as a small label over the battery icon.";
       };
       settings = lib.mkOption {
-        type = configValueType;
+        type = types.nullOr configValueType;
         default = null;
         example = {
           General = {

--- a/modules/widgets/battery.nix
+++ b/modules/widgets/battery.nix
@@ -14,7 +14,7 @@ in {
         description = "Enable to show the battery percentage as a small label over the battery icon.";
       };
       settings = lib.mkOption {
-        type = types.nullOr configValueType;
+        type = lib.types.nullOr configValueType;
         default = null;
         example = {
           General = {

--- a/modules/widgets/battery.nix
+++ b/modules/widgets/battery.nix
@@ -1,4 +1,7 @@
-{ lib, ... }: {
+{ lib, ... }:
+let
+  inherit (import ./lib.nix { inherit lib; }) configValueType;
+in {
   battery = {
     description = "The battery indicator widget.";
 
@@ -11,7 +14,7 @@
         description = "Enable to show the battery percentage as a small label over the battery icon.";
       };
       settings = lib.mkOption {
-        type = with lib.types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        type = configValueType;
         default = null;
         example = {
           General = {

--- a/modules/widgets/digital-clock.nix
+++ b/modules/widgets/digital-clock.nix
@@ -1,6 +1,7 @@
 { lib, ... }:
 let
   inherit (lib) mkOption types;
+  inherit (import ./lib.nix { inherit lib; }) configValueType;
 
   mkBoolOption = description: mkOption {
     type = with types; nullOr bool;
@@ -220,7 +221,7 @@ in
           };
       };
       settings = mkOption {
-        type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        type = configValueType;
         default = null;
         example = {
           Appearance = {

--- a/modules/widgets/digital-clock.nix
+++ b/modules/widgets/digital-clock.nix
@@ -221,7 +221,7 @@ in
           };
       };
       settings = mkOption {
-        type = configValueType;
+        type = types.nullOr configValueType;
         default = null;
         example = {
           Appearance = {

--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -134,7 +134,7 @@ in
         };
       };
       settings = mkOption {
-        type = configValueType;
+        type = types.nullOr configValueType;
         default = null;
         example = {
           General = {

--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -1,6 +1,7 @@
 { lib, ... }:
 let
   inherit (lib) mkOption types;
+  inherit (import ./lib.nix { inherit lib; }) configValueType;
 
   mkBoolOption = description: mkOption {
     type = with types; nullOr bool;
@@ -133,7 +134,7 @@ in
         };
       };
       settings = mkOption {
-        type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        type = configValueType;
         default = null;
         example = {
           General = {

--- a/modules/widgets/keyboard-layout.nix
+++ b/modules/widgets/keyboard-layout.nix
@@ -26,7 +26,7 @@ in
           apply = getIndexFromEnum enumVals;
         };
       settings = lib.mkOption {
-        type = configValueType;
+        type = lib.types.nullOr configValueType;
         default = null;
         example = {
           General = {

--- a/modules/widgets/keyboard-layout.nix
+++ b/modules/widgets/keyboard-layout.nix
@@ -1,5 +1,7 @@
 { lib, ... }:
 let
+  inherit (import ./lib.nix { inherit lib; }) configValueType;
+
   getIndexFromEnum = enum: value:
     if value == null
     then null
@@ -24,7 +26,7 @@ in
           apply = getIndexFromEnum enumVals;
         };
       settings = lib.mkOption {
-        type = with lib.types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        type = configValueType;
         default = null;
         example = {
           General = {

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -83,6 +83,16 @@ in
         };
       showActionButtonCaptions = mkBoolOption "Whether to display captions ('shut down', 'log out', etc.) for the footer action buttons";
       pin = mkBoolOption "Whether the popup should remain open when another window is activated.";
+      popupHeight = mkOption {
+        type = with types; ints.positive;
+        default = null;
+        example = 500;
+      };
+      popupWidth = mkOption {
+        type = with types; ints.positive;
+        default = null;
+        example = 700;
+      };
       settings = mkOption {
         type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
         default = null;
@@ -106,10 +116,15 @@ in
       , showButtonsFor
       , showActionButtonCaptions
       , pin
+      , popupHeight
+      , popupWidth
       , settings
       }: {
         name = "org.kde.plasma.kickoff";
         config = lib.recursiveUpdate {
+          popupHeight = popupHeight;
+          popupWidth = popupWidth;
+
           General = lib.filterAttrs (_: v: v != null) (
             {
               inherit icon pin;

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -1,6 +1,7 @@
 { lib, ... }:
 let
   inherit (lib) mkOption types;
+  inherit (import ./lib.nix { inherit lib; }) configValueType;
 
   mkBoolOption = description: mkOption {
     type = with types; nullOr bool;
@@ -94,12 +95,13 @@ in
         example = 700;
       };
       settings = mkOption {
-        type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        type = configValueType;
         default = null;
         example = {
           General = {
             icon = "nix-snowflake-white";
           };
+          popupHeight = 500;
         };
         description = "Extra configuration options for the widget.";
         apply = settings: if settings == null then {} else settings;

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -84,12 +84,12 @@ in
       showActionButtonCaptions = mkBoolOption "Whether to display captions ('shut down', 'log out', etc.) for the footer action buttons";
       pin = mkBoolOption "Whether the popup should remain open when another window is activated.";
       popupHeight = mkOption {
-        type = with types; ints.positive;
+        type = with types; nullOr ints.positive;
         default = null;
         example = 500;
       };
       popupWidth = mkOption {
-        type = with types; ints.positive;
+        type = with types; nullOr ints.positive;
         default = null;
         example = 700;
       };

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -95,7 +95,7 @@ in
         example = 700;
       };
       settings = mkOption {
-        type = configValueType;
+        type = types.nullOr configValueType;
         default = null;
         example = {
           General = {

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -123,12 +123,12 @@ in
       , settings
       }: {
         name = "org.kde.plasma.kickoff";
-        config = lib.recursiveUpdate {
-          popupHeight = popupHeight;
-          popupWidth = popupWidth;
+        config = lib.recursiveUpdate
+          (lib.filterAttrsRecursive (_: v: v != null) {
+            popupHeight = popupHeight;
+            popupWidth = popupWidth;
 
-          General = lib.filterAttrs (_: v: v != null) (
-            {
+            General = {
               inherit icon pin;
 
               menuLabel = label;
@@ -139,9 +139,8 @@ in
               applicationsDisplay = applicationsDisplayMode;
               primaryActions = showButtonsFor;
               showActionButtonCaptions = showActionButtonCaptions;
-            }
-          );
-        } settings;
+            };
+        }) settings;
       };
   };
 }

--- a/modules/widgets/plasma-panel-colorizer.nix
+++ b/modules/widgets/plasma-panel-colorizer.nix
@@ -698,7 +698,7 @@ in
         };
       };
       settings = mkOption {
-        type = configValueType;
+        type = types.nullOr configValueType;
         default = null;
         example = {
           General = {

--- a/modules/widgets/plasma-panel-colorizer.nix
+++ b/modules/widgets/plasma-panel-colorizer.nix
@@ -1,6 +1,7 @@
 { lib, ... }:
 let
   inherit (lib) mkOption types;
+  inherit (import ./lib.nix { inherit lib; }) configValueType;
 
   mkBoolOption = description:
     mkOption {
@@ -697,7 +698,7 @@ in
         };
       };
       settings = mkOption {
-        type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        type = configValueType;
         default = null;
         example = {
           General = {

--- a/modules/widgets/plasmusic-toolbar.nix
+++ b/modules/widgets/plasmusic-toolbar.nix
@@ -293,7 +293,7 @@ in
         apply = font: if font == null then null else qfont.fontToString font;
       };
       settings = mkOption {
-        type = configValueType;
+        type = types.nullOr configValueType;
         default = null;
         example = {
           General = {

--- a/modules/widgets/plasmusic-toolbar.nix
+++ b/modules/widgets/plasmusic-toolbar.nix
@@ -1,6 +1,8 @@
 { lib, ... }:
 let
   inherit (lib) mkOption types;
+  inherit (import ./lib.nix { inherit lib; }) configValueType;
+
   qfont = import ../../lib/qfont.nix { inherit lib; };
 
   mkBoolOption = description: lib.mkOption {
@@ -291,7 +293,7 @@ in
         apply = font: if font == null then null else qfont.fontToString font;
       };
       settings = mkOption {
-        type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        type = configValueType;
         default = null;
         example = {
           General = {

--- a/modules/widgets/system-monitor.nix
+++ b/modules/widgets/system-monitor.nix
@@ -1,6 +1,7 @@
 { lib, ... }:
 let
   inherit (lib) mkOption types;
+  inherit (import ./lib.nix { inherit lib; }) configValueType;
 
   # KDE expects a key/value pair like this:
   # ```ini
@@ -137,7 +138,7 @@ in
         };
       };
       settings = mkOption {
-        type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        type = configValueType;
         default = null;
         description = "Extra configuration options for the widget.";
         apply = settings: if settings == null then {} else settings;

--- a/modules/widgets/system-monitor.nix
+++ b/modules/widgets/system-monitor.nix
@@ -138,7 +138,7 @@ in
         };
       };
       settings = mkOption {
-        type = configValueType;
+        type = types.nullOr configValueType;
         default = null;
         description = "Extra configuration options for the widget.";
         apply = settings: if settings == null then {} else settings;

--- a/modules/widgets/system-tray.nix
+++ b/modules/widgets/system-tray.nix
@@ -154,7 +154,7 @@ in
         };
       };
       settings = mkOption {
-        type = configValueType;
+        type = types.nullOr configValueType;
         default = null;
         description = "Extra configuration options for the widget.";
         apply = settings: if settings == null then {} else settings;

--- a/modules/widgets/system-tray.nix
+++ b/modules/widgets/system-tray.nix
@@ -1,6 +1,7 @@
 { lib, widgets, ... }:
 let
   inherit (lib) mkOption types;
+  inherit (import ./lib.nix { inherit lib; }) configValueType;
 
   mkBoolOption = description: mkOption {
     type = with types; nullOr bool;
@@ -153,7 +154,7 @@ in
         };
       };
       settings = mkOption {
-        type = with types; nullOr (attrsOf (attrsOf (either (oneOf [ bool float int str ]) (listOf (oneOf [ bool float int str ])))));
+        type = configValueType;
         default = null;
         description = "Extra configuration options for the widget.";
         apply = settings: if settings == null then {} else settings;


### PR DESCRIPTION
This pull request adds support for generating JavaScript to configure top level widget settings and uses this to allow configuring kickoff's `popupHeight` and `popupWidth`.

For

```nix
programs.plasma.panels = [
  {
    widgets = [
      {
        kickoff = {
          popupHeight = 510;
          popupWidth = 778;
        };
      }
    ];
  }
];
```

the resulting JavaScript is

```js
panelWidgets["org.kde.plasma.kickoff"] = panel.addWidget("org.kde.plasma.kickoff");
var w = panelWidgets["org.kde.plasma.kickoff"];
w.currentConfigGroup = [];
w.writeConfig("popupHeight", 510);
w.writeConfig("popupWidth", 778);
```

and the config looks like this

```ini
[Containments][1694][Applets][1695][Configuration]
popupHeight=510
popupWidth=778
# ...

[Containments][1694][Applets][1695][Configuration][General]
# ...
```