### PR TITLE
Lots of refactoring around startup-scripts

### DIFF
--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -154,7 +154,7 @@ let
     };
   });
 
-  anyPanelSet = ((builtins.length cfg.panels) > 0);
+  anyPanelSet = (builtins.length cfg.panels) > 0;
 in
 {
   imports = [

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -5,10 +5,7 @@
 } @ args:
 let
   cfg = config.programs.plasma;
-  inherit (import ../lib/wallpapers.nix { inherit lib; }) wallpaperFillModeTypes;
-
   desktopWidgets = if cfg.desktop.widgets != null then cfg.desktop.widgets else [ ];
-
   hasWidget = widgetName:
     builtins.any (panel: builtins.any (widget: widget.name == widgetName) panel.widgets) cfg.panels ||
     builtins.any (widget: widget.name == widgetName) desktopWidgets;

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -7,8 +7,8 @@ let
   cfg = config.programs.plasma;
   inherit (import ../lib/wallpapers.nix { inherit lib; }) wallpaperFillModeTypes;
 
-  desktopWidgets = if cfg.desktop.widgets != null then cfg.desktop.widgets else [];
-  
+  desktopWidgets = if cfg.desktop.widgets != null then cfg.desktop.widgets else [ ];
+
   hasWidget = widgetName:
     builtins.any (panel: builtins.any (widget: widget.name == widgetName) panel.widgets) cfg.panels ||
     builtins.any (widget: widget.name == widgetName) desktopWidgets;
@@ -157,11 +157,7 @@ let
     };
   });
 
-  anyPanelOrWallpaperSet = ((cfg.workspace.wallpaper != null) ||
-    (cfg.workspace.wallpaperSlideShow != null) ||
-    (cfg.workspace.wallpaperPictureOfTheDay != null) ||
-    (cfg.workspace.wallpaperPlainColor != null) ||
-    ((builtins.length cfg.panels) > 0));
+  anyPanelSet = ((builtins.length cfg.panels) > 0);
 in
 {
   imports = [
@@ -173,80 +169,31 @@ in
     default = [ ];
   };
 
-  # Wallpaper and panels are in the same script since the resetting of the
-  # panels in the panels-script also has a tendency to reset the wallpaper, so
-  # these should run at the same time.
   config = (lib.mkIf cfg.enable {
     home.packages = (lib.flatten (lib.filter (x: x != null)
       (lib.mapAttrsToList
         (widgetName: packages: if (hasWidget widgetName) then packages else null)
         additionalWidgetPackages)));
 
-    programs.plasma.startup.desktopScript."panels_and_wallpaper" = (lib.mkIf anyPanelOrWallpaperSet
+    programs.plasma.startup.desktopScript."panels" = (lib.mkIf anyPanelSet
       (
         let
-          anyPanels = ((builtins.length cfg.panels) > 0);
           anyNonDefaultScreens = ((builtins.any (panel: panel.screen != null)) cfg.panels);
-          panelPreCMD = (if anyPanels then ''
+          panelPreCMD = ''
             # We delete plasma-org.kde.plasma.desktop-appletsrc to hinder it
             # growing indefinitely. See:
             # https://github.com/nix-community/plasma-manager/issues/76
             [ -f ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc ] && rm ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc
-          '' else "");
-          panelLayoutStr = (if anyPanels then (import ../lib/panel.nix { inherit lib; inherit config; }) else "");
+          '';
+          panelLayoutStr = (import ../lib/panel.nix { inherit lib; inherit config; });
           panelPostCMD = (if anyNonDefaultScreens then ''
             sed -i 's/^lastScreen\\x5b$i\\x5d=/lastScreen[$i]=/' ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc
           '' else "");
-          # This meaningless comment inserts the URL into the desktop-script
-          # which means that when the wallpaper is updated, the sha256 hash
-          # changes and the script will be re-run.
-          wallpaperDesktopScript = (if (cfg.workspace.wallpaper != null) then ''
-            // Wallpaper to set later: ${cfg.workspace.wallpaper}
-          '' else "");
-          wallpaperPostCMD = (if (cfg.workspace.wallpaper != null) then ''
-            plasma-apply-wallpaperimage ${cfg.workspace.wallpaper}
-          '' else "");
-          wallpaperSlideShow = (if (cfg.workspace.wallpaperSlideShow != null) then ''
-            // Wallpaper slideshow
-            let allDesktops = desktops();
-            for (var desktopIndex = 0; desktopIndex < allDesktops.length; desktopIndex++) {
-                var desktop = allDesktops[desktopIndex];
-                desktop.wallpaperPlugin = "org.kde.slideshow";
-                desktop.currentConfigGroup = Array("Wallpaper", "org.kde.slideshow", "General");
-                desktop.writeConfig("SlidePaths", ${with cfg.workspace.wallpaperSlideShow; if ((builtins.isPath path) || (builtins.isString path)) then
-                  "\"" + (builtins.toString path) + "\"" else
-                  "[" + (builtins.concatStringsSep "," (map (s: "\"" + s + "\"") path)) + "]"});
-                desktop.writeConfig("SlideInterval", "${builtins.toString cfg.workspace.wallpaperSlideShow.interval}");
-                ${lib.optionalString (cfg.workspace.wallpaperFillMode != null) ''desktop.writeConfig("FillMode", "${cfg.workspace.wallpaperFillMode}");''}
-            }
-          '' else "");
-          wallpaperPOTD = (if (cfg.workspace.wallpaperPictureOfTheDay != null) then ''
-            // Wallpaper POTD
-            let allDesktops = desktops();
-            for (const desktop of allDesktops) {
-                desktop.wallpaperPlugin = "org.kde.potd";
-                desktop.currentConfigGroup = ["Wallpaper", "org.kde.potd", "General"];
-                desktop.writeConfig("Provider", "${cfg.workspace.wallpaperPictureOfTheDay.provider}");
-                desktop.writeConfig("UpdateOverMeteredConnection", "${if (cfg.workspace.wallpaperPictureOfTheDay.updateOverMeteredConnection) then "1" else "0"}");
-                ${lib.optionalString (cfg.workspace.wallpaperFillMode != null) ''desktop.writeConfig("FillMode", "${cfg.workspace.wallpaperFillMode}");''}
-              }
-          '' else "");
-          wallpaperPlainColor = (if (cfg.workspace.wallpaperPlainColor != null) then ''
-            // Wallpaper plain color
-            let allDesktops = desktops();
-            for (var desktopIndex = 0; desktopIndex < allDesktops.length; desktopIndex++) {
-                var desktop = allDesktops[desktopIndex];
-                desktop.wallpaperPlugin = "org.kde.color";
-                desktop.currentConfigGroup = Array("Wallpaper", "org.kde.color", "General");
-                desktop.writeConfig("Color", "${cfg.workspace.wallpaperPlainColor}");
-            }
-          '' else ""
-          );
         in
         {
           preCommands = panelPreCMD;
-          text = panelLayoutStr + wallpaperDesktopScript + wallpaperSlideShow + wallpaperPOTD + wallpaperPlainColor;
-          postCommands = panelPostCMD + wallpaperPostCMD;
+          text = panelLayoutStr;
+          postCommands = panelPostCMD;
           restartServices =
             (lib.unique (if anyNonDefaultScreens then [ "plasma-plasmashell" ] else [ ])
               ++ (lib.filter (service: shouldRestart service) (builtins.attrNames serviceRestarts)));

--- a/modules/startup.nix
+++ b/modules/startup.nix
@@ -223,7 +223,7 @@ in
         fi
       done
 
-      [ should_reset = 1 ] && rm ${config.xdg.dataHome}/plasma-manager/last_run_desktop_script_*
+      [ $should_reset = 1 ] && rm ${config.xdg.dataHome}/plasma-manager/last_run_desktop_script_*
     '';
     runAlways = true;
   };

--- a/modules/startup.nix
+++ b/modules/startup.nix
@@ -19,12 +19,22 @@ let
     default = [ ];
     description = "Services to restart after the script has been run.";
   };
+  runAlwaysOption = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    example = true;
+    description = ''
+      When enabled the script will run even if no changes have been made
+      since last successful run.
+    '';
+  };
 
   startupScriptType = lib.types.submodule {
     options = {
       text = textOption;
       priority = priorityOption;
       restartServices = restartServicesOption;
+      runAlways = runAlwaysOption;
     };
   };
   desktopScriptType = lib.types.submodule {
@@ -32,6 +42,7 @@ let
       text = textOption;
       priority = priorityOption;
       restartServices = restartServicesOption;
+      runAlways = runAlwaysOption;
       preCommands = lib.mkOption {
         type = lib.types.str;
         description = "Commands to run before the desktop script lines.";
@@ -45,25 +56,35 @@ let
     };
   };
 
+  createScriptContentRunOnce = name: sha256sumFile: script: text: ''
+    last_update="$(sha256sum ${sha256sumFile})"
+    last_update_file=${config.xdg.dataHome}/plasma-manager/last_run_${name}
+    if [ -f "$last_update_file" ]; then
+      stored_last_update=$(cat "$last_update_file")
+    fi
+
+    if ! [ "$last_update" = "$stored_last_update" ]; then
+      echo "Running script: ${name}"
+      success=1
+      trap 'success=0' ERR
+      ${text}
+      if [ $success -eq 1 ]; then
+        echo "$last_update" > "$last_update_file"
+        ${builtins.concatStringsSep "\n" (map (s: "echo ${s} >> ${config.xdg.dataHome}/plasma-manager/services_to_restart") script.restartServices)}
+      fi
+    fi
+  '';
+
+  createScriptContentRunAlways = name: text: ''
+    echo "Running script: ${name}"
+    ${text}
+  '';
+
   createScriptContent = name: sha256sumFile: script: text: {
     "plasma-manager/${cfg.startup.scriptsDir}/${builtins.toString script.priority}_${name}.sh" = {
       text = ''
         #!/bin/sh
-        last_update="$(sha256sum ${sha256sumFile})"
-        last_update_file=${config.xdg.dataHome}/plasma-manager/last_run_${name}
-        if [ -f "$last_update_file" ]; then
-          stored_last_update=$(cat "$last_update_file")
-        fi
-
-        if ! [ "$last_update" = "$stored_last_update" ]; then
-          success=1
-          trap 'success=0' ERR
-          ${text}
-          if [ $success -eq 1 ]; then
-            echo "$last_update" > "$last_update_file"
-            ${builtins.concatStringsSep "\n" (map (s: "echo ${s} >> ${config.xdg.dataHome}/plasma-manager/services_to_restart") script.restartServices)}
-          fi
-        fi
+        ${if script.runAlways then (createScriptContentRunAlways name text) else (createScriptContentRunOnce name sha256sumFile script text)}
       '';
       executable = true;
     };
@@ -111,7 +132,7 @@ in
         # Autostart scripts
         (lib.mkMerge
           (lib.mapAttrsToList
-            (name: script: createScriptContent name "$0" script script.text)
+            (name: script: createScriptContent "script_${name}" "$0" script script.text)
             cfg.startup.startupScript))
         # Desktop scripts
         (lib.mkMerge
@@ -156,7 +177,7 @@ in
               if [ -f $services_restart_file ]; then rm $services_restart_file; fi
 
               for script in ${config.xdg.dataHome}/plasma-manager/${cfg.startup.scriptsDir}/*.sh; do
-                  [ -x "$script" ] && $script
+                [ -x "$script" ] && $script
               done
 
               # Restart the services
@@ -179,4 +200,31 @@ in
         X-KDE-autostart-condition=ksmserver
       '';
     };
+
+  # Due to the fact that running certain desktop-scripts can reset what has
+  # been applied by other desktop-script (for example running the panel
+  # desktop-script will reset the wallpaper), we make it so that if any of the
+  # desktop-scripts have been modified, that we must re-run all the
+  # desktop-scripts, not just the ones who have been changed.
+  config.programs.plasma.startup.startupScript."reset_lastrun_desktopscripts" = lib.mkIf (cfg.startup.desktopScript != { }) {
+    text = ''
+      should_reset=0
+      for ds in ${config.xdg.dataHome}/plasma-manager/data/desktop_script_*.js; do
+        ds_name="$(basename $ds)"
+        ds_name="''${ds_name%.js}"
+        ds_shafile="${config.xdg.dataHome}/plasma-manager/last_run_"$ds_name
+
+        if ! [ -f "$ds_shafile" ]; then
+          echo "Resetting desktop-script last_run-files since $ds_name is a new desktop-script"
+          should_reset=1
+        elif ! [ "$(cat $ds_shafile)" = "$(sha256sum $ds)" ]; then
+          echo "Resetting desktop-script last_run-files since $ds_name has changed content"
+          should_reset=1
+        fi
+      done
+
+      [ should_reset = 1 ] && rm ${config.xdg.dataHome}/plasma-manager/last_run_desktop_script_*
+    '';
+    runAlways = true;
+  };
 }

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -316,7 +316,7 @@ in
         postCommands = ''
           plasma-apply-wallpaperimage ${cfg.workspace.wallpaper}
         '';
-        priority = 2;
+        priority = 3;
       });
 
       desktopScript."wallpaper_potd" = (lib.mkIf (cfg.workspace.wallpaperPictureOfTheDay != null) {
@@ -331,7 +331,7 @@ in
               ${lib.optionalString (cfg.workspace.wallpaperFillMode != null) ''desktop.writeConfig("FillMode", "${cfg.workspace.wallpaperFillMode}");''}
           }
         '';
-        priority = 2;
+        priority = 3;
       });
 
       desktopScript."wallpaper_plaincolor" = (lib.mkIf (cfg.workspace.wallpaperPlainColor != null) {
@@ -345,7 +345,7 @@ in
               desktop.writeConfig("Color", "${cfg.workspace.wallpaperPlainColor}");
           }
         '';
-        priority = 2;
+        priority = 3;
       });
 
       desktopScript."wallpaper_slideshow" = (lib.mkIf (cfg.workspace.wallpaperSlideShow != null) {
@@ -363,7 +363,7 @@ in
               ${lib.optionalString (cfg.workspace.wallpaperFillMode != null) ''desktop.writeConfig("FillMode", "${cfg.workspace.wallpaperFillMode}");''}
           }
         '';
-        priority = 2;
+        priority = 3;
       });
     };
   });

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -313,7 +313,7 @@ in
         # wallpaper changes, the sha256sum also changes for the js file, which
         # gives us the correct behavior with last_run files.
         text = "// Wallpaper to set later: ${cfg.workspace.wallpaper}";
-        postCMD = ''
+        postCommands = ''
           plasma-apply-wallpaperimage ${cfg.workspace.wallpaper}
         '';
         priority = 2;


### PR DESCRIPTION
Added a `runAlways` option for startup-scripts and desktop-scripts which is intended to be used for scripts which must run at every login. Also split the wallpapers and panels script into different scripts and not the same as was the case before (even though it wasn't really intuitive).
Furthermore, since it's a known problem that running only some of the desktop-scripts may mess up the actions of other desktop-scripts (this was the reason why panels and wallpapers were pushed into a single script in the first place), this PR makes it so that if one of the desktop-scripts need to run (for example due to one of the desktop-scripts having changed contents), all the desktop-scripts will now run together.
There's also some increased logging in the autostart script now.

I haven't done extensive testing so some more of that will be needed before merging. When I'll be able to do so I'm not sure, but hopefully not too long. If anyone else has the time to test that would of course be appreciated as always. With that said, from my early tests it seems to look quite good.