### PR TITLE
Add displayName option for keyboard layout

### DIFF
--- a/modules/input.nix
+++ b/modules/input.nix
@@ -51,6 +51,15 @@ let
         '';
         apply = builtins.toString;
       };
+      displayName = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        example = "us";
+        description = ''
+          Keyboard layout display name.
+        '';
+        apply = builtins.toString;
+      };
     };
   };
 
@@ -414,6 +423,11 @@ in
           layout = "ca";
           variant = "eng";
         }
+        {
+          layout = "us";
+          variant = "intl";
+          displayName = "usi";
+        }
       ];
       description = ''
         Keyboard layouts to use.
@@ -464,6 +478,7 @@ in
         Use.value = true;
         LayoutList.value = strings.concatStringsSep "," (map (l: l.layout) cfg.input.keyboard.layouts);
         VariantList.value = strings.concatStringsSep "," (map (l: l.variant) cfg.input.keyboard.layouts);
+        DisplayNames.value = strings.concatStringsSep "," (map (l: l.displayName) cfg.input.keyboard.layouts);
       };
     })
     (mkIf (cfg.input.keyboard.options != null) {


### PR DESCRIPTION
Gives the chance for setting the label / display name for a keyboard layout.
![keyboard-layouts](https://github.com/user-attachments/assets/877576e1-ac93-4507-8c4c-7ac03e3ada2c)
![keyboard-add-layout](https://github.com/user-attachments/assets/dd6956f0-0f16-4eb3-918c-0b96657bacd2)
