### PR TITLE
Added the ability to disable some animations

### DIFF
--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -73,7 +73,7 @@ let
         (x: x == value)
         (throw "getIndexFromEnum (kwin): Value ${value} isn't present in the enum. This is a bug")
         enum;
-  
+
   convertPoloniumFilter = list:
     if list == null
     then null
@@ -361,14 +361,16 @@ in
           };
           layout = {
             engine =
-              let enumVals = [
-                "binaryTree"
-                "half"
-                "threeColumn"
-                "monocle"
-                "kwin"
-              ];
-              in mkOption {
+              let
+                enumVals = [
+                  "binaryTree"
+                  "half"
+                  "threeColumn"
+                  "monocle"
+                  "kwin"
+                ];
+              in
+              mkOption {
                 type = with types; nullOr (enum enumVals);
                 default = null;
                 example = "binaryTree";

--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -117,7 +117,7 @@ in
       };
       minimization = {
         animation = mkOption {
-          type = with types; nullOr (enum [ "squash" "magiclamp" ]);
+          type = with types; nullOr (enum [ "squash" "magiclamp" "off" ]);
           default = null;
           example = "magiclamp";
           description = "The effect when windows are minimized.";
@@ -148,14 +148,14 @@ in
         description = "Arrange desktops in a virtual cube.";
       };
       desktopSwitching.animation = mkOption {
-        type = with types; nullOr (enum [ "fade" "slide" ]);
+        type = with types; nullOr (enum [ "fade" "slide" "off" ]);
         default = null;
         example = "fade";
         description = "The animation used when switching virtual desktop.";
       };
       windowOpenClose = {
         animation = mkOption {
-          type = with types; nullOr (enum [ "fade" "glide" "scale" ]);
+          type = with types; nullOr (enum [ "fade" "glide" "scale" "off" ]);
           default = null;
           example = "glide";
           description = "The animation used when opening/closing windows.";


### PR DESCRIPTION
Although the changed settings use radio buttons, the animations can be disabled by deselecting the active radio button. These additions should work as is, as disabling an animation just disables the default option in the config file. I am currently unable to test the change though, as I’m having some problems with my NixOS configuration. 🙈

The settings written to the config file are the following (by setting them through system settings):

- `minimization.animation`:
  - Squash: section missing
  - Magic lamp:
    ```ini
    [Plugins]
    magiclampEnabled=true
    squashEnabled=false
    ```
  - Off:
    ```ini
    [Plugins]
    squashEnabled=false
    ```
- `desktopSwitching.animation`:
  - Slide: section missing
  - Fade:
    ```ini
    [Plugins]
    fadedesktopEnabled=true
    slideEnabled=false
    ```
  - Off:
    ```ini
    [Plugins]
    slideEnabled=false
    ```
- `windowOpenClose.animation`:
  - Scale: section missing
  - Fade:
    ```ini
    [Plugins]
    fadeEnabled=true
    scaleEnabled=false
    ```
  - Glide:
    ```ini
    [Plugins]
    glideEnabled=true
    scaleEnabled=false
    ```
  - Off:
    ```ini
    [Plugins]
    scaleEnabled=false
    ```
