### PR TITLE
Various Additions to PowerDevil Configuration

### DIFF
--- a/modules/input.nix
+++ b/modules/input.nix
@@ -478,7 +478,9 @@ in
         Use.value = true;
         LayoutList.value = strings.concatStringsSep "," (map (l: l.layout) cfg.input.keyboard.layouts);
         VariantList.value = strings.concatStringsSep "," (map (l: l.variant) cfg.input.keyboard.layouts);
-        DisplayNames.value = strings.concatStringsSep "," (map (l: l.displayName) cfg.input.keyboard.layouts);
+        DisplayNames.value = strings.concatStringsSep "," (
+          map (l: l.displayName) cfg.input.keyboard.layouts
+        );
       };
     })
     (mkIf (cfg.input.keyboard.options != null) {

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -178,13 +178,21 @@ let
         nullOr (enum [
           "performance"
           "balanced"
-          "power-saver"
+          "powerSaving"
         ]);
       default = null;
-      example = "power-saver";
+      example = "powerSaving";
       description = ''
         The Power Profile to Enter in this mode
       '';
+      apply =
+        profile:
+        if profile == null then
+          null
+        else if profile == "powerSaving" then
+          "power-saver"
+        else
+          profile;
     };
   };
 

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -222,6 +222,9 @@ let
         else
           null;
       DisplayBrightness = cfg.powerdevil.${optionsName}.displayBrightness;
+      UseProfileSpecificDisplayBrightness = (
+        if (cfg.powerdevil.${optionsName}.displayBrightness == null) then null else true
+      );
     };
     "${cfgSectName}/Performance" = {
       PowerProfile = cfg.powerdevil.${optionsName}.powerProfile;

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -215,7 +215,7 @@ let
       DimDisplayIdleTimeoutSec = 
         if (cfg.powerdevil.${optionsName}.dimDisplay.idleTimeout != null) then
           cfg.powerdevil.${optionsName}.dimDisplay.idleTimeout
-        else if (cfg.powerdevil.${optionsName}.dimDisplay.enable = false) then
+        else if (cfg.powerdevil.${optionsName}.dimDisplay.enable == false) then
           -1
         else
           null;

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -39,6 +39,7 @@ let
     sleep = 1;
     hibernate = 2;
     shutdown = 8;
+    shutDown = 8; # For consistency - all the other instances use camelCase - ideally, the above option would be replaced with this one, but I don't think I can simply add a renamed module import as it's renaming one of the values in the enum type, rather than the option itself?
     lockScreen = 32;
     turnOffScreen = 64;
   };

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -165,6 +165,13 @@ let
       The brightness to set the display to in this mode
       '';
     };
+    powerProfile = lib.mkOption {
+      type = with lib.types; nullOr (enum [
+        "performance"
+        "balanced"
+        "power-saver"
+      ]);
+    };
   };
 
   # By the same logic as createPowerDevilOptions, we can generate the
@@ -194,6 +201,9 @@ let
           null;
       DimDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.dimDisplay.idleTimeout;
       DisplayBrightness = cfg.powerdevil.${optionsName}.displayBrightness;
+    };
+    "${cfgSectName}/Performance" = {
+      PowerProfile = cfg.powerdevil.${optionsName}.powerProfile;
     };
   };
 in

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -88,7 +88,7 @@ let
     whenLaptopLidClosed = lib.mkOption {
       type = with lib.types; nullOr (enum (builtins.attrNames whenLaptopLidClosedActions));
       default = null;
-      example = "shutdown";
+      example = "shutDown";
       description = ''
         The action, when on ${type}, to perform when the laptop lid is closed.
       '';

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -185,14 +185,7 @@ let
       description = ''
         The Power Profile to Enter in this mode
       '';
-      apply =
-        profile:
-        if profile == null then
-          null
-        else if profile == "powerSaving" then
-          "power-saver"
-        else
-          profile;
+      apply = profile: if profile == "powerSaving" then "power-saver" else profile;
     };
   };
 

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -38,8 +38,7 @@ let
     doNothing = 0;
     sleep = 1;
     hibernate = 2;
-    shutdown = 8;
-    shutDown = 8; # For consistency - all the other instances use camelCase - ideally, the above option would be replaced with this one, but I don't think I can simply add a renamed module import as it's renaming one of the values in the enum type, rather than the option itself?
+    shutDown = 8;
     lockScreen = 32;
     turnOffScreen = 64;
   };

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -21,6 +21,13 @@ let
     shutDown = 8;
   };
 
+  autoCriticalActions = {
+    nothing = 0;
+    hibernate = 2;
+    sleep = 1;
+    shutDown = 8;
+  };
+
   whenSleepingEnterActions = {
     standby = 1;
     hybridSleep = 2;
@@ -299,6 +306,33 @@ in
           '';
         };
       };
+      batteryLevels = {
+            lowLevel = lib.mkOption {
+              type = with lib.types; nullOr (ints.between 0 100);
+              default = null;
+              example = 10;
+              description = ''
+              The battery level considered "low" for the laptop
+              '';
+            };
+            criticalLevel = lib.mkOption {
+              type = with lib.types; nullOr (ints.between 0 100);
+              default = null;
+              example = 2;
+              description = ''
+              The battery level considered "critical" for the laptop
+              '';
+            };
+            criticalAction = lib.mkOption {
+              type = with lib.types; nullOr (enum (builtins.attrNames autoCriticalActions));
+              default = null;
+              example = "shutDown";
+              description = ''
+                The action to perform when Critical Battery Level is reached
+              '';
+              apply = action: if (action == null) then null else autoCriticalActions."${action}";
+            };
+          };
     };
   };
 
