### PR TITLE
Update workflow names and triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     paths:
     - '**/*.nix'
     - 'flake.lock'
-    - 'script/'
+    - 'script/**'
 
 # cancel previous runs when pushing new changes
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,15 @@
 name: "Check"
 on:
   pull_request:
+    paths:
+    - '**/*.nix'
+    - 'flake.lock'
+
 # cancel previous runs when pushing new changes
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     paths:
     - '**/*.nix'
     - 'flake.lock'
+    - 'script/'
 
 # cancel previous runs when pushing new changes
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "Check"
+name: "Nix Checks"
 on:
   pull_request:
     paths:

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -1,8 +1,13 @@
-name: GitHub Pages
+name: GitHub Pages Docs Generation
 on:
   push:
     branches:
-      - trunk
+    - trunk
+    paths:
+    - 'flake.nix'
+    - 'modules/'
+    - 'docs/'
+    
 jobs:
   publish:
     strategy:

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -5,6 +5,7 @@ on:
     - trunk
     paths:
     - 'flake.nix'
+    - 'flake.lock'
     - 'modules/**'
     - 'docs/**'
     

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -5,8 +5,8 @@ on:
     - trunk
     paths:
     - 'flake.nix'
-    - 'modules/'
-    - 'docs/'
+    - 'modules/**'
+    - 'docs/**'
     
 jobs:
   publish:


### PR DESCRIPTION
Makes it so that the CI pipeline only runs on changes to:
- Any `.nix` file anywhere in the project
- Any changes in `script/` directory
- Any changes to `flake.lock`

This makes it so that for example changes to README or other irrelevant things for the flake checks doesn't trigger needless CI checks.

Additionally makes it so that the docs generation only runs on changes in the following paths have been merged:
- Any files (incl. in subdirectories) in `modules/`
- Any files (incl. in subdirectories) in `docs/`
- flake.nix
- flake.lock

This also reduces the needs for running the docs generation when there has been no relevant changes.

I've done some testing here and since this seems to work fine I'll merge right away!