### PR TITLE
Add module for KRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ At the moment `plasma-manager` supports configuring the following:
 - Hotkeys (via the `hotkeys` module)
 - Panels and Extra Widgets (via the `panels` module)
 - Keyboards, Touchpads and Mice (via the `input` module)
+- KRunner (via the `krunner` module)
 - Screen locker (via the `kscreenlocker` module)
 - Fonts (via the `fonts` module)
 - Window Rules (via the `window-rules` module)
 - KDE apps (via the `apps` module). In particular the following kde apps have
   modules in `plasma-manager`:
+  - ghostwriter
   - kate
   - konsole
   - okular

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -8,6 +8,7 @@
     ./fonts.nix
     ./hotkeys.nix
     ./input.nix
+    ./krunner.nix
     ./kscreenlocker.nix
     ./kwin.nix
     ./panels.nix

--- a/modules/krunner.nix
+++ b/modules/krunner.nix
@@ -8,13 +8,13 @@ in {
       example = "center";
       description = "Position of KRunner on screen.";
     };
-    activateWhenTypingOnDesktop = mkOption {
+    activateWhenTypingOnDesktop = lib.mkOption {
       type = with lib.types; nullOr bool;
       default = null;
       example = true;
       description = "Activate KRunner when typing on the desktop.";
     };
-    historyBehavior = mkOption {
+    historyBehavior = lib.mkOption {
       type = with lib.types;
         nullOr (enum [ "disabled" "enableSuggestions" "enableAutoComplete" ]);
       default = null;

--- a/modules/krunner.nix
+++ b/modules/krunner.nix
@@ -1,43 +1,44 @@
 { config, lib, ... }:
 let cfg = config.programs.plasma;
-in with lib; {
+in {
   options.programs.plasma.krunner = {
-    position = mkOption {
-      type = with types; nullOr (enum [ "Top" "Center" ]);
+    position = lib.mkOption {
+      type = with lib.types; nullOr (enum [ "top" "center" ]);
       default = null;
-      example = "Center";
+      example = "center";
       description = "Position of KRunner on screen.";
     };
     activateWhenTypingOnDesktop = mkOption {
-      type = with types; nullOr bool;
+      type = with lib.types; nullOr bool;
       default = null;
+      example = true;
       description = "Activate KRunner when typing on the desktop.";
     };
     historyBehavior = mkOption {
-      type = with types;
-        nullOr (enum [ "Disabled" "EnableSuggestions" "EnableAutoComplete" ]);
+      type = with lib.types;
+        nullOr (enum [ "disabled" "enableSuggestions" "enableAutoComplete" ]);
       default = null;
-      example = "Disabled";
+      example = "disabled";
       description = "Behavior of KRunner’s history.";
     };
   };
 
-  config.programs.plasma.configFile."krunnerrc" = (mkMerge [
-    (mkIf (cfg.krunner.position != null) {
-      General.FreeFloating = cfg.krunner.position == "Center";
+  config.programs.plasma.configFile."krunnerrc" = (lib.mkMerge [
+    (lib.mkIf (cfg.krunner.position != null) {
+      General.FreeFloating = cfg.krunner.position == "center";
     })
-    (mkIf (cfg.krunner.activateWhenTypingOnDesktop != null) {
+    (lib.mkIf (cfg.krunner.activateWhenTypingOnDesktop != null) {
       General.ActivateWhenTypingOnDesktop =
         cfg.krunner.activateWhenTypingOnDesktop;
     })
-    (mkIf (cfg.krunner.historyBehavior != null) {
+    (lib.mkIf (cfg.krunner.historyBehavior != null) {
       General.historyBehavior =
-        (if cfg.krunner.historyBehavior == "EnableSuggestions" then
+        (if cfg.krunner.historyBehavior == "enableSuggestions" then
           "CompletionSuggestion"
-        else if cfg.krunner.historyBehavior == "EnableAutoComplete" then
+        else if cfg.krunner.historyBehavior == "enableAutoComplete" then
           "ImmediateCompletion"
         else
-          cfg.krunner.historyBehavior);
+          "Disabled");
     })
   ]);
 }

--- a/modules/krunner.nix
+++ b/modules/krunner.nix
@@ -1,0 +1,43 @@
+{ config, lib, ... }:
+let cfg = config.programs.plasma;
+in with lib; {
+  options.programs.plasma.krunner = {
+    position = mkOption {
+      type = with types; nullOr (enum [ "Top" "Center" ]);
+      default = null;
+      example = "Center";
+      description = "Position of KRunner on screen.";
+    };
+    activateWhenTypingOnDesktop = mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      description = "Activate KRunner when typing on the desktop.";
+    };
+    historyBehavior = mkOption {
+      type = with types;
+        nullOr (enum [ "Disabled" "EnableSuggestions" "EnableAutoComplete" ]);
+      default = null;
+      example = "Disabled";
+      description = "Behavior of KRunner’s history.";
+    };
+  };
+
+  config.programs.plasma.configFile."krunnerrc" = (mkMerge [
+    (mkIf (cfg.krunner.position != null) {
+      General.FreeFloating = cfg.krunner.position == "Center";
+    })
+    (mkIf (cfg.krunner.activateWhenTypingOnDesktop != null) {
+      General.ActivateWhenTypingOnDesktop =
+        cfg.krunner.activateWhenTypingOnDesktop;
+    })
+    (mkIf (cfg.krunner.historyBehavior != null) {
+      General.historyBehavior =
+        (if cfg.krunner.historyBehavior == "EnableSuggestions" then
+          "CompletionSuggestion"
+        else if cfg.krunner.historyBehavior == "EnableAutoComplete" then
+          "ImmediateCompletion"
+        else
+          cfg.krunner.historyBehavior);
+    })
+  ]);
+}


### PR DESCRIPTION
Added a basic module for KRunner, basically only the options available in its configuration window (none for its search results, for example). From my testing, it seems to work. The module is formatted according to `nixpkgs-fmt`.