### PR TITLE
Revert "Fix onlyMinimized option for icon-tasks"

### DIFF
--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -122,19 +122,7 @@ in
           onlyInCurrentScreen = mkBoolOption "Whether to show only window tasks that are on the same screen as the widget.";
           onlyInCurrentDesktop = mkBoolOption "Whether to only show tasks that are on the current virtual desktop.";
           onlyInCurrentActivity = mkBoolOption "Whether to show only tasks that are on the current activity.";
-          onlyMinimized = mkOption {
-            type = types.nullOr types.bool;
-            default = null;
-            example = true;
-            description = "Whether to show only window tasks that are minimized.";
-            apply = onlyMinimized:
-              if onlyMinimized == null
-              then null
-              else
-                if onlyMinimized == true
-                then 1
-                else 0;
-          };
+          onlyMinimized = mkBoolOption "Whether to show only window tasks that are minimized.";
         };
         unhideOnAttentionNeeded = mkBoolOption "Whether to unhide if a window wants attention.";
         newTasksAppearOn = mkOption {


### PR DESCRIPTION
This reverts commit df4d1d36d0c29d3cc655c4e35d0f6ebecd6d7303. 

As it has been fixed upstream in: https://invent.kde.org/plasma/plasma-desktop/-/merge_requests/2457

We should wait until plasma 6.2.0 release