### PR TITLE
Fix data type for icon-tasks

### DIFF
--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -123,10 +123,17 @@ in
           onlyInCurrentDesktop = mkBoolOption "Whether to only show tasks that are on the current virtual desktop.";
           onlyInCurrentActivity = mkBoolOption "Whether to show only tasks that are on the current activity.";
           onlyMinimized = mkOption {
-            type = types.nullOr types.ints.positive;
+            type = types.nullOr types.bool;
             default = null;
-            example = 1;
+            example = true;
             description = "Whether to show only window tasks that are minimized.";
+            apply = onlyMinimized:
+              if onlyMinimized == null
+              then null
+              else
+                if onlyMinimized == true
+                then 1
+                else 0
           };
         };
         unhideOnAttentionNeeded = mkBoolOption "Whether to unhide if a window wants attention.";

--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -122,7 +122,12 @@ in
           onlyInCurrentScreen = mkBoolOption "Whether to show only window tasks that are on the same screen as the widget.";
           onlyInCurrentDesktop = mkBoolOption "Whether to only show tasks that are on the current virtual desktop.";
           onlyInCurrentActivity = mkBoolOption "Whether to show only tasks that are on the current activity.";
-          onlyMinimized = mkBoolOption "Whether to show only window tasks that are minimized.";
+          onlyMinimized = mkOption {
+            type = types.nullOr types.ints.positive;
+            default = null;
+            example = 1;
+            description = "Whether to show only window tasks that are minimized.";
+          };
         };
         unhideOnAttentionNeeded = mkBoolOption "Whether to unhide if a window wants attention.";
         newTasksAppearOn = mkOption {

--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -133,7 +133,7 @@ in
               else
                 if onlyMinimized == true
                 then 1
-                else 0
+                else 0;
           };
         };
         unhideOnAttentionNeeded = mkBoolOption "Whether to unhide if a window wants attention.";


### PR DESCRIPTION
Believe it or not: of the four filter options for the icon-tasks widget the `showOnlyMinimized` option is in fact not a bool, but an integer according to [this](https://invent.kde.org/plasma/plasma-desktop/-/blob/02726a1ca0189f71f46513078cbc82af9daa9425/applets/taskmanager/package/contents/config/main.xml). Note that the default value is set to `false` regardless which seems to be interpreted as `0` (just as true is). 

While this feels like a bug and will be reported the module in `icon-tasks.nix` for the time being does not have the desired effect when setting `behavior.showTasks.onlyMinimized = true`.