### PR TITLE
Fix Window Rules Matching by Window Role

### DIFF
--- a/modules/window-rules.nix
+++ b/modules/window-rules.nix
@@ -35,6 +35,7 @@ with lib.types; let
   matchNameMap = {
     "window-class" = "wmclass";
     "window-types" = "types";
+    "window-role" = "windowrole";
   };
   matchOptionType = hasMatchWhole:
     submodule {


### PR DESCRIPTION
The Attribute window-role in kwinrulesrc is stored as windowrole (found using rc2nix). This adds an extra override to matchNameMap to account for this. Until this is merged, kwin rules cannot use Window Role Matching.