### PR TITLE
flake.nix: add docs-html and docs-json packages

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -42,4 +42,5 @@ let
 in
 {
   html = plasma-manager-options;
+  json = pmOptionsDoc.optionsJSON;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -30,8 +30,13 @@
       };
 
       packages = forAllSystems (system:
-        let pkgs = nixpkgsFor.${system}; in
-        {
+        let
+          pkgs = nixpkgsFor.${system};
+          docs = import ./docs {
+            inherit pkgs;
+            lib = pkgs.lib;
+          };
+        in {
           default = self.packages.${system}.rc2nix;
 
           demo = (inputs.nixpkgs.lib.nixosSystem {
@@ -44,6 +49,9 @@
               (_: { environment.systemPackages = [ self.packages.${system}.rc2nix ]; })
             ];
           }).config.system.build.vm;
+
+          docs-html = docs.html;
+          docs-json = docs.json;
 
           rc2nix = pkgs.writeShellApplication {
             name = "rc2nix";


### PR DESCRIPTION
This patchset adds two packages inside the Nix flake: `docs-html` and `docs-json`.

Exposing `docs-json` enables the use of [home-manager-option-search](https://github.com/mipmip/home-manager-option-search) to index plasma-manager options.