@@ -310,6 +344,11 @@ in
       // {
         General = {
           pausePlayersOnSuspend = cfg.powerdevil.general.pausePlayersOnSuspend;
+        };
+        BatteryManagement = {
+          BatteryCriticalAction = cfg.powerdevil.batteryLevels.criticalAction;
+          BatteryCriticalLevel = cfg.powerdevil.batteryLevels.criticalLevel;
+          BatteryLowLevel = cfg.powerdevil.batteryLevels.lowLevel;
         };
       }
     );

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -179,6 +179,11 @@ let
         "balanced"
         "power-saver"
       ]);
+      default = null;
+      example = "power-saver";
+      description = ''
+      The Power Profile to Enter in this mode
+      '';
     };
   };
 

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -170,19 +170,21 @@ let
       default = null;
       example = 10;
       description = ''
-      The brightness to set the display to in this mode
+        The brightness to set the display to in this mode
       '';
     };
     powerProfile = lib.mkOption {
-      type = with lib.types; nullOr (enum [
-        "performance"
-        "balanced"
-        "power-saver"
-      ]);
+      type =
+        with lib.types;
+        nullOr (enum [
+          "performance"
+          "balanced"
+          "power-saver"
+        ]);
       default = null;
       example = "power-saver";
       description = ''
-      The Power Profile to Enter in this mode
+        The Power Profile to Enter in this mode
       '';
     };
   };
@@ -212,7 +214,7 @@ let
           true
         else
           null;
-      DimDisplayIdleTimeoutSec = 
+      DimDisplayIdleTimeoutSec =
         if (cfg.powerdevil.${optionsName}.dimDisplay.idleTimeout != null) then
           cfg.powerdevil.${optionsName}.dimDisplay.idleTimeout
         else if (cfg.powerdevil.${optionsName}.dimDisplay.enable == false) then
@@ -319,32 +321,32 @@ in
         };
       };
       batteryLevels = {
-            lowLevel = lib.mkOption {
-              type = with lib.types; nullOr (ints.between 0 100);
-              default = null;
-              example = 10;
-              description = ''
-              The battery level considered "low" for the laptop
-              '';
-            };
-            criticalLevel = lib.mkOption {
-              type = with lib.types; nullOr (ints.between 0 100);
-              default = null;
-              example = 2;
-              description = ''
-              The battery level considered "critical" for the laptop
-              '';
-            };
-            criticalAction = lib.mkOption {
-              type = with lib.types; nullOr (enum (builtins.attrNames autoCriticalActions));
-              default = null;
-              example = "shutDown";
-              description = ''
-                The action to perform when Critical Battery Level is reached
-              '';
-              apply = action: if (action == null) then null else autoCriticalActions."${action}";
-            };
-          };
+        lowLevel = lib.mkOption {
+          type = with lib.types; nullOr (ints.between 0 100);
+          default = null;
+          example = 10;
+          description = ''
+            The battery level considered "low" for the laptop
+          '';
+        };
+        criticalLevel = lib.mkOption {
+          type = with lib.types; nullOr (ints.between 0 100);
+          default = null;
+          example = 2;
+          description = ''
+            The battery level considered "critical" for the laptop
+          '';
+        };
+        criticalAction = lib.mkOption {
+          type = with lib.types; nullOr (enum (builtins.attrNames autoCriticalActions));
+          default = null;
+          example = "shutDown";
+          description = ''
+            The action to perform when Critical Battery Level is reached
+          '';
+          apply = action: if (action == null) then null else autoCriticalActions."${action}";
+        };
+      };
     };
   };
 

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -157,6 +157,14 @@ let
         '';
       };
     };
+    displayBrightness = lib.mkOption {
+      type = with lib.types; nullOr (ints.between 0 100);
+      default = null;
+      example = 10;
+      description = ''
+      The brightness to set the display to in this mode
+      '';
+    };
   };
 
   # By the same logic as createPowerDevilOptions, we can generate the
@@ -185,6 +193,7 @@ let
         else
           null;
       DimDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.dimDisplay.idleTimeout;
+      DisplayBrightness = cfg.powerdevil.${optionsName}.displayBrightness;
     };
   };
 in

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -212,7 +212,13 @@ let
           true
         else
           null;
-      DimDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.dimDisplay.idleTimeout;
+      DimDisplayIdleTimeoutSec = 
+        if (cfg.powerdevil.${optionsName}.dimDisplay.idleTimeout != null) then
+          cfg.powerdevil.${optionsName}.dimDisplay.idleTimeout
+        else if (cfg.powerdevil.${optionsName}.dimDisplay.enable = false) then
+          -1
+        else
+          null;
       DisplayBrightness = cfg.powerdevil.${optionsName}.displayBrightness;
     };
     "${cfgSectName}/Performance" = {


### PR DESCRIPTION
This PR includes various additions to the plasma-manager powerdevil module - for configuring the KDE Plasma Power Management Settings:

- Display Brightness per power mode
- Power Profile per Power Mode
- Battery Level Management
  - Low/Critical Power Levels
  - Critical Power Action

There are also a couple of bugfixes:

- Display Dimming Idle Timeout was not being set properly - it should be -1 if dimming is disabled
- Lid Closing actions used "shutdown" in place of the "shutDown" used by all other actions, for the sake of consistency, this option was added alongside "shutdown" - this should probably be a replacement, but I wasn't sure how to write the mkRenamedOption or Assertion to give a reasonable warning as to the replacement having occurred.
- 