### PR TITLE
Powerdevil revamp

### DIFF
--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -90,21 +90,22 @@ let
           If enabled, the lid action will be inhibited when an external monitor is connected.
         '';
       };
+
+      whenSleepingEnter = lib.mkOption {
+        type = with lib.types; nullOr (enum (builtins.attrNames whenSleepingEnterActions));
+        default = null;
+        example = "standbyThenHibernate";
+        description = ''
+          The state, when on ${type}, to enter when sleeping.
+        '';
+        apply = action: if (action == null) then null else whenSleepingEnterActions."${action}";
+      };
     };
 
     displayAndBrightness = {};
 
     otherSettings = {};
 
-    whenSleepingEnter = lib.mkOption {
-      type = with lib.types; nullOr (enum (builtins.attrNames whenSleepingEnterActions));
-      default = null;
-      example = "standbyThenHibernate";
-      description = ''
-        The state, when on ${type}, to enter when sleeping.
-      '';
-      apply = action: if (action == null) then null else whenSleepingEnterActions."${action}";
-    };
     turnOffDisplay = {
       idleTimeout = lib.mkOption {
         type = with lib.types; nullOr (either (enum [ "never" ]) (ints.between 30 600000));
@@ -194,7 +195,7 @@ let
       PowerButtonAction = cfg.powerdevil.${optionsName}.suspendSession.powerButtonAction;
       AutoSuspendAction = cfg.powerdevil.${optionsName}.suspendSession.autoSuspend.action;
       AutoSuspendIdleTimeoutSec = cfg.powerdevil.${optionsName}.suspendSession.autoSuspend.idleTimeout;
-      SleepMode = cfg.powerdevil.${optionsName}.whenSleepingEnter;
+      SleepMode = cfg.powerdevil.${optionsName}.suspendSession.whenSleepingEnter;
       LidAction = cfg.powerdevil.${optionsName}.suspendSession.whenLaptopLidClosed;
       InhibitLidActionWhenExternalMonitorPresent =
         cfg.powerdevil.${optionsName}.suspendSession.inhibitLidActionWhenExternalMonitorConnected;
@@ -283,6 +284,18 @@ in
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "lowBattery" "inhibitLidActionWhenExternalMonitorConnected"]
       ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "inhibitLidActionWhenExternalMonitorConnected"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "AC" "whenSleepingEnter"]
+      ["programs" "plasma" "powerdevil" "AC" "suspendSession" "whenSleepingEnter"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "battery" "whenSleepingEnter"]
+      ["programs" "plasma" "powerdevil" "battery" "suspendSession" "whenSleepingEnter"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "lowBattery" "whenSleepingEnter"]
+      ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "whenSleepingEnter"]
     )
   ];
 

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -120,7 +120,7 @@ let
           nullOr bool;
         default = null;
         example = false;
-        description = "If enabled, the lid action will be executed even when an external monitor is connected.";
+        description = "If enabled, when on ${type}, the lid action will be executed even when an external monitor is connected.";
       };
 
       whenSleepingEnter = lib.mkOption {
@@ -144,7 +144,7 @@ let
             nullOr bool;
           default = null;
           example = true;
-          description = "Enable or disable screen brightness changing.";
+          description = "Enable or disable, when on ${type}, changing the screen brightness.";
         };
 
         percentage = lib.mkOption {
@@ -220,7 +220,7 @@ let
             nullOr bool;
           default = null;
           example = true;
-          description = "Enable or disable keyboard brightness changing.";
+          description = "Enable or disable, when on ${type}, changing the keyboard brightness.";
         };
 
         percentage = lib.mkOption {

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -11,7 +11,7 @@ let
 
   # Values can be found at:
   # https://github.com/KDE/powerdevil/blob/master/daemon/powerdevilenums.h
-  powerButtonActions = {
+  whenPowerButtonPressedActions = {
     nothing = 0;
     sleep = 1;
     hibernate = 2;
@@ -62,14 +62,14 @@ let
         };
       };
 
-      powerButtonAction = lib.mkOption {
-        type = with lib.types; nullOr (enum (builtins.attrNames powerButtonActions));
+      whenPowerButtonPressed = lib.mkOption {
+        type = with lib.types; nullOr (enum (builtins.attrNames whenPowerButtonPressedActions));
         default = null;
         example = "nothing";
         description = ''
           The action, when on ${type}, to perform when the power button is pressed.
         '';
-        apply = action: if (action == null) then null else powerButtonActions."${action}";
+        apply = action: if (action == null) then null else whenPowerButtonPressedActions."${action}";
       };
 
       whenLaptopLidClosed = lib.mkOption {
@@ -194,7 +194,7 @@ let
   # options from (i.e. powerdevil.AC or powerdevil.battery).
   createPowerDevilConfig = cfgSectName: optionsName: {
     "${cfgSectName}/SuspendAndShutdown" = {
-      PowerButtonAction = cfg.powerdevil.${optionsName}.suspendSession.powerButtonAction;
+      PowerButtonAction = cfg.powerdevil.${optionsName}.suspendSession.whenPowerButtonPressed;
       AutoSuspendAction = cfg.powerdevil.${optionsName}.suspendSession.afterAPeriodOfInactivity.action;
       AutoSuspendIdleTimeoutSec = cfg.powerdevil.${optionsName}.suspendSession.afterAPeriodOfInactivity.idleTimeout;
       SleepMode = cfg.powerdevil.${optionsName}.suspendSession.whenSleepingEnter;
@@ -253,15 +253,15 @@ in
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "AC" "powerButtonAction"]
-      ["programs" "plasma" "powerdevil" "AC" "suspendSession" "powerButtonAction"]
+      ["programs" "plasma" "powerdevil" "AC" "suspendSession" "whenPowerButtonPressed"]
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "battery" "powerButtonAction"]
-      ["programs" "plasma" "powerdevil" "battery" "suspendSession" "powerButtonAction"]
+      ["programs" "plasma" "powerdevil" "battery" "suspendSession" "whenPowerButtonPressed"]
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "lowBattery" "powerButtonAction"]
-      ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "powerButtonAction"]
+      ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "whenPowerButtonPressed"]
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "AC" "whenLaptopLidClosed"]

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -88,7 +88,7 @@ let
         idleTimeout = lib.mkOption {
           type = with lib.types;
             nullOr (
-              ints.between 60 600000
+              ints.between 60 604800
             );
           default = null;
           example = 600;
@@ -208,7 +208,7 @@ let
         idleTimeout = lib.mkOption {
           type = with lib.types;
             nullOr
-            (ints.between 20 600000);
+            (ints.between 10 604800);
           default = null;
           example = 300;
           description = ''
@@ -221,7 +221,7 @@ let
       turnOffScreen = {
         idleTimeout = lib.mkOption {
           type = with lib.types;
-            nullOr (either (enum [ "never" ]) (ints.between 30 600000));
+            nullOr (either (enum [ "never" ]) (ints.between 30 604800));
           default = null;
           example = 300;
           description = ''
@@ -243,7 +243,7 @@ let
               either (enum [
                 "whenLockedAndUnlocked"
                 "immediately"
-              ]) (ints.between 20 600000)
+              ]) (ints.between 10 604800)
             );
           default = null;
           example = 60;

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -80,9 +80,10 @@ let
             The action, when on ${type}, to perform after a certain period of inactivity.
           '';
           apply = action:
-            if (action == null)
-            then null
-            else afterAPeriodOfInactivityActions."${action}";
+            if (action == null) then
+              null
+            else
+              afterAPeriodOfInactivityActions."${action}";
         };
 
         idleTimeout = lib.mkOption {
@@ -112,9 +113,10 @@ let
           The action, when on ${type}, to perform when the power button is pressed.
         '';
         apply = action:
-          if (action == null)
-          then null
-          else whenPowerButtonPressedActions."${action}";
+          if (action == null) then
+            null
+          else
+            whenPowerButtonPressedActions."${action}";
       };
 
       whenLaptopLidClosed = lib.mkOption {
@@ -130,9 +132,10 @@ let
           The action, when on ${type}, to perform when the laptop lid is closed.
         '';
         apply = action:
-          if (action == null)
-          then null
-          else whenLaptopLidClosedActions."${action}";
+          if (action == null) then
+            null
+          else
+            whenLaptopLidClosedActions."${action}";
       };
 
       evenWhenAnExternalMonitorIsConnected = lib.mkOption {
@@ -160,9 +163,10 @@ let
           The state, when on ${type}, to enter when sleeping.
         '';
         apply = action:
-          if (action == null)
-          then null
-          else whenSleepingEnterActions."${action}";
+          if (action == null) then
+            null
+          else
+            whenSleepingEnterActions."${action}";
       };
     };
 
@@ -627,9 +631,10 @@ in
             The action to perform when the battery reaches critical level.
           '';
           apply = action:
-            if (action == null)
-            then null
-            else atCriticalLevelActions."${action}";
+            if (action == null) then
+              null
+            else
+              atCriticalLevelActions."${action}";
 
         };
         lowLevelForPeripheralDevice = lib.mkOption {

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -69,219 +69,221 @@ let
   # can generate the options by just specifying the type (i.e. "AC" or
   # "battery").
   generateOptionsForProfile = profile: {
-    suspendSession = {
-      afterAPeriodOfInactivity = {
-        action = lib.mkOption {
-          type = with lib.types;
-            nullOr (enum (builtins.attrNames afterAPeriodOfInactivityActions));
-          default = null;
-          example = "doNothing";
-          description = "The action, when on ${profile}, to perform after a certain period of inactivity.";
-          apply = action:
-            if (action == null) then
-              null
-            else
-              afterAPeriodOfInactivityActions."${action}";
-        };
-
-        idleTimeout = lib.mkOption {
-          type = with lib.types;
-            nullOr (ints.between 60 604800);
-          default = null;
-          example = 600;
-          description = "The duration (in seconds), when on ${profile}, the computer must be idle until the auto-suspend action is executed.";
-        };
-      };
-
-      whenPowerButtonPressed = lib.mkOption {
-        type = with lib.types;
-          nullOr (enum (builtins.attrNames whenPowerButtonPressedActions));
-        default = null;
-        example = "doNothing";
-        description = "The action, when on ${profile}, to perform when the power button is pressed.";
-        apply = action:
-          if (action == null) then
-            null
-          else
-            whenPowerButtonPressedActions."${action}";
-      };
-
-      whenLaptopLidClosed = lib.mkOption {
-        type = with lib.types;
-          nullOr (enum (builtins.attrNames whenLaptopLidClosedActions));
-        default = null;
-        example = "shutDown";
-        description = "The action, when on ${profile}, to perform when the laptop lid is closed.";
-        apply = action:
-          if (action == null) then
-            null
-          else
-            whenLaptopLidClosedActions."${action}";
-      };
-
-      evenWhenAnExternalMonitorIsConnected = lib.mkOption {
-        type = with lib.types;
-          nullOr bool;
-        default = null;
-        example = false;
-        description = "If enabled, when on ${profile}, the lid action will be executed even when an external monitor is connected.";
-      };
-
-      whenSleepingEnter = lib.mkOption {
-        type = with lib.types;
-          nullOr (enum (builtins.attrNames whenSleepingEnterActions));
-        default = null;
-        example = "standbyThenHibernate";
-        description = "The state, when on ${profile}, to enter when sleeping.";
-        apply = action:
-          if (action == null) then
-            null
-          else
-            whenSleepingEnterActions."${action}";
-      };
-    };
-
-    displayAndBrightness = {
-      changeScreenBrightness = {
-        enable = lib.mkOption {
-          type = with lib.types;
-            nullOr bool;
-          default = null;
-          example = true;
-          description = "Enable or disable, when on ${profile}, changing the screen brightness.";
-        };
-
-        percentage = lib.mkOption {
-          type = with lib.types;
-            nullOr (ints.between 1 100);
-          default = null;
-          example = 70;
-          description = "The screen brightness percentage when on ${profile}.";
-        };
-      };
-
-      dimAutomatically = {
-        idleTimeout = lib.mkOption {
-          type = with lib.types;
-            nullOr (either
-              (enum ["never"])
-              (ints.between 10 604800));
-          default = null;
-          example = 300;
-          description = "The duration (in seconds), when on ${profile}, the computer must be idle until the display starts dimming.";
-          apply = timeout:
-            if (timeout == null) then
-              null
-            else if (timeout == "never") then
-              -1
-            else
-              timeout;
-        };
-      };
-
-      turnOffScreen = {
-        idleTimeout = lib.mkOption {
-          type = with lib.types;
-            nullOr (either
-              (enum [ "never" ])
-              (ints.between 30 604800));
-          default = null;
-          example = 300;
-          description = "The duration (in seconds), when on ${profile}, the computer must be idle (when unlocked) until the display turns off.";
-          apply = timeout:
-            if (timeout == null) then
-              null
-            else if (timeout == "never") then
-              -1
-            else
-              timeout;
-        };
-
-        idleTimeoutWhenLocked = lib.mkOption {
-          type = with lib.types;
-            nullOr (either
-              (enum ["whenLockedAndUnlocked" "immediately"])
-              (ints.between 10 604800));
-          default = null;
-          example = 60;
-          description = "The duration (in seconds), when on ${profile}, the computer must be idle (when locked) until the display turns off.";
-          apply = timeout:
-            if (timeout == null) then
-              null
-            else if (timeout == "whenLockedAndUnlocked") then
-              -2
-            else if (timeout == "immediately") then
-              0
-            else
-              timeout;
-        };
-      };
-
-      changeKeyboardBrightness = {
-        enable = lib.mkOption {
-          type = with lib.types;
-            nullOr bool;
-          default = null;
-          example = true;
-          description = "Enable or disable, when on ${profile}, changing the keyboard brightness.";
-        };
-
-        percentage = lib.mkOption {
-          type = with lib.types;
-            nullOr (ints.between 0 100);
-          default = null;
-          example = 70;
-          description = "The keyboard brightness percentage when on ${profile}.";
-        };
-      };
-    };
-
-    otherSettings = {
-      switchToPowerProfile = lib.mkOption {
-        type = with lib.types;
-          nullOr (enum (builtins.attrNames switchToPowerProfileActions));
-        default = null;
-        example = "performance";
-        description = "The power profile, when on ${profile}, adopted by the computer.";
-        apply = profile:
-          if (profile == null || profile == "leaveUnchanged") then
-            null
-          else
-            switchToPowerProfileActions."${profile}";
-      };
-
-      runCustomScripts = {
-        "whenEnteringOn${capitalize(profile)}PowerState" = lib.mkOption {
-          type = with lib.types;
-            nullOr str;
-          default = null;
-          example = "echo 'hello, world'";
-          description = "A script or the path for a script/program to be run when entering ${profile}.";
-        };
-
-        "whenExitingOn${capitalize(profile)}PowerState" = lib.mkOption {
-          type = with lib.types;
-            nullOr str;
-          default = null;
-          example = "echo 'farewwll, world'";
-          description = "A script or the path for a script/program to be run when exiting ${profile}.";
-        };
-
+    "${profile}" = {
+      suspendSession = {
         afterAPeriodOfInactivity = {
-          script = lib.mkOption {
+          action = lib.mkOption {
             type = with lib.types;
-              nullOr str;
+              nullOr (enum (builtins.attrNames afterAPeriodOfInactivityActions));
             default = null;
-            example = "echo 'are you there, world'";
-            description = "A script or the path for a script/program to be run after a period of inactivity when on ${profile}.";
+            example = "doNothing";
+            description = "The action, when on ${profile}, to perform after a certain period of inactivity.";
+            apply = action:
+              if (action == null) then
+                null
+              else
+                afterAPeriodOfInactivityActions."${action}";
           };
 
           idleTimeout = lib.mkOption {
             type = with lib.types;
-              nullOr (ints.between 10 604800);
+              nullOr (ints.between 60 604800);
             default = null;
             example = 600;
-            description = "The duration (in seconds), when on ${profile}, the computer must be idle until the script is run.";
+            description = "The duration (in seconds), when on ${profile}, the computer must be idle until the auto-suspend action is executed.";
+          };
+        };
+
+        whenPowerButtonPressed = lib.mkOption {
+          type = with lib.types;
+            nullOr (enum (builtins.attrNames whenPowerButtonPressedActions));
+          default = null;
+          example = "doNothing";
+          description = "The action, when on ${profile}, to perform when the power button is pressed.";
+          apply = action:
+            if (action == null) then
+              null
+            else
+              whenPowerButtonPressedActions."${action}";
+        };
+
+        whenLaptopLidClosed = lib.mkOption {
+          type = with lib.types;
+            nullOr (enum (builtins.attrNames whenLaptopLidClosedActions));
+          default = null;
+          example = "shutDown";
+          description = "The action, when on ${profile}, to perform when the laptop lid is closed.";
+          apply = action:
+            if (action == null) then
+              null
+            else
+              whenLaptopLidClosedActions."${action}";
+        };
+
+        evenWhenAnExternalMonitorIsConnected = lib.mkOption {
+          type = with lib.types;
+            nullOr bool;
+          default = null;
+          example = false;
+          description = "If enabled, when on ${profile}, the lid action will be executed even when an external monitor is connected.";
+        };
+
+        whenSleepingEnter = lib.mkOption {
+          type = with lib.types;
+            nullOr (enum (builtins.attrNames whenSleepingEnterActions));
+          default = null;
+          example = "standbyThenHibernate";
+          description = "The state, when on ${profile}, to enter when sleeping.";
+          apply = action:
+            if (action == null) then
+              null
+            else
+              whenSleepingEnterActions."${action}";
+        };
+      };
+
+      displayAndBrightness = {
+        changeScreenBrightness = {
+          enable = lib.mkOption {
+            type = with lib.types;
+              nullOr bool;
+            default = null;
+            example = true;
+            description = "Enable or disable, when on ${profile}, changing the screen brightness.";
+          };
+
+          percentage = lib.mkOption {
+            type = with lib.types;
+              nullOr (ints.between 1 100);
+            default = null;
+            example = 70;
+            description = "The screen brightness percentage when on ${profile}.";
+          };
+        };
+
+        dimAutomatically = {
+          idleTimeout = lib.mkOption {
+            type = with lib.types;
+              nullOr (either
+                (enum ["never"])
+                (ints.between 10 604800));
+            default = null;
+            example = 300;
+            description = "The duration (in seconds), when on ${profile}, the computer must be idle until the display starts dimming.";
+            apply = timeout:
+              if (timeout == null) then
+                null
+              else if (timeout == "never") then
+                -1
+              else
+                timeout;
+          };
+        };
+
+        turnOffScreen = {
+          idleTimeout = lib.mkOption {
+            type = with lib.types;
+              nullOr (either
+                (enum [ "never" ])
+                (ints.between 30 604800));
+            default = null;
+            example = 300;
+            description = "The duration (in seconds), when on ${profile}, the computer must be idle (when unlocked) until the display turns off.";
+            apply = timeout:
+              if (timeout == null) then
+                null
+              else if (timeout == "never") then
+                -1
+              else
+                timeout;
+          };
+
+          idleTimeoutWhenLocked = lib.mkOption {
+            type = with lib.types;
+              nullOr (either
+                (enum ["whenLockedAndUnlocked" "immediately"])
+                (ints.between 10 604800));
+            default = null;
+            example = 60;
+            description = "The duration (in seconds), when on ${profile}, the computer must be idle (when locked) until the display turns off.";
+            apply = timeout:
+              if (timeout == null) then
+                null
+              else if (timeout == "whenLockedAndUnlocked") then
+                -2
+              else if (timeout == "immediately") then
+                0
+              else
+                timeout;
+          };
+        };
+
+        changeKeyboardBrightness = {
+          enable = lib.mkOption {
+            type = with lib.types;
+              nullOr bool;
+            default = null;
+            example = true;
+            description = "Enable or disable, when on ${profile}, changing the keyboard brightness.";
+          };
+
+          percentage = lib.mkOption {
+            type = with lib.types;
+              nullOr (ints.between 0 100);
+            default = null;
+            example = 70;
+            description = "The keyboard brightness percentage when on ${profile}.";
+          };
+        };
+      };
+
+      otherSettings = {
+        switchToPowerProfile = lib.mkOption {
+          type = with lib.types;
+            nullOr (enum (builtins.attrNames switchToPowerProfileActions));
+          default = null;
+          example = "performance";
+          description = "The power profile, when on ${profile}, adopted by the computer.";
+          apply = profile:
+            if (profile == null || profile == "leaveUnchanged") then
+              null
+            else
+              switchToPowerProfileActions."${profile}";
+        };
+
+        runCustomScripts = {
+          "whenEnteringOn${capitalize(profile)}PowerState" = lib.mkOption {
+            type = with lib.types;
+              nullOr str;
+            default = null;
+            example = "echo 'hello, world'";
+            description = "A script or the path for a script/program to be run when entering ${profile}.";
+          };
+
+          "whenExitingOn${capitalize(profile)}PowerState" = lib.mkOption {
+            type = with lib.types;
+              nullOr str;
+            default = null;
+            example = "echo 'farewwll, world'";
+            description = "A script or the path for a script/program to be run when exiting ${profile}.";
+          };
+
+          afterAPeriodOfInactivity = {
+            script = lib.mkOption {
+              type = with lib.types;
+                nullOr str;
+              default = null;
+              example = "echo 'are you there, world'";
+              description = "A script or the path for a script/program to be run after a period of inactivity when on ${profile}.";
+            };
+
+            idleTimeout = lib.mkOption {
+              type = with lib.types;
+                nullOr (ints.between 10 604800);
+              default = null;
+              example = 600;
+              description = "The duration (in seconds), when on ${profile}, the computer must be idle until the script is run.";
+            };
           };
         };
       };
@@ -527,12 +529,11 @@ in
     ++ generalAssertions;
 
   options = {
-    programs.plasma.powerdevil = {
-      AC = (generateOptionsForProfile "AC");
-      battery = (generateOptionsForProfile "battery");
-      lowBattery = (generateOptionsForProfile "lowBattery");
-    }
-    // generalOptions;
+    programs.plasma.powerdevil =
+      (generateOptionsForProfile "AC")
+      // (generateOptionsForProfile "battery")
+      // (generateOptionsForProfile "lowBattery")
+      // generalOptions;
   };
 
   config.programs.plasma.configFile = lib.mkIf cfg.enable {

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -510,35 +510,51 @@ let
 
   generateAssertionsForProfile = profile: [
     {
-      assertion = (
-        cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.action != afterAPeriodOfInactivityActions.doNothing
-        || cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.idleTimeout == null
-      );
+      assertion =
+        let
+          afterAPeriodOfInactivity = cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity;
+        in
+          (
+            afterAPeriodOfInactivity.action != afterAPeriodOfInactivityActions.doNothing
+            || afterAPeriodOfInactivity.idleTimeout == null
+          );
       message = "Setting programs.plasma.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.idleTimeout for autosuspend-action \"doNothing\" is not supported.";
     }
     {
-      assertion = (
-        cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeout != -1
-        || cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked == null
-      );
+      assertion =
+        let
+          turnOffScreen = cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen;
+        in
+          (
+            turnOffScreen.idleTimeout != -1
+            || turnOffScreen.idleTimeoutWhenLocked == null
+          );
       message = "Setting programs.plasma.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked for idleTimeout \"never\" is not supported.";
     }
     {
-      assertion = (
-        cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable != false
-        || cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage == null
-      );
+      assertion =
+        let
+          changeScreenBrightness = cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness;
+        in
+          (
+            changeScreenBrightness.enable != false
+            || changeScreenBrightness.percentage == null
+          );
       message = "Cannot set programs.plasma.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage when programs.plasma.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable is disabled.";
     }
   ];
 
   generalAssertions = [
     {
-      assertion = (
-        cfg.powerdevil.batteryLevels.lowLevel == null
-        || cfg.powerdevil.batteryLevels.criticalLevel == null
-        || cfg.powerdevil.batteryLevels.lowLevel > cfg.powerdevil.batteryLevels.criticalLevel
-      );
+      assertion =
+        let
+          batteryLevels = cfg.powerdevil.batteryLevels;
+        in
+          (
+            batteryLevels.lowLevel == null
+            || batteryLevels.criticalLevel == null
+            || batteryLevels.lowLevel > batteryLevels.criticalLevel
+          );
       message = "programs.plasma.powerdevil.batteryLevels.criticalLevel cannot be greater than programs.plasma.powerdevil.batteryLevels.lowLevel.";
     }
   ];

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -397,6 +397,11 @@ in
       ["programs" "plasma" "powerdevil" "lowBattery" "turnOffDisplay"]
       ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "turnOffScreen"]
     )
+
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "general" "pausePlayersOnSuspend"]
+      ["programs" "plasma" "powerdevil" "otherSettings" "pauseMediaPlayersWhenSuspending"]
+    )
   ];
 
   config.assertions =
@@ -494,8 +499,8 @@ in
 
         };
       };
-      general = {
-        pausePlayersOnSuspend = lib.mkOption {
+      otherSettings = {
+        pauseMediaPlayersWhenSuspending = lib.mkOption {
           type = with lib.types; nullOr bool;
           default = null;
           example = false;
@@ -519,7 +524,7 @@ in
           BatteryCriticalAction = cfg.powerdevil.batteryLevels.atCriticalLevel;
         };
         General = {
-          pausePlayersOnSuspend = cfg.powerdevil.general.pausePlayersOnSuspend;
+          pausePlayersOnSuspend = cfg.powerdevil.otherSettings.pauseMediaPlayersWhenSuspending;
         };
       }
     );

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -43,16 +43,28 @@ let
     suspendSession = {
       afterAPeriodOfInactivity = {
         action = lib.mkOption {
-          type = with lib.types; nullOr (enum (builtins.attrNames afterAPeriodOfInactivityActions));
+          type = with lib.types;
+            nullOr (
+              enum (
+                builtins.attrNames afterAPeriodOfInactivityActions
+              )
+            );
           default = null;
           example = "nothing";
           description = ''
             The action, when on ${type}, to perform after a certain period of inactivity.
           '';
-          apply = action: if (action == null) then null else afterAPeriodOfInactivityActions."${action}";
+          apply = action:
+            if (action == null)
+            then null
+            else afterAPeriodOfInactivityActions."${action}";
         };
+
         idleTimeout = lib.mkOption {
-          type = with lib.types; nullOr (ints.between 60 600000);
+          type = with lib.types;
+            nullOr (
+              ints.between 60 600000
+            );
           default = null;
           example = 600;
           description = ''
@@ -63,27 +75,46 @@ let
       };
 
       whenPowerButtonPressed = lib.mkOption {
-        type = with lib.types; nullOr (enum (builtins.attrNames whenPowerButtonPressedActions));
+        type = with lib.types;
+          nullOr (
+            enum (
+              builtins.attrNames whenPowerButtonPressedActions
+            )
+          );
         default = null;
         example = "nothing";
         description = ''
           The action, when on ${type}, to perform when the power button is pressed.
         '';
-        apply = action: if (action == null) then null else whenPowerButtonPressedActions."${action}";
+        apply = action:
+          if (action == null)
+          then null
+          else whenPowerButtonPressedActions."${action}";
       };
 
       whenLaptopLidClosed = lib.mkOption {
-        type = with lib.types; nullOr (enum (builtins.attrNames whenLaptopLidClosedActions));
+        type = with lib.types;
+          nullOr (
+            enum (
+              builtins.attrNames whenLaptopLidClosedActions
+            )
+          );
         default = null;
         example = "shutdown";
         description = ''
           The action, when on ${type}, to perform when the laptop lid is closed.
         '';
-        apply = action: if (action == null) then null else whenLaptopLidClosedActions."${action}";
+        apply = action:
+          if (action == null)
+          then null
+          else whenLaptopLidClosedActions."${action}";
       };
 
       evenWhenAnExternalMonitorIsConnected = lib.mkOption {
-        type = with lib.types; nullOr bool;
+        type = with lib.types;
+          nullOr (
+            bool
+          );
         default = null;
         example = false;
         description = ''
@@ -92,26 +123,43 @@ let
       };
 
       whenSleepingEnter = lib.mkOption {
-        type = with lib.types; nullOr (enum (builtins.attrNames whenSleepingEnterActions));
+        type = with lib.types;
+          nullOr (
+            enum (
+              builtins.attrNames whenSleepingEnterActions
+            )
+          );
         default = null;
         example = "standbyThenHibernate";
         description = ''
           The state, when on ${type}, to enter when sleeping.
         '';
-        apply = action: if (action == null) then null else whenSleepingEnterActions."${action}";
+        apply = action:
+          if (action == null)
+          then null
+          else whenSleepingEnterActions."${action}";
       };
     };
 
     displayAndBrightness = {
       changeScreenBrightness = {
         enable = lib.mkOption {
-          type = with lib.types; nullOr bool;
+          type = with lib.types;
+            nullOr (
+              bool
+            );
           default = null;
           example = true;
-          description = "Enable or disable screen brightness changing.";
+          description = ''
+            Enable or disable screen brightness changing.
+          '';
         };
+
         percentage = lib.mkOption {
-          type = with lib.types; nullOr (ints.between 0 100);
+          type = with lib.types;
+            nullOr (
+              ints.between 0 100
+            );
           default = null;
           example = 70;
           description = ''
@@ -122,13 +170,20 @@ let
 
       dimAutomatically = {
         enable = lib.mkOption {
-          type = with lib.types; nullOr bool;
+          type = with lib.types;
+            nullOr
+            bool;
           default = null;
           example = false;
-          description = "Enable or disable screen dimming.";
+          description = ''
+            Enable or disable screen dimming.
+          '';
         };
+
         idleTimeout = lib.mkOption {
-          type = with lib.types; nullOr (ints.between 20 600000);
+          type = with lib.types;
+            nullOr
+            (ints.between 20 600000);
           default = null;
           example = 300;
           description = ''
@@ -140,7 +195,8 @@ let
 
       turnOffScreen = {
         idleTimeout = lib.mkOption {
-          type = with lib.types; nullOr (either (enum [ "never" ]) (ints.between 30 600000));
+          type = with lib.types;
+            nullOr (either (enum [ "never" ]) (ints.between 30 600000));
           default = null;
           example = 300;
           description = ''

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -216,6 +216,7 @@ let
             else
               timeout;
         };
+
         idleTimeoutWhenLocked = lib.mkOption {
           type =
             with lib.types;
@@ -291,6 +292,7 @@ let
             ${type}.
           '';
         };
+
         "whenExitingOn${capitalize(type)}PowerState" = lib.mkOption {
           type = with lib.types;
             nullOr str;
@@ -301,6 +303,7 @@ let
             ${type}.
           '';
         };
+
         afterAPeriodOfInactivity = {
           script = lib.mkOption {
             type = with lib.types;
@@ -312,6 +315,7 @@ let
               of inactivity when on ${type}.
             '';
           };
+
           idleTimeout = lib.mkOption {
             type = with lib.types;
               nullOr (ints.between 10 604800);
@@ -340,6 +344,7 @@ let
       InhibitLidActionWhenExternalMonitorPresent = ! cfg.powerdevil.${optionsName}.suspendSession.evenWhenAnExternalMonitorIsConnected;
       SleepMode = cfg.powerdevil.${optionsName}.suspendSession.whenSleepingEnter;
     };
+
     "${cfgSectName}/Display" = {
       UseProfileSpecificDisplayBrightness=
         if (cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.enable != null) then
@@ -361,15 +366,18 @@ let
       TurnOffDisplayIdleTimeoutWhenLockedSec =
         cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked;
     };
+
     "${cfgSectName}/Performance" = {
       PowerProfile=cfg.powerdevil.${optionsName}.otherSettings.switchToPowerProfile;
     };
+
     "${cfgSectName}/RunScript" = {
       ProfileLoadCommand = cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts."whenEnteringOn${capitalize(optionsName)}PowerState";
       ProfileUnloadCommand=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts."whenExitingOn${capitalize(optionsName)}PowerState";
       IdleTimeoutCommand=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.script;
       RunScriptIdleTimeoutSec=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.idleTimeout;
     };
+
     "${cfgSectName}/Keyboard" = {
       UseProfileSpecificKeyboardBrightness=
         if (cfg.powerdevil.${optionsName}.displayAndBrightness.changeKeyboardBrightness.enable != null) then
@@ -492,7 +500,6 @@ in
       ["programs" "plasma" "powerdevil" "lowBattery" "turnOffDisplay"]
       ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "turnOffScreen"]
     )
-
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "general" "pausePlayersOnSuspend"]
       ["programs" "plasma" "powerdevil" "otherSettings" "pauseMediaPlayersWhenSuspending"]
@@ -559,6 +566,7 @@ in
             battery settings.
           '';
         };
+
         criticalLevel = lib.mkOption {
           type = with lib.types;
             nullOr (ints.between 0 100);
@@ -571,6 +579,7 @@ in
             action.
           '';
         };
+
         atCriticalLevel = lib.mkOption {
           type = with lib.types;
             nullOr (enum (builtins.attrNames atCriticalLevelActions));
@@ -586,6 +595,7 @@ in
               atCriticalLevelActions."${action}";
 
         };
+
         lowLevelForPeripheralDevice = lib.mkOption {
           type = with lib.types;
             nullOr (ints.between 0 100);
@@ -597,6 +607,7 @@ in
           '';
         };
       };
+
       otherSettings = {
         pauseMediaPlayersWhenSuspending = lib.mkOption {
           type = with lib.types;

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -337,6 +337,19 @@ let
       RunScriptIdleTimeoutSec=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.idleTimeout;
     };
   };
+
+  generalConfig = {
+    BatteryManagement = {
+      BatteryLowLevel = cfg.powerdevil.batteryLevels.lowLevel;
+      BatteryCriticalLevel = cfg.powerdevil.batteryLevels.criticalLevel;
+      BatteryCriticalAction = cfg.powerdevil.batteryLevels.atCriticalLevel;
+      PeripheralBatteryLowLevel = cfg.powerdevil.batteryLevels.lowLevelForPeripheralDevice;
+    };
+    General = {
+      pausePlayersOnSuspend = cfg.powerdevil.otherSettings.pauseMediaPlayersWhenSuspending;
+    };
+  };
+
 in
 {
   imports = [
@@ -564,17 +577,7 @@ in
       (createPowerDevilConfig "AC" "AC")
       // (createPowerDevilConfig "Battery" "battery")
       // (createPowerDevilConfig "LowBattery" "lowBattery")
-      // {
-        BatteryManagement = {
-          BatteryLowLevel = cfg.powerdevil.batteryLevels.lowLevel;
-          BatteryCriticalLevel = cfg.powerdevil.batteryLevels.criticalLevel;
-          BatteryCriticalAction = cfg.powerdevil.batteryLevels.atCriticalLevel;
-          PeripheralBatteryLowLevel = cfg.powerdevil.batteryLevels.lowLevelForPeripheralDevice;
-        };
-        General = {
-          pausePlayersOnSuspend = cfg.powerdevil.otherSettings.pauseMediaPlayersWhenSuspending;
-        };
-      }
+      // generalConfig
     );
   };
 }

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -284,6 +284,57 @@ let
     };
   };
 
+  generalOptions = {
+    batteryLevels = {
+      lowLevel = lib.mkOption {
+        type = with lib.types;
+          nullOr (ints.between 0 100);
+        default = null;
+        example = "10";
+        description = "The battery charge will be considered low when it drops to this level. Settings for low battery will be used instead of regular battery settings.";
+      };
+
+      criticalLevel = lib.mkOption {
+        type = with lib.types;
+          nullOr (ints.between 0 100);
+        default = null;
+        example = "5";
+        description = "The battery charge will be considered critical when it drops to this level. After a brief warning, the system will automaticelly suspend or shutdown, according to the configured critical battery level action.";
+      };
+
+      atCriticalLevel = lib.mkOption {
+        type = with lib.types;
+          nullOr (enum (builtins.attrNames atCriticalLevelActions));
+        default = null;
+        example = "hibernate";
+        description = "The action to perform when the battery reaches critical level.";
+        apply = action:
+          if (action == null) then
+            null
+          else
+            atCriticalLevelActions."${action}";
+      };
+
+      lowLevelForPeripheralDevice = lib.mkOption {
+        type = with lib.types;
+          nullOr (ints.between 0 100);
+        default = null;
+        example = "10";
+        description = "The battery charge for peripheral devices will be considered low when it reaches this level.";
+      };
+    };
+
+    otherSettings = {
+      pauseMediaPlayersWhenSuspending = lib.mkOption {
+        type = with lib.types;
+          nullOr bool;
+        default = null;
+        example = false;
+        description = "If enabled, pause media players when the system is suspended.";
+      };
+    };
+  };
+
   # By the same logic as generateOptionsForProfile, we can generate the
   # configuration. cfgSectName is here the name of the section in powerdevilrc,
   # while profile is the name of the "namespace" where we should draw the
@@ -525,56 +576,8 @@ in
       AC = (generateOptionsForProfile "AC");
       battery = (generateOptionsForProfile "battery");
       lowBattery = (generateOptionsForProfile "lowBattery");
-      batteryLevels = {
-        lowLevel = lib.mkOption {
-          type = with lib.types;
-            nullOr (ints.between 0 100);
-          default = null;
-          example = "10";
-          description = "The battery charge will be considered low when it drops to this level. Settings for low battery will be used instead of regular battery settings.";
-        };
-
-        criticalLevel = lib.mkOption {
-          type = with lib.types;
-            nullOr (ints.between 0 100);
-          default = null;
-          example = "5";
-          description = "The battery charge will be considered critical when it drops to this level. After a brief warning, the system will automaticelly suspend or shutdown, according to the configured critical battery level action.";
-        };
-
-        atCriticalLevel = lib.mkOption {
-          type = with lib.types;
-            nullOr (enum (builtins.attrNames atCriticalLevelActions));
-          default = null;
-          example = "hibernate";
-          description = "The action to perform when the battery reaches critical level.";
-          apply = action:
-            if (action == null) then
-              null
-            else
-              atCriticalLevelActions."${action}";
-
-        };
-
-        lowLevelForPeripheralDevice = lib.mkOption {
-          type = with lib.types;
-            nullOr (ints.between 0 100);
-          default = null;
-          example = "10";
-          description = "The battery charge for peripheral devices will be considered low when it reaches this level.";
-        };
-      };
-
-      otherSettings = {
-        pauseMediaPlayersWhenSuspending = lib.mkOption {
-          type = with lib.types;
-            nullOr bool;
-          default = null;
-          example = false;
-          description = "If enabled, pause media players when the system is suspended.";
-        };
-      };
-    };
+    }
+    // generalOptions;
   };
 
   config.programs.plasma.configFile = lib.mkIf cfg.enable {

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -61,21 +61,22 @@ let
         '';
         };
       };
+
+      powerButtonAction = lib.mkOption {
+        type = with lib.types; nullOr (enum (builtins.attrNames powerButtonActions));
+        default = null;
+        example = "nothing";
+        description = ''
+          The action, when on ${type}, to perform when the power button is pressed.
+        '';
+        apply = action: if (action == null) then null else powerButtonActions."${action}";
+      };
     };
 
     displayAndBrightness = {};
 
     otherSettings = {};
 
-    powerButtonAction = lib.mkOption {
-      type = with lib.types; nullOr (enum (builtins.attrNames powerButtonActions));
-      default = null;
-      example = "nothing";
-      description = ''
-        The action, when on ${type}, to perform when the power button is pressed.
-      '';
-      apply = action: if (action == null) then null else powerButtonActions."${action}";
-    };
     whenSleepingEnter = lib.mkOption {
       type = with lib.types; nullOr (enum (builtins.attrNames whenSleepingEnterActions));
       default = null;
@@ -188,7 +189,7 @@ let
   # options from (i.e. powerdevil.AC or powerdevil.battery).
   createPowerDevilConfig = cfgSectName: optionsName: {
     "${cfgSectName}/SuspendAndShutdown" = {
-      PowerButtonAction = cfg.powerdevil.${optionsName}.powerButtonAction;
+      PowerButtonAction = cfg.powerdevil.${optionsName}.suspendSession.powerButtonAction;
       AutoSuspendAction = cfg.powerdevil.${optionsName}.suspendSession.autoSuspend.action;
       AutoSuspendIdleTimeoutSec = cfg.powerdevil.${optionsName}.suspendSession.autoSuspend.idleTimeout;
       SleepMode = cfg.powerdevil.${optionsName}.whenSleepingEnter;
@@ -244,6 +245,18 @@ in
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "lowBattery" "autoSuspend"]
       ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "autoSuspend"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "AC" "powerButtonAction"]
+      ["programs" "plasma" "powerdevil" "AC" "suspendSession" "powerButtonAction"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "battery" "powerButtonAction"]
+      ["programs" "plasma" "powerdevil" "battery" "suspendSession" "powerButtonAction"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "lowBattery" "powerButtonAction"]
+      ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "powerButtonAction"]
     )
   ];
 

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -481,7 +481,7 @@ in
 
   config.assertions =
     let
-      createAssertionsForProfile = profile: [
+      generateAssertionsForProfile = profile: [
         {
           assertion = (
             cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.action != afterAPeriodOfInactivityActions.doNothing
@@ -517,9 +517,9 @@ in
       ];
 
     in
-      (createAssertionsForProfile "AC")
-      ++ (createAssertionsForProfile "battery")
-      ++ (createAssertionsForProfile "lowBattery")
+      (generateAssertionsForProfile "AC")
+      ++ (generateAssertionsForProfile "battery")
+      ++ (generateAssertionsForProfile "lowBattery")
       ++ generalAssertions;
 
   options = {

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -40,6 +40,12 @@ let
   # can generate the options by just specifying the type (i.e. "AC" or
   # "battery").
   createPowerDevilOptions = type: {
+    suspendSession = {};
+
+    displayAndBrightness = {};
+
+    otherSettings = {};
+
     powerButtonAction = lib.mkOption {
       type = with lib.types; nullOr (enum (builtins.attrNames powerButtonActions));
       default = null;

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -102,7 +102,24 @@ let
       };
     };
 
-    displayAndBrightness = {};
+    displayAndBrightness = {
+      changeScreenBrightness = {
+        enable = lib.mkOption {
+          type = with lib.types; nullOr bool;
+          default = null;
+          example = true;
+          description = "Enable or disable screen brightness changing.";
+        };
+        percentage = lib.mkOption {
+          type = with lib.types; nullOr (ints.between 0 100);
+          default = null;
+          example = 70;
+          description = ''
+            The screen brightness percentage when on ${type}.
+          '';
+        };
+      };
+    };
 
     otherSettings = {};
 
@@ -168,22 +185,6 @@ let
         '';
       };
     };
-    changeScreenBrightness = {
-      enable = lib.mkOption {
-        type = with lib.types; nullOr bool;
-        default = null;
-        example = true;
-        description = "Enable or disable screen brightness changing.";
-      };
-      percentage = lib.mkOption {
-        type = with lib.types; nullOr (ints.between 0 100);
-        default = null;
-        example = 70;
-        description = ''
-          The screen brightness percentage when on ${type}.
-        '';
-      };
-    };
   };
 
   # By the same logic as createPowerDevilOptions, we can generate the
@@ -213,13 +214,13 @@ let
           null;
       DimDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.dimDisplay.idleTimeout;
       UseProfileSpecificDisplayBrightness=
-        if (cfg.powerdevil.${optionsName}.changeScreenBrightness.enable != null) then
-          cfg.powerdevil.${optionsName}.changeScreenBrightness.enable
-        else if (cfg.powerdevil.${optionsName}.changeScreenBrightness.percentage != null) then
+        if (cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.enable != null) then
+          cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.enable
+        else if (cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.percentage != null) then
           true
         else
           null;
-      DisplayBrightness=cfg.powerdevil.${optionsName}.changeScreenBrightness.percentage;
+      DisplayBrightness=cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.percentage;
     };
   };
 in
@@ -297,6 +298,18 @@ in
       ["programs" "plasma" "powerdevil" "lowBattery" "whenSleepingEnter"]
       ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "whenSleepingEnter"]
     )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "AC" "changeScreenBrightness"]
+      ["programs" "plasma" "powerdevil" "AC" "displayAndBrightness" "changeScreenBrightness"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "battery" "changeScreenBrightness"]
+      ["programs" "plasma" "powerdevil" "battery" "displayAndBrightness" "changeScreenBrightness"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "lowBattery" "changeScreenBrightness"]
+      ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "changeScreenBrightness"]
+    )
   ];
 
   config.assertions =
@@ -325,10 +338,10 @@ in
         }
         {
           assertion = (
-            cfg.powerdevil.${type}.changeScreenBrightness.enable != false
-            || cfg.powerdevil.${type}.changeScreenBrightness.percentage == null
+            cfg.powerdevil.${type}.displayAndBrightness.changeScreenBrightness.enable != false
+            || cfg.powerdevil.${type}.displayAndBrightness.changeScreenBrightness.percentage == null
           );
-          message = "Cannot set programs.plasma.powerdevil.${type}.changeScreenBrightness.percentage when programs.plasma.powerdevil.${type}.changeScreenBrightness.enable is disabled.";
+          message = "Cannot set programs.plasma.powerdevil.${type}.displayAndBrightness.changeScreenBrightness.percentage when programs.plasma.powerdevil.${type}.displayAndBrightness.changeScreenBrightness.enable is disabled.";
         }
       ];
     in

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -194,8 +194,7 @@ let
         };
 
         idleTimeoutWhenLocked = lib.mkOption {
-          type =
-            with lib.types;
+          type = with lib.types;
             nullOr (either
               (enum ["whenLockedAndUnlocked" "immediately"])
               (ints.between 10 604800));
@@ -235,9 +234,8 @@ let
 
     otherSettings = {
       switchToPowerProfile = lib.mkOption {
-        type =
-          with lib.types;
-            nullOr (enum (builtins.attrNames switchToPowerProfileActions));
+        type = with lib.types;
+          nullOr (enum (builtins.attrNames switchToPowerProfileActions));
         default = null;
         example = "performance";
         description = "The power profile, when on ${profile}, adopted by the computer.";

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -69,11 +69,7 @@ let
       afterAPeriodOfInactivity = {
         action = lib.mkOption {
           type = with lib.types;
-            nullOr (
-              enum (
-                builtins.attrNames afterAPeriodOfInactivityActions
-              )
-            );
+            nullOr (enum (builtins.attrNames afterAPeriodOfInactivityActions));
           default = null;
           example = "doNothing";
           description = ''
@@ -88,9 +84,7 @@ let
 
         idleTimeout = lib.mkOption {
           type = with lib.types;
-            nullOr (
-              ints.between 60 604800
-            );
+            nullOr (ints.between 60 604800);
           default = null;
           example = 600;
           description = ''
@@ -102,11 +96,7 @@ let
 
       whenPowerButtonPressed = lib.mkOption {
         type = with lib.types;
-          nullOr (
-            enum (
-              builtins.attrNames whenPowerButtonPressedActions
-            )
-          );
+          nullOr (enum (builtins.attrNames whenPowerButtonPressedActions));
         default = null;
         example = "doNothing";
         description = ''
@@ -121,11 +111,7 @@ let
 
       whenLaptopLidClosed = lib.mkOption {
         type = with lib.types;
-          nullOr (
-            enum (
-              builtins.attrNames whenLaptopLidClosedActions
-            )
-          );
+          nullOr (enum (builtins.attrNames whenLaptopLidClosedActions));
         default = null;
         example = "shutDown";
         description = ''
@@ -140,9 +126,7 @@ let
 
       evenWhenAnExternalMonitorIsConnected = lib.mkOption {
         type = with lib.types;
-          nullOr (
-            bool
-          );
+          nullOr bool;
         default = null;
         example = false;
         description = ''
@@ -152,11 +136,7 @@ let
 
       whenSleepingEnter = lib.mkOption {
         type = with lib.types;
-          nullOr (
-            enum (
-              builtins.attrNames whenSleepingEnterActions
-            )
-          );
+          nullOr (enum (builtins.attrNames whenSleepingEnterActions));
         default = null;
         example = "standbyThenHibernate";
         description = ''
@@ -174,9 +154,7 @@ let
       changeScreenBrightness = {
         enable = lib.mkOption {
           type = with lib.types;
-            nullOr (
-              bool
-            );
+            nullOr bool;
           default = null;
           example = true;
           description = ''
@@ -186,9 +164,7 @@ let
 
         percentage = lib.mkOption {
           type = with lib.types;
-            nullOr (
-              ints.between 1 100
-            );
+            nullOr (ints.between 1 100);
           default = null;
           example = 70;
           description = ''
@@ -200,8 +176,7 @@ let
       dimAutomatically = {
         enable = lib.mkOption {
           type = with lib.types;
-            nullOr
-            bool;
+            nullOr bool;
           default = null;
           example = false;
           description = ''
@@ -211,8 +186,7 @@ let
 
         idleTimeout = lib.mkOption {
           type = with lib.types;
-            nullOr
-            (ints.between 10 604800);
+            nullOr (ints.between 10 604800);
           default = null;
           example = 300;
           description = ''
@@ -225,7 +199,9 @@ let
       turnOffScreen = {
         idleTimeout = lib.mkOption {
           type = with lib.types;
-            nullOr (either (enum [ "never" ]) (ints.between 30 604800));
+            nullOr (either
+              (enum [ "never" ])
+              (ints.between 30 604800));
           default = null;
           example = 300;
           description = ''
@@ -243,12 +219,9 @@ let
         idleTimeoutWhenLocked = lib.mkOption {
           type =
             with lib.types;
-            nullOr (
-              either (enum [
-                "whenLockedAndUnlocked"
-                "immediately"
-              ]) (ints.between 10 604800)
-            );
+            nullOr (either
+              (enum ["whenLockedAndUnlocked" "immediately"])
+              (ints.between 10 604800));
           default = null;
           example = 60;
           description = ''
@@ -270,9 +243,7 @@ let
       changeKeyboardBrightness = {
         enable = lib.mkOption {
           type = with lib.types;
-            nullOr (
-              bool
-            );
+            nullOr bool;
           default = null;
           example = true;
           description = ''
@@ -282,9 +253,7 @@ let
 
         percentage = lib.mkOption {
           type = with lib.types;
-            nullOr (
-              ints.between 0 100
-            );
+            nullOr (ints.between 0 100);
           default = null;
           example = 70;
           description = ''
@@ -298,11 +267,7 @@ let
       switchToPowerProfile = lib.mkOption {
         type =
           with lib.types;
-            nullOr (
-              enum (
-                builtins.attrNames switchToPowerProfileActions
-              )
-            );
+            nullOr (enum (builtins.attrNames switchToPowerProfileActions));
         default = null;
         example = "performance";
         description = ''
@@ -318,9 +283,7 @@ let
       runCustomScripts = {
         "whenEnteringOn${capitalize(type)}PowerState" = lib.mkOption {
           type = with lib.types;
-            nullOr (
-              str
-            );
+            nullOr str;
           default = null;
           example = "echo 'hello, world'";
           description = ''
@@ -330,9 +293,7 @@ let
         };
         "whenExitingOn${capitalize(type)}PowerState" = lib.mkOption {
           type = with lib.types;
-            nullOr (
-              str
-            );
+            nullOr str;
           default = null;
           example = "echo 'farewwll, world'";
           description = ''
@@ -343,9 +304,7 @@ let
         afterAPeriodOfInactivity = {
           script = lib.mkOption {
             type = with lib.types;
-              nullOr (
-                str
-              );
+              nullOr str;
             default = null;
             example = "echo 'are you there, world'";
             description = ''
@@ -355,9 +314,7 @@ let
           };
           idleTimeout = lib.mkOption {
             type = with lib.types;
-              nullOr (
-                ints.between 10 604800
-              );
+              nullOr (ints.between 10 604800);
             default = null;
             example = 600;
             description = ''
@@ -593,9 +550,7 @@ in
       batteryLevels = {
         lowLevel = lib.mkOption {
           type = with lib.types;
-            nullOr (
-              ints.between 0 100
-            );
+            nullOr (ints.between 0 100);
           default = null;
           example = "10";
           description = ''
@@ -606,9 +561,7 @@ in
         };
         criticalLevel = lib.mkOption {
           type = with lib.types;
-            nullOr (
-              ints.between 0 100
-            );
+            nullOr (ints.between 0 100);
           default = null;
           example = "5";
           description = ''
@@ -620,11 +573,7 @@ in
         };
         atCriticalLevel = lib.mkOption {
           type = with lib.types;
-            nullOr (
-              enum (
-                builtins.attrNames atCriticalLevelActions
-              )
-            );
+            nullOr (enum (builtins.attrNames atCriticalLevelActions));
           default = null;
           example = "hibernate";
           description = ''
@@ -639,9 +588,7 @@ in
         };
         lowLevelForPeripheralDevice = lib.mkOption {
           type = with lib.types;
-            nullOr (
-              ints.between 0 100
-            );
+            nullOr (ints.between 0 100);
           default = null;
           example = "10";
           description = ''
@@ -652,7 +599,8 @@ in
       };
       otherSettings = {
         pauseMediaPlayersWhenSuspending = lib.mkOption {
-          type = with lib.types; nullOr bool;
+          type = with lib.types;
+            nullOr bool;
           default = null;
           example = false;
           description = ''

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -47,8 +47,8 @@ let
           default = null;
           example = "nothing";
           description = ''
-          The action, when on ${type}, to perform after a certain period of inactivity.
-        '';
+            The action, when on ${type}, to perform after a certain period of inactivity.
+          '';
           apply = action: if (action == null) then null else autoSuspendActions."${action}";
         };
         idleTimeout = lib.mkOption {
@@ -56,9 +56,9 @@ let
           default = null;
           example = 600;
           description = ''
-          The duration (in seconds), when on ${type}, the computer must be idle
-          until the auto-suspend action is executed.
-        '';
+            The duration (in seconds), when on ${type}, the computer must be idle
+            until the auto-suspend action is executed.
+          '';
         };
       };
 

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -119,6 +119,24 @@ let
           '';
         };
       };
+
+      dimDisplay = {
+        enable = lib.mkOption {
+          type = with lib.types; nullOr bool;
+          default = null;
+          example = false;
+          description = "Enable or disable screen dimming.";
+        };
+        idleTimeout = lib.mkOption {
+          type = with lib.types; nullOr (ints.between 20 600000);
+          default = null;
+          example = 300;
+          description = ''
+            The duration (in seconds), when on ${type}, the computer must be idle
+            until the display starts dimming.
+          '';
+        };
+      };
     };
 
     otherSettings = {};
@@ -168,23 +186,6 @@ let
             timeout;
       };
     };
-    dimDisplay = {
-      enable = lib.mkOption {
-        type = with lib.types; nullOr bool;
-        default = null;
-        example = false;
-        description = "Enable or disable screen dimming.";
-      };
-      idleTimeout = lib.mkOption {
-        type = with lib.types; nullOr (ints.between 20 600000);
-        default = null;
-        example = 300;
-        description = ''
-          The duration (in seconds), when on ${type}, the computer must be idle
-          until the display starts dimming.
-        '';
-      };
-    };
   };
 
   # By the same logic as createPowerDevilOptions, we can generate the
@@ -206,13 +207,13 @@ let
       TurnOffDisplayIdleTimeoutWhenLockedSec =
         cfg.powerdevil.${optionsName}.turnOffDisplay.idleTimeoutWhenLocked;
       DimDisplayWhenIdle =
-        if (cfg.powerdevil.${optionsName}.dimDisplay.enable != null) then
-          cfg.powerdevil.${optionsName}.dimDisplay.enable
-        else if (cfg.powerdevil.${optionsName}.dimDisplay.idleTimeout != null) then
+        if (cfg.powerdevil.${optionsName}.displayAndBrightness.dimDisplay.enable != null) then
+          cfg.powerdevil.${optionsName}.displayAndBrightness.dimDisplay.enable
+        else if (cfg.powerdevil.${optionsName}.displayAndBrightness.dimDisplay.idleTimeout != null) then
           true
         else
           null;
-      DimDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.dimDisplay.idleTimeout;
+      DimDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.dimDisplay.idleTimeout;
       UseProfileSpecificDisplayBrightness=
         if (cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.enable != null) then
           cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.enable
@@ -310,6 +311,18 @@ in
       ["programs" "plasma" "powerdevil" "lowBattery" "changeScreenBrightness"]
       ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "changeScreenBrightness"]
     )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "AC" "dimDisplay"]
+      ["programs" "plasma" "powerdevil" "AC" "displayAndBrightness" "dimDisplay"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "battery" "dimDisplay"]
+      ["programs" "plasma" "powerdevil" "battery" "displayAndBrightness" "dimDisplay"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "lowBattery" "dimDisplay"]
+      ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "dimDisplay"]
+    )
   ];
 
   config.assertions =
@@ -331,10 +344,10 @@ in
         }
         {
           assertion = (
-            cfg.powerdevil.${type}.dimDisplay.enable != false
-            || cfg.powerdevil.${type}.dimDisplay.idleTimeout == null
+            cfg.powerdevil.${type}.displayAndBrightness.dimDisplay.enable != false
+            || cfg.powerdevil.${type}.displayAndBrightness.dimDisplay.idleTimeout == null
           );
-          message = "Cannot set programs.plasma.powerdevil.${type}.dimDisplay.idleTimeout when programs.plasma.powerdevil.${type}.dimDisplay.enable is disabled.";
+          message = "Cannot set programs.plasma.powerdevil.${type}.displayAndBrightness.dimDisplay.idleTimeout when programs.plasma.powerdevil.${type}.displayAndBrightness.dimDisplay.enable is disabled.";
         }
         {
           assertion = (

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -250,25 +250,14 @@ let
   # options from (i.e. powerdevil.AC or powerdevil.battery).
   createPowerDevilConfig = cfgSectName: optionsName: {
     "${cfgSectName}/SuspendAndShutdown" = {
-      PowerButtonAction = cfg.powerdevil.${optionsName}.suspendSession.whenPowerButtonPressed;
       AutoSuspendAction = cfg.powerdevil.${optionsName}.suspendSession.afterAPeriodOfInactivity.action;
       AutoSuspendIdleTimeoutSec = cfg.powerdevil.${optionsName}.suspendSession.afterAPeriodOfInactivity.idleTimeout;
-      SleepMode = cfg.powerdevil.${optionsName}.suspendSession.whenSleepingEnter;
+      PowerButtonAction = cfg.powerdevil.${optionsName}.suspendSession.whenPowerButtonPressed;
       LidAction = cfg.powerdevil.${optionsName}.suspendSession.whenLaptopLidClosed;
       InhibitLidActionWhenExternalMonitorPresent = ! cfg.powerdevil.${optionsName}.suspendSession.evenWhenAnExternalMonitorIsConnected;
+      SleepMode = cfg.powerdevil.${optionsName}.suspendSession.whenSleepingEnter;
     };
     "${cfgSectName}/Display" = {
-      TurnOffDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffScreen.idleTimeout;
-      TurnOffDisplayIdleTimeoutWhenLockedSec =
-        cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked;
-      DimDisplayWhenIdle =
-        if (cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.enable != null) then
-          cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.enable
-        else if (cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.idleTimeout != null) then
-          true
-        else
-          null;
-      DimDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.idleTimeout;
       UseProfileSpecificDisplayBrightness=
         if (cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.enable != null) then
           cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.enable
@@ -277,6 +266,17 @@ let
         else
           null;
       DisplayBrightness=cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.percentage;
+      DimDisplayWhenIdle =
+        if (cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.enable != null) then
+          cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.enable
+        else if (cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.idleTimeout != null) then
+          true
+        else
+          null;
+      DimDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.idleTimeout;
+      TurnOffDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffScreen.idleTimeout;
+      TurnOffDisplayIdleTimeoutWhenLockedSec =
+        cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked;
     };
   };
 in

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -310,17 +310,31 @@ let
             ${type}.
           '';
         };
-        afterAPeriodOfInactivity = lib.mkOption {
-          type = with lib.types;
-            nullOr (
-              str
-            );
-          default = null;
-          example = "echo 'are you there, world'";
-          description = ''
-            A script or the path for a script/program to be run after a period
-            of inactivity when on ${type}.
-          '';
+        afterAPeriodOfInactivity = {
+          script = lib.mkOption {
+            type = with lib.types;
+              nullOr (
+                str
+              );
+            default = null;
+            example = "echo 'are you there, world'";
+            description = ''
+              A script or the path for a script/program to be run after a period
+              of inactivity when on ${type}.
+            '';
+          };
+          idleTimeout = lib.mkOption {
+            type = with lib.types;
+              nullOr (
+                ints.between 10 604800
+              );
+            default = null;
+            example = 600;
+            description = ''
+              The duration (in seconds), when on ${type}, the computer must be
+               idle until the script is run.
+            '';
+          };
         };
       };
     };
@@ -366,7 +380,8 @@ let
     "${cfgSectName}/RunScript" = {
       ProfileLoadCommand = cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts."whenEnteringOn${capitalize(optionsName)}PowerState";
       ProfileUnloadCommand=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts."whenExitingOn${capitalize(optionsName)}PowerState";
-      IdleTimeoutCommand=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts.afterAPeriodOfInactivity;
+      IdleTimeoutCommand=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.script;
+      RunScriptIdleTimeoutSec=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.idleTimeout;
     };
   };
 in

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -174,25 +174,24 @@ let
       };
 
       dimAutomatically = {
-        enable = lib.mkOption {
-          type = with lib.types;
-            nullOr bool;
-          default = null;
-          example = false;
-          description = ''
-            Enable or disable screen dimming.
-          '';
-        };
-
         idleTimeout = lib.mkOption {
           type = with lib.types;
-            nullOr (ints.between 10 604800);
+            nullOr (either
+              (enum ["never"])
+              (ints.between 10 604800));
           default = null;
           example = 300;
           description = ''
             The duration (in seconds), when on ${type}, the computer must be idle
             until the display starts dimming.
           '';
+          apply = timeout:
+            if (timeout == null) then
+              null
+            else if (timeout == "never") then
+              -1
+            else
+              timeout;
         };
       };
 
@@ -354,13 +353,6 @@ let
         else
           null;
       DisplayBrightness=cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.percentage;
-      DimDisplayWhenIdle =
-        if (cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.enable != null) then
-          cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.enable
-        else if (cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.idleTimeout != null) then
-          true
-        else
-          null;
       DimDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.idleTimeout;
       TurnOffDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffScreen.idleTimeout;
       TurnOffDisplayIdleTimeoutWhenLockedSec =
@@ -488,6 +480,33 @@ in
       ["programs" "plasma" "powerdevil" "lowBattery" "dimDisplay"]
       ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "dimAutomatically"]
     )
+    (lib.mkRemovedOptionModule
+      ["programs" "plasma" "powerdevil" "AC" "displayAndBrightness" "dimAutomatically" "enable"]
+      ''
+      The programs.plasma.powerdevil.AC.displayAndbrightness.dimAutomatically.enable
+      option was removed. If you wish to disable the screen to dim automatically,
+      set the programs.plasma.powerdevil.AC.displayAndbrightness.dimAutomatically.idleTimeout
+      to "never".
+      ''
+    )
+    (lib.mkRemovedOptionModule
+      ["programs" "plasma" "powerdevil" "battery" "displayAndBrightness" "dimAutomatically" "enable"]
+      ''
+      The programs.plasma.powerdevil.battery.displayAndbrightness.dimAutomatically.enable
+      option was removed. If you wish to disable the screen to dim automatically,
+      set the programs.plasma.powerdevil.battery.displayAndbrightness.dimAutomatically.idleTimeout
+      to "never".
+      ''
+    )
+    (lib.mkRemovedOptionModule
+      ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "dimAutomatically" "enable"]
+      ''
+      The programs.plasma.powerdevil.lowBattery.displayAndbrightness.dimAutomatically.enable
+      option was removed. If you wish to disable the screen to dim automatically,
+      set the programs.plasma.powerdevil.lowBattery.displayAndbrightness.dimAutomatically.idleTimeout
+      to "never".
+      ''
+    )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "AC" "turnOffDisplay"]
       ["programs" "plasma" "powerdevil" "AC" "displayAndBrightness" "turnOffScreen"]
@@ -522,13 +541,6 @@ in
             || cfg.powerdevil.${type}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked == null
           );
           message = "Setting programs.plasma.powerdevil.${type}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked for idleTimeout \"never\" is not supported.";
-        }
-        {
-          assertion = (
-            cfg.powerdevil.${type}.displayAndBrightness.dimAutomatically.enable != false
-            || cfg.powerdevil.${type}.displayAndBrightness.dimAutomatically.idleTimeout == null
-          );
-          message = "Cannot set programs.plasma.powerdevil.${type}.displayAndBrightness.dimAutomatically.idleTimeout when programs.plasma.powerdevil.${type}.displayAndBrightness.dimAutomatically.enable is disabled.";
         }
         {
           assertion = (

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -50,6 +50,17 @@ let
     shutDown = 8;
   };
 
+  # ancillary function
+  capitalize = string:
+    with lib.strings;
+    concatImapStrings
+      (pos: char:
+        if (pos == 1) then
+          toUpper char
+        else
+          char)
+      (stringToCharacters string);
+
   # Since AC and battery allows the same options we create a function here which
   # can generate the options by just specifying the type (i.e. "AC" or
   # "battery").
@@ -273,6 +284,45 @@ let
           else
             switchToPowerProfileActions."${profile}";
       };
+
+      runCustomScripts = {
+        "whenEnteringOn${capitalize(type)}PowerState" = lib.mkOption {
+          type = with lib.types;
+            nullOr (
+              str
+            );
+          default = null;
+          example = "echo 'hello, world'";
+          description = ''
+            A script or the path for a script/program to be run when entering
+            ${type}.
+          '';
+        };
+        "whenExitingOn${capitalize(type)}PowerState" = lib.mkOption {
+          type = with lib.types;
+            nullOr (
+              str
+            );
+          default = null;
+          example = "echo 'farewwll, world'";
+          description = ''
+            A script or the path for a script/program to be run when exiting
+            ${type}.
+          '';
+        };
+        afterAPeriodOfInactivity = lib.mkOption {
+          type = with lib.types;
+            nullOr (
+              str
+            );
+          default = null;
+          example = "echo 'are you there, world'";
+          description = ''
+            A script or the path for a script/program to be run after a period
+            of inactivity when on ${type}.
+          '';
+        };
+      };
     };
   };
 
@@ -312,6 +362,11 @@ let
     };
     "${cfgSectName}/Performance" = {
       PowerProfile=cfg.powerdevil.${optionsName}.otherSettings.switchToPowerProfile;
+    };
+    "${cfgSectName}/RunScript" = {
+      ProfileLoadCommand = cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts."whenEnteringOn${capitalize(optionsName)}PowerState";
+      ProfileUnloadCommand=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts."whenExitingOn${capitalize(optionsName)}PowerState";
+      IdleTimeoutCommand=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts.afterAPeriodOfInactivity;
     };
   };
 in

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -458,6 +458,41 @@ let
       )
     ];
 
+    generateAssertionsForProfile = profile: [
+      {
+        assertion = (
+          cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.action != afterAPeriodOfInactivityActions.doNothing
+          || cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.idleTimeout == null
+        );
+        message = "Setting programs.plasma.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.idleTimeout for autosuspend-action \"doNothing\" is not supported.";
+      }
+      {
+        assertion = (
+          cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeout != -1
+          || cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked == null
+        );
+        message = "Setting programs.plasma.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked for idleTimeout \"never\" is not supported.";
+      }
+      {
+        assertion = (
+          cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable != false
+          || cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage == null
+        );
+        message = "Cannot set programs.plasma.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage when programs.plasma.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable is disabled.";
+      }
+    ];
+
+    generalAssertions = [
+      {
+        assertion = (
+          cfg.powerdevil.batteryLevels.lowLevel == null
+          || cfg.powerdevil.batteryLevels.criticalLevel == null
+          || cfg.powerdevil.batteryLevels.lowLevel > cfg.powerdevil.batteryLevels.criticalLevel
+        );
+        message = "programs.plasma.powerdevil.batteryLevels.criticalLevel cannot be greater than programs.plasma.powerdevil.batteryLevels.lowLevel.";
+      }
+    ];
+
 in
 {
   imports =
@@ -467,47 +502,10 @@ in
     ++ generalModifiedOptionsModules;
 
   config.assertions =
-    let
-      generateAssertionsForProfile = profile: [
-        {
-          assertion = (
-            cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.action != afterAPeriodOfInactivityActions.doNothing
-            || cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.idleTimeout == null
-          );
-          message = "Setting programs.plasma.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.idleTimeout for autosuspend-action \"doNothing\" is not supported.";
-        }
-        {
-          assertion = (
-            cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeout != -1
-            || cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked == null
-          );
-          message = "Setting programs.plasma.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked for idleTimeout \"never\" is not supported.";
-        }
-        {
-          assertion = (
-            cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable != false
-            || cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage == null
-          );
-          message = "Cannot set programs.plasma.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage when programs.plasma.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable is disabled.";
-        }
-      ];
-
-      generalAssertions = [
-        {
-          assertion = (
-            cfg.powerdevil.batteryLevels.lowLevel == null
-            || cfg.powerdevil.batteryLevels.criticalLevel == null
-            || cfg.powerdevil.batteryLevels.lowLevel > cfg.powerdevil.batteryLevels.criticalLevel
-          );
-          message = "programs.plasma.powerdevil.batteryLevels.criticalLevel cannot be greater than programs.plasma.powerdevil.batteryLevels.lowLevel.";
-        }
-      ];
-
-    in
-      (generateAssertionsForProfile "AC")
-      ++ (generateAssertionsForProfile "battery")
-      ++ (generateAssertionsForProfile "lowBattery")
-      ++ generalAssertions;
+    (generateAssertionsForProfile "AC")
+    ++ (generateAssertionsForProfile "battery")
+    ++ (generateAssertionsForProfile "lowBattery")
+    ++ generalAssertions;
 
   options = {
     programs.plasma.powerdevil = {

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -183,7 +183,7 @@ let
         percentage = lib.mkOption {
           type = with lib.types;
             nullOr (
-              ints.between 0 100
+              ints.between 1 100
             );
           default = null;
           example = 70;

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -481,27 +481,27 @@ in
 
   config.assertions =
     let
-      createAssertions = type: [
+      createAssertions = profile: [
         {
           assertion = (
-            cfg.powerdevil.${type}.suspendSession.afterAPeriodOfInactivity.action != afterAPeriodOfInactivityActions.doNothing
-            || cfg.powerdevil.${type}.suspendSession.afterAPeriodOfInactivity.idleTimeout == null
+            cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.action != afterAPeriodOfInactivityActions.doNothing
+            || cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.idleTimeout == null
           );
-          message = "Setting programs.plasma.powerdevil.${type}.suspendSession.afterAPeriodOfInactivity.idleTimeout for autosuspend-action \"doNothing\" is not supported.";
+          message = "Setting programs.plasma.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.idleTimeout for autosuspend-action \"doNothing\" is not supported.";
         }
         {
           assertion = (
-            cfg.powerdevil.${type}.displayAndBrightness.turnOffScreen.idleTimeout != -1
-            || cfg.powerdevil.${type}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked == null
+            cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeout != -1
+            || cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked == null
           );
-          message = "Setting programs.plasma.powerdevil.${type}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked for idleTimeout \"never\" is not supported.";
+          message = "Setting programs.plasma.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked for idleTimeout \"never\" is not supported.";
         }
         {
           assertion = (
-            cfg.powerdevil.${type}.displayAndBrightness.changeScreenBrightness.enable != false
-            || cfg.powerdevil.${type}.displayAndBrightness.changeScreenBrightness.percentage == null
+            cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable != false
+            || cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage == null
           );
-          message = "Cannot set programs.plasma.powerdevil.${type}.displayAndBrightness.changeScreenBrightness.percentage when programs.plasma.powerdevil.${type}.displayAndBrightness.changeScreenBrightness.enable is disabled.";
+          message = "Cannot set programs.plasma.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage when programs.plasma.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable is disabled.";
         }
         {
           assertion = (

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -221,49 +221,16 @@ in
 {
   imports = [
     (lib.mkRenamedOptionModule
-      [
-        "programs"
-        "plasma"
-        "powerdevil"
-        "powerButtonAction"
-      ]
-      [
-        "programs"
-        "plasma"
-        "powerdevil"
-        "AC"
-        "powerButtonAction"
-      ]
+      ["programs" "plasma" "powerdevil" "powerButtonAction"]
+      ["programs" "plasma" "powerdevil" "AC" "powerButtonAction"]
     )
     (lib.mkRenamedOptionModule
-      [
-        "programs"
-        "plasma"
-        "powerdevil"
-        "autoSuspend"
-      ]
-      [
-        "programs"
-        "plasma"
-        "powerdevil"
-        "AC"
-        "autoSuspend"
-      ]
+      ["programs" "plasma" "powerdevil" "autoSuspend"]
+      ["programs" "plasma" "powerdevil" "AC" "autoSuspend"]
     )
     (lib.mkRenamedOptionModule
-      [
-        "programs"
-        "plasma"
-        "powerdevil"
-        "turnOffDisplay"
-      ]
-      [
-        "programs"
-        "plasma"
-        "powerdevil"
-        "AC"
-        "turnOffDisplay"
-      ]
+      ["programs" "plasma" "powerdevil" "turnOffDisplay"]
+      ["programs" "plasma" "powerdevil" "AC" "turnOffDisplay"]
     )
   ];
 

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -596,6 +596,18 @@ in
             else atCriticalLevelActions."${action}";
 
         };
+        lowLevelForPeripheralDevice = lib.mkOption {
+          type = with lib.types;
+            nullOr (
+              ints.between 0 100
+            );
+          default = null;
+          example = "10";
+          description = ''
+            The battery charge for peripheral devices will be considered low
+             when it reaches this level.
+          '';
+        };
       };
       otherSettings = {
         pauseMediaPlayersWhenSuspending = lib.mkOption {
@@ -620,6 +632,7 @@ in
           BatteryLowLevel = cfg.powerdevil.batteryLevels.lowLevel;
           BatteryCriticalLevel = cfg.powerdevil.batteryLevels.criticalLevel;
           BatteryCriticalAction = cfg.powerdevil.batteryLevels.atCriticalLevel;
+          PeripheralBatteryLowLevel = cfg.powerdevil.batteryLevels.lowLevelForPeripheralDevice;
         };
         General = {
           pausePlayersOnSuspend = cfg.powerdevil.otherSettings.pauseMediaPlayersWhenSuspending;

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -290,7 +290,7 @@ let
   # configuration. cfgSectName is here the name of the section in powerdevilrc,
   # while profile is the name of the "namespace" where we should draw the
   # options from (i.e. powerdevil.AC or powerdevil.battery).
-  createPowerDevilConfig = cfgSectName: profile: {
+  generateConfigForProfile = cfgSectName: profile: {
     "${cfgSectName}/SuspendAndShutdown" = {
       AutoSuspendAction = cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.action;
       AutoSuspendIdleTimeoutSec = cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.idleTimeout;
@@ -574,9 +574,9 @@ in
 
   config.programs.plasma.configFile = lib.mkIf cfg.enable {
     powerdevilrc = lib.filterAttrsRecursive (k: v: v != null) (
-      (createPowerDevilConfig "AC" "AC")
-      // (createPowerDevilConfig "Battery" "battery")
-      // (createPowerDevilConfig "LowBattery" "lowBattery")
+      (generateConfigForProfile "AC" "AC")
+      // (generateConfigForProfile "Battery" "battery")
+      // (generateConfigForProfile "LowBattery" "lowBattery")
       // generalConfig
     );
   };

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -137,55 +137,55 @@ let
           '';
         };
       };
+
+      turnOffDisplay = {
+        idleTimeout = lib.mkOption {
+          type = with lib.types; nullOr (either (enum [ "never" ]) (ints.between 30 600000));
+          default = null;
+          example = 300;
+          description = ''
+            The duration (in seconds), when on ${type}, the computer must be idle
+            (when unlocked) until the display turns off.
+          '';
+          apply =
+            timeout:
+            if (timeout == null) then
+              null
+            else if (timeout == "never") then
+              -1
+            else
+              timeout;
+        };
+        idleTimeoutWhenLocked = lib.mkOption {
+          type =
+            with lib.types;
+            nullOr (
+              either (enum [
+                "whenLockedAndUnlocked"
+                "immediately"
+              ]) (ints.between 20 600000)
+            );
+          default = null;
+          example = 60;
+          description = ''
+            The duration (in seconds), when on ${type}, the computer must be idle
+            (when locked) until the display turns off.
+          '';
+          apply =
+            timeout:
+            if (timeout == null) then
+              null
+            else if (timeout == "whenLockedAndUnlocked") then
+              -2
+            else if (timeout == "immediately") then
+              0
+            else
+              timeout;
+        };
+      };
     };
 
     otherSettings = {};
-
-    turnOffDisplay = {
-      idleTimeout = lib.mkOption {
-        type = with lib.types; nullOr (either (enum [ "never" ]) (ints.between 30 600000));
-        default = null;
-        example = 300;
-        description = ''
-          The duration (in seconds), when on ${type}, the computer must be idle
-          (when unlocked) until the display turns off.
-        '';
-        apply =
-          timeout:
-          if (timeout == null) then
-            null
-          else if (timeout == "never") then
-            -1
-          else
-            timeout;
-      };
-      idleTimeoutWhenLocked = lib.mkOption {
-        type =
-          with lib.types;
-          nullOr (
-            either (enum [
-              "whenLockedAndUnlocked"
-              "immediately"
-            ]) (ints.between 20 600000)
-          );
-        default = null;
-        example = 60;
-        description = ''
-          The duration (in seconds), when on ${type}, the computer must be idle
-          (when locked) until the display turns off.
-        '';
-        apply =
-          timeout:
-          if (timeout == null) then
-            null
-          else if (timeout == "whenLockedAndUnlocked") then
-            -2
-          else if (timeout == "immediately") then
-            0
-          else
-            timeout;
-      };
-    };
   };
 
   # By the same logic as createPowerDevilOptions, we can generate the
@@ -203,9 +203,9 @@ let
         cfg.powerdevil.${optionsName}.suspendSession.inhibitLidActionWhenExternalMonitorConnected;
     };
     "${cfgSectName}/Display" = {
-      TurnOffDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.turnOffDisplay.idleTimeout;
+      TurnOffDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffDisplay.idleTimeout;
       TurnOffDisplayIdleTimeoutWhenLockedSec =
-        cfg.powerdevil.${optionsName}.turnOffDisplay.idleTimeoutWhenLocked;
+        cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffDisplay.idleTimeoutWhenLocked;
       DimDisplayWhenIdle =
         if (cfg.powerdevil.${optionsName}.displayAndBrightness.dimDisplay.enable != null) then
           cfg.powerdevil.${optionsName}.displayAndBrightness.dimDisplay.enable
@@ -323,6 +323,18 @@ in
       ["programs" "plasma" "powerdevil" "lowBattery" "dimDisplay"]
       ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "dimDisplay"]
     )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "AC" "turnOffDisplay"]
+      ["programs" "plasma" "powerdevil" "AC" "displayAndBrightness" "turnOffDisplay"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "battery" "turnOffDisplay"]
+      ["programs" "plasma" "powerdevil" "battery" "displayAndBrightness" "turnOffDisplay"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "lowBattery" "turnOffDisplay"]
+      ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "turnOffDisplay"]
+    )
   ];
 
   config.assertions =
@@ -337,10 +349,10 @@ in
         }
         {
           assertion = (
-            cfg.powerdevil.${type}.turnOffDisplay.idleTimeout != -1
-            || cfg.powerdevil.${type}.turnOffDisplay.idleTimeoutWhenLocked == null
+            cfg.powerdevil.${type}.displayAndBrightness.turnOffDisplay.idleTimeout != -1
+            || cfg.powerdevil.${type}.displayAndBrightness.turnOffDisplay.idleTimeoutWhenLocked == null
           );
-          message = "Setting programs.plasma.powerdevil.${type}.turnOffDisplay.idleTimeoutWhenLocked for idleTimeout \"never\" is not supported.";
+          message = "Setting programs.plasma.powerdevil.${type}.displayAndBrightness.turnOffDisplay.idleTimeoutWhenLocked for idleTimeout \"never\" is not supported.";
         }
         {
           assertion = (

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -367,17 +367,6 @@ let
         cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked;
     };
 
-    "${cfgSectName}/Performance" = {
-      PowerProfile=cfg.powerdevil.${optionsName}.otherSettings.switchToPowerProfile;
-    };
-
-    "${cfgSectName}/RunScript" = {
-      ProfileLoadCommand = cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts."whenEnteringOn${capitalize(optionsName)}PowerState";
-      ProfileUnloadCommand=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts."whenExitingOn${capitalize(optionsName)}PowerState";
-      IdleTimeoutCommand=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.script;
-      RunScriptIdleTimeoutSec=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.idleTimeout;
-    };
-
     "${cfgSectName}/Keyboard" = {
       UseProfileSpecificKeyboardBrightness=
         if (cfg.powerdevil.${optionsName}.displayAndBrightness.changeKeyboardBrightness.enable != null) then
@@ -387,6 +376,17 @@ let
         else
           null;
       KeyboardBrightness=cfg.powerdevil.${optionsName}.displayAndBrightness.changeKeyboardBrightness.percentage;
+    };
+
+    "${cfgSectName}/Performance" = {
+      PowerProfile=cfg.powerdevil.${optionsName}.otherSettings.switchToPowerProfile;
+    };
+
+    "${cfgSectName}/RunScript" = {
+      ProfileLoadCommand = cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts."whenEnteringOn${capitalize(optionsName)}PowerState";
+      ProfileUnloadCommand=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts."whenExitingOn${capitalize(optionsName)}PowerState";
+      IdleTimeoutCommand=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.script;
+      RunScriptIdleTimeoutSec=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.idleTimeout;
     };
   };
 in

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -82,12 +82,12 @@ let
         apply = action: if (action == null) then null else whenLaptopLidClosedActions."${action}";
       };
 
-      inhibitLidActionWhenExternalMonitorConnected = lib.mkOption {
+      evenWhenAnExternalMonitorIsConnected = lib.mkOption {
         type = with lib.types; nullOr bool;
         default = null;
-        example = true;
+        example = false;
         description = ''
-          If enabled, the lid action will be inhibited when an external monitor is connected.
+          If enabled, the lid action will be executed even when an external monitor is connected.
         '';
       };
 
@@ -199,8 +199,7 @@ let
       AutoSuspendIdleTimeoutSec = cfg.powerdevil.${optionsName}.suspendSession.afterAPeriodOfInactivity.idleTimeout;
       SleepMode = cfg.powerdevil.${optionsName}.suspendSession.whenSleepingEnter;
       LidAction = cfg.powerdevil.${optionsName}.suspendSession.whenLaptopLidClosed;
-      InhibitLidActionWhenExternalMonitorPresent =
-        cfg.powerdevil.${optionsName}.suspendSession.inhibitLidActionWhenExternalMonitorConnected;
+      InhibitLidActionWhenExternalMonitorPresent = ! cfg.powerdevil.${optionsName}.suspendSession.evenWhenAnExternalMonitorIsConnected;
     };
     "${cfgSectName}/Display" = {
       TurnOffDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffDisplay.idleTimeout;
@@ -277,15 +276,15 @@ in
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "AC" "inhibitLidActionWhenExternalMonitorConnected"]
-      ["programs" "plasma" "powerdevil" "AC" "suspendSession" "inhibitLidActionWhenExternalMonitorConnected"]
+      ["programs" "plasma" "powerdevil" "AC" "suspendSession" "evenWhenAnExternalMonitorIsConnected"]
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "battery" "inhibitLidActionWhenExternalMonitorConnected"]
-      ["programs" "plasma" "powerdevil" "battery" "suspendSession" "inhibitLidActionWhenExternalMonitorConnected"]
+      ["programs" "plasma" "powerdevil" "battery" "suspendSession" "evenWhenAnExternalMonitorIsConnected"]
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "lowBattery" "inhibitLidActionWhenExternalMonitorConnected"]
-      ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "inhibitLidActionWhenExternalMonitorConnected"]
+      ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "evenWhenAnExternalMonitorIsConnected"]
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "AC" "whenSleepingEnter"]

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -64,7 +64,7 @@ let
   # Since AC and battery allows the same options we create a function here which
   # can generate the options by just specifying the type (i.e. "AC" or
   # "battery").
-  createPowerDevilOptions = type: {
+  createPowerDevilOptions = profile: {
     suspendSession = {
       afterAPeriodOfInactivity = {
         action = lib.mkOption {
@@ -72,7 +72,7 @@ let
             nullOr (enum (builtins.attrNames afterAPeriodOfInactivityActions));
           default = null;
           example = "doNothing";
-          description = "The action, when on ${type}, to perform after a certain period of inactivity.";
+          description = "The action, when on ${profile}, to perform after a certain period of inactivity.";
           apply = action:
             if (action == null) then
               null
@@ -85,7 +85,7 @@ let
             nullOr (ints.between 60 604800);
           default = null;
           example = 600;
-          description = "The duration (in seconds), when on ${type}, the computer must be idle until the auto-suspend action is executed.";
+          description = "The duration (in seconds), when on ${profile}, the computer must be idle until the auto-suspend action is executed.";
         };
       };
 
@@ -94,7 +94,7 @@ let
           nullOr (enum (builtins.attrNames whenPowerButtonPressedActions));
         default = null;
         example = "doNothing";
-        description = "The action, when on ${type}, to perform when the power button is pressed.";
+        description = "The action, when on ${profile}, to perform when the power button is pressed.";
         apply = action:
           if (action == null) then
             null
@@ -107,7 +107,7 @@ let
           nullOr (enum (builtins.attrNames whenLaptopLidClosedActions));
         default = null;
         example = "shutDown";
-        description = "The action, when on ${type}, to perform when the laptop lid is closed.";
+        description = "The action, when on ${profile}, to perform when the laptop lid is closed.";
         apply = action:
           if (action == null) then
             null
@@ -120,7 +120,7 @@ let
           nullOr bool;
         default = null;
         example = false;
-        description = "If enabled, when on ${type}, the lid action will be executed even when an external monitor is connected.";
+        description = "If enabled, when on ${profile}, the lid action will be executed even when an external monitor is connected.";
       };
 
       whenSleepingEnter = lib.mkOption {
@@ -128,7 +128,7 @@ let
           nullOr (enum (builtins.attrNames whenSleepingEnterActions));
         default = null;
         example = "standbyThenHibernate";
-        description = "The state, when on ${type}, to enter when sleeping.";
+        description = "The state, when on ${profile}, to enter when sleeping.";
         apply = action:
           if (action == null) then
             null
@@ -144,7 +144,7 @@ let
             nullOr bool;
           default = null;
           example = true;
-          description = "Enable or disable, when on ${type}, changing the screen brightness.";
+          description = "Enable or disable, when on ${profile}, changing the screen brightness.";
         };
 
         percentage = lib.mkOption {
@@ -152,7 +152,7 @@ let
             nullOr (ints.between 1 100);
           default = null;
           example = 70;
-          description = "The screen brightness percentage when on ${type}.";
+          description = "The screen brightness percentage when on ${profile}.";
         };
       };
 
@@ -164,7 +164,7 @@ let
               (ints.between 10 604800));
           default = null;
           example = 300;
-          description = "The duration (in seconds), when on ${type}, the computer must be idle until the display starts dimming.";
+          description = "The duration (in seconds), when on ${profile}, the computer must be idle until the display starts dimming.";
           apply = timeout:
             if (timeout == null) then
               null
@@ -183,7 +183,7 @@ let
               (ints.between 30 604800));
           default = null;
           example = 300;
-          description = "The duration (in seconds), when on ${type}, the computer must be idle (when unlocked) until the display turns off.";
+          description = "The duration (in seconds), when on ${profile}, the computer must be idle (when unlocked) until the display turns off.";
           apply = timeout:
             if (timeout == null) then
               null
@@ -201,7 +201,7 @@ let
               (ints.between 10 604800));
           default = null;
           example = 60;
-          description = "The duration (in seconds), when on ${type}, the computer must be idle (when locked) until the display turns off.";
+          description = "The duration (in seconds), when on ${profile}, the computer must be idle (when locked) until the display turns off.";
           apply = timeout:
             if (timeout == null) then
               null
@@ -220,7 +220,7 @@ let
             nullOr bool;
           default = null;
           example = true;
-          description = "Enable or disable, when on ${type}, changing the keyboard brightness.";
+          description = "Enable or disable, when on ${profile}, changing the keyboard brightness.";
         };
 
         percentage = lib.mkOption {
@@ -228,7 +228,7 @@ let
             nullOr (ints.between 0 100);
           default = null;
           example = 70;
-          description = "The keyboard brightness percentage when on ${type}.";
+          description = "The keyboard brightness percentage when on ${profile}.";
         };
       };
     };
@@ -240,7 +240,7 @@ let
             nullOr (enum (builtins.attrNames switchToPowerProfileActions));
         default = null;
         example = "performance";
-        description = "The power profile, when on ${type}, adopted by the computer.";
+        description = "The power profile, when on ${profile}, adopted by the computer.";
         apply = profile:
           if (profile == null || profile == "leaveUnchanged") then
             null
@@ -249,20 +249,20 @@ let
       };
 
       runCustomScripts = {
-        "whenEnteringOn${capitalize(type)}PowerState" = lib.mkOption {
+        "whenEnteringOn${capitalize(profile)}PowerState" = lib.mkOption {
           type = with lib.types;
             nullOr str;
           default = null;
           example = "echo 'hello, world'";
-          description = "A script or the path for a script/program to be run when entering ${type}.";
+          description = "A script or the path for a script/program to be run when entering ${profile}.";
         };
 
-        "whenExitingOn${capitalize(type)}PowerState" = lib.mkOption {
+        "whenExitingOn${capitalize(profile)}PowerState" = lib.mkOption {
           type = with lib.types;
             nullOr str;
           default = null;
           example = "echo 'farewwll, world'";
-          description = "A script or the path for a script/program to be run when exiting ${type}.";
+          description = "A script or the path for a script/program to be run when exiting ${profile}.";
         };
 
         afterAPeriodOfInactivity = {
@@ -271,7 +271,7 @@ let
               nullOr str;
             default = null;
             example = "echo 'are you there, world'";
-            description = "A script or the path for a script/program to be run after a period of inactivity when on ${type}.";
+            description = "A script or the path for a script/program to be run after a period of inactivity when on ${profile}.";
           };
 
           idleTimeout = lib.mkOption {
@@ -279,7 +279,7 @@ let
               nullOr (ints.between 10 604800);
             default = null;
             example = 600;
-            description = "The duration (in seconds), when on ${type}, the computer must be idle until the script is run.";
+            description = "The duration (in seconds), when on ${profile}, the computer must be idle until the script is run.";
           };
         };
       };

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -2,6 +2,10 @@
 let
   cfg = config.programs.plasma;
 
+  # ============================
+  # === options declarations ===
+  # ============================
+
   afterAPeriodOfInactivityActions = {
     doNothing = 0;
     sleep = 1;
@@ -335,6 +339,11 @@ let
     };
   };
 
+
+  # ==================================
+  # === configuration declarations ===
+  # ==================================
+
   # By the same logic as generateOptionsForProfile, we can generate the
   # configuration. cfgSectName is here the name of the section in powerdevilrc,
   # while profile is the name of the "namespace" where we should draw the
@@ -399,6 +408,11 @@ let
     };
   };
 
+
+  # =============================================
+  # === modified options modules declarations ===
+  # =============================================
+
   generateModifiedOptionsModules = profile:
     [
       (lib.mkRenamedOptionModule
@@ -439,59 +453,64 @@ let
       )
     ];
 
-    generalModifiedOptionsModules = [
-      (lib.mkRenamedOptionModule
-        ["programs" "plasma" "powerdevil" "powerButtonAction"]
-        ["programs" "plasma" "powerdevil" "AC" "powerButtonAction"]
-      )
-      (lib.mkRenamedOptionModule
-        ["programs" "plasma" "powerdevil" "autoSuspend"]
-        ["programs" "plasma" "powerdevil" "AC" "autoSuspend"]
-      )
-      (lib.mkRenamedOptionModule
-        ["programs" "plasma" "powerdevil" "turnOffDisplay"]
-        ["programs" "plasma" "powerdevil" "AC" "turnOffDisplay"]
-      )
-      (lib.mkRenamedOptionModule
-        ["programs" "plasma" "powerdevil" "general" "pausePlayersOnSuspend"]
-        ["programs" "plasma" "powerdevil" "otherSettings" "pauseMediaPlayersWhenSuspending"]
-      )
-    ];
+  generalModifiedOptionsModules = [
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "powerButtonAction"]
+      ["programs" "plasma" "powerdevil" "AC" "powerButtonAction"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "autoSuspend"]
+      ["programs" "plasma" "powerdevil" "AC" "autoSuspend"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "turnOffDisplay"]
+      ["programs" "plasma" "powerdevil" "AC" "turnOffDisplay"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "general" "pausePlayersOnSuspend"]
+      ["programs" "plasma" "powerdevil" "otherSettings" "pauseMediaPlayersWhenSuspending"]
+    )
+  ];
 
-    generateAssertionsForProfile = profile: [
-      {
-        assertion = (
-          cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.action != afterAPeriodOfInactivityActions.doNothing
-          || cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.idleTimeout == null
-        );
-        message = "Setting programs.plasma.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.idleTimeout for autosuspend-action \"doNothing\" is not supported.";
-      }
-      {
-        assertion = (
-          cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeout != -1
-          || cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked == null
-        );
-        message = "Setting programs.plasma.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked for idleTimeout \"never\" is not supported.";
-      }
-      {
-        assertion = (
-          cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable != false
-          || cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage == null
-        );
-        message = "Cannot set programs.plasma.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage when programs.plasma.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable is disabled.";
-      }
-    ];
 
-    generalAssertions = [
-      {
-        assertion = (
-          cfg.powerdevil.batteryLevels.lowLevel == null
-          || cfg.powerdevil.batteryLevels.criticalLevel == null
-          || cfg.powerdevil.batteryLevels.lowLevel > cfg.powerdevil.batteryLevels.criticalLevel
-        );
-        message = "programs.plasma.powerdevil.batteryLevels.criticalLevel cannot be greater than programs.plasma.powerdevil.batteryLevels.lowLevel.";
-      }
-    ];
+  # ===============================
+  # === assertions declarations ===
+  # ===============================
+
+  generateAssertionsForProfile = profile: [
+    {
+      assertion = (
+        cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.action != afterAPeriodOfInactivityActions.doNothing
+        || cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.idleTimeout == null
+      );
+      message = "Setting programs.plasma.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.idleTimeout for autosuspend-action \"doNothing\" is not supported.";
+    }
+    {
+      assertion = (
+        cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeout != -1
+        || cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked == null
+      );
+      message = "Setting programs.plasma.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked for idleTimeout \"never\" is not supported.";
+    }
+    {
+      assertion = (
+        cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable != false
+        || cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage == null
+      );
+      message = "Cannot set programs.plasma.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage when programs.plasma.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable is disabled.";
+    }
+  ];
+
+  generalAssertions = [
+    {
+      assertion = (
+        cfg.powerdevil.batteryLevels.lowLevel == null
+        || cfg.powerdevil.batteryLevels.criticalLevel == null
+        || cfg.powerdevil.batteryLevels.lowLevel > cfg.powerdevil.batteryLevels.criticalLevel
+      );
+      message = "programs.plasma.powerdevil.batteryLevels.criticalLevel cannot be greater than programs.plasma.powerdevil.batteryLevels.lowLevel.";
+    }
+  ];
 
 in
 {

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -36,6 +36,13 @@ let
     standbyThenHibernate = 3;
   };
 
+  switchToPowerProfileActions = {
+    leaveUnchanged = "leave-unchanged";
+    powerSave = "power-saver";
+    balanced = "balanced";
+    performance = "performance";
+  };
+
   atCriticalLevelActions = {
     doNothing = 0;
     sleep = 1;
@@ -246,7 +253,27 @@ let
       };
     };
 
-    otherSettings = {};
+    otherSettings = {
+      switchToPowerProfile = lib.mkOption {
+        type =
+          with lib.types;
+            nullOr (
+              enum (
+                builtins.attrNames switchToPowerProfileActions
+              )
+            );
+        default = null;
+        example = "performance";
+        description = ''
+          The power profile, when on ${type}, adopted by the computer.
+        '';
+        apply = profile:
+          if (profile == null || profile == "leaveUnchanged") then
+            null
+          else
+            switchToPowerProfileActions."${profile}";
+      };
+    };
   };
 
   # By the same logic as createPowerDevilOptions, we can generate the
@@ -282,6 +309,9 @@ let
       TurnOffDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffScreen.idleTimeout;
       TurnOffDisplayIdleTimeoutWhenLockedSec =
         cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked;
+    };
+    "${cfgSectName}/Performance" = {
+      PowerProfile=cfg.powerdevil.${optionsName}.otherSettings.switchToPowerProfile;
     };
   };
 in

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -210,8 +210,7 @@ let
             The duration (in seconds), when on ${type}, the computer must be idle
             (when unlocked) until the display turns off.
           '';
-          apply =
-            timeout:
+          apply = timeout:
             if (timeout == null) then
               null
             else if (timeout == "never") then
@@ -234,8 +233,7 @@ let
             The duration (in seconds), when on ${type}, the computer must be idle
             (when locked) until the display turns off.
           '';
-          apply =
-            timeout:
+          apply = timeout:
             if (timeout == null) then
               null
             else if (timeout == "whenLockedAndUnlocked") then

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -2,7 +2,7 @@
 let
   cfg = config.programs.plasma;
 
-  autoSuspendActions = {
+  afterAPeriodOfInactivityActions = {
     nothing = 0;
     sleep = 1;
     hibernate = 2;
@@ -41,15 +41,15 @@ let
   # "battery").
   createPowerDevilOptions = type: {
     suspendSession = {
-      autoSuspend = {
+      afterAPeriodOfInactivity = {
         action = lib.mkOption {
-          type = with lib.types; nullOr (enum (builtins.attrNames autoSuspendActions));
+          type = with lib.types; nullOr (enum (builtins.attrNames afterAPeriodOfInactivityActions));
           default = null;
           example = "nothing";
           description = ''
             The action, when on ${type}, to perform after a certain period of inactivity.
           '';
-          apply = action: if (action == null) then null else autoSuspendActions."${action}";
+          apply = action: if (action == null) then null else afterAPeriodOfInactivityActions."${action}";
         };
         idleTimeout = lib.mkOption {
           type = with lib.types; nullOr (ints.between 60 600000);
@@ -195,8 +195,8 @@ let
   createPowerDevilConfig = cfgSectName: optionsName: {
     "${cfgSectName}/SuspendAndShutdown" = {
       PowerButtonAction = cfg.powerdevil.${optionsName}.suspendSession.powerButtonAction;
-      AutoSuspendAction = cfg.powerdevil.${optionsName}.suspendSession.autoSuspend.action;
-      AutoSuspendIdleTimeoutSec = cfg.powerdevil.${optionsName}.suspendSession.autoSuspend.idleTimeout;
+      AutoSuspendAction = cfg.powerdevil.${optionsName}.suspendSession.afterAPeriodOfInactivity.action;
+      AutoSuspendIdleTimeoutSec = cfg.powerdevil.${optionsName}.suspendSession.afterAPeriodOfInactivity.idleTimeout;
       SleepMode = cfg.powerdevil.${optionsName}.suspendSession.whenSleepingEnter;
       LidAction = cfg.powerdevil.${optionsName}.suspendSession.whenLaptopLidClosed;
       InhibitLidActionWhenExternalMonitorPresent =
@@ -241,15 +241,15 @@ in
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "AC" "autoSuspend"]
-      ["programs" "plasma" "powerdevil" "AC" "suspendSession" "autoSuspend"]
+      ["programs" "plasma" "powerdevil" "AC" "suspendSession" "afterAPeriodOfInactivity"]
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "battery" "autoSuspend"]
-      ["programs" "plasma" "powerdevil" "battery" "suspendSession" "autoSuspend"]
+      ["programs" "plasma" "powerdevil" "battery" "suspendSession" "afterAPeriodOfInactivity"]
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "lowBattery" "autoSuspend"]
-      ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "autoSuspend"]
+      ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "afterAPeriodOfInactivity"]
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "AC" "powerButtonAction"]
@@ -342,10 +342,10 @@ in
       createAssertions = type: [
         {
           assertion = (
-            cfg.powerdevil.${type}.suspendSession.autoSuspend.action != autoSuspendActions.nothing
-            || cfg.powerdevil.${type}.suspendSession.autoSuspend.idleTimeout == null
+            cfg.powerdevil.${type}.suspendSession.afterAPeriodOfInactivity.action != afterAPeriodOfInactivityActions.nothing
+            || cfg.powerdevil.${type}.suspendSession.afterAPeriodOfInactivity.idleTimeout == null
           );
-          message = "Setting programs.plasma.powerdevil.${type}.suspendSession.autoSuspend.idleTimeout for autosuspend-action \"nothing\" is not supported.";
+          message = "Setting programs.plasma.powerdevil.${type}.suspendSession.afterAPeriodOfInactivity.idleTimeout for autosuspend-action \"nothing\" is not supported.";
         }
         {
           assertion = (

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -484,7 +484,11 @@ let
           AutoSuspendIdleTimeoutSec = suspendSession.afterAPeriodOfInactivity.idleTimeout;
           PowerButtonAction = suspendSession.whenPowerButtonPressed;
           LidAction = suspendSession.whenLaptopLidClosed;
-          InhibitLidActionWhenExternalMonitorPresent = ! suspendSession.evenWhenAnExternalMonitorIsConnected;
+          InhibitLidActionWhenExternalMonitorPresent =
+            if (suspendSession.evenWhenAnExternalMonitorIsConnected != null) then
+              ! suspendSession.evenWhenAnExternalMonitorIsConnected
+            else
+              null;
           SleepMode = suspendSession.whenSleepingEnter;
         };
       };

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -342,104 +342,6 @@ let
   };
 
 
-  # ==================================
-  # === configuration declarations ===
-  # ==================================
-
-  # By the same logic as generateOptionsForProfile, we can generate the
-  # configuration. cfgSectName is here the name of the section in powerdevilrc,
-  # while profile is the name of the "namespace" where we should draw the
-  # options from (i.e. powerdevil.AC or powerdevil.battery).
-  generateConfigForProfile = cfgSectName: profile:
-    let
-      suspendSession = cfg.powerdevil.${profile}.suspendSession;
-      displayAndBrightness = cfg.powerdevil.${profile}.displayAndBrightness;
-      changeKeyboardBrightness = displayAndBrightness.changeKeyboardBrightness;
-      otherSettings = cfg.powerdevil.${profile}.otherSettings;
-      runCustomScripts = otherSettings.runCustomScripts;
-
-      suspendAndShutdown = {
-        "${cfgSectName}/SuspendAndShutdown" = {
-          AutoSuspendAction = suspendSession.afterAPeriodOfInactivity.action;
-          AutoSuspendIdleTimeoutSec = suspendSession.afterAPeriodOfInactivity.idleTimeout;
-          PowerButtonAction = suspendSession.whenPowerButtonPressed;
-          LidAction = suspendSession.whenLaptopLidClosed;
-          InhibitLidActionWhenExternalMonitorPresent = ! suspendSession.evenWhenAnExternalMonitorIsConnected;
-          SleepMode = suspendSession.whenSleepingEnter;
-        };
-      };
-
-      display = {
-        "${cfgSectName}/Display" = {
-          UseProfileSpecificDisplayBrightness =
-            if (displayAndBrightness.changeScreenBrightness.enable != null) then
-              displayAndBrightness.changeScreenBrightness.enable
-            else if (displayAndBrightness.changeScreenBrightness.percentage != null) then
-              true
-            else
-              null;
-          DisplayBrightness = displayAndBrightness.changeScreenBrightness.percentage;
-          DimDisplayIdleTimeoutSec = displayAndBrightness.dimAutomatically.idleTimeout;
-          TurnOffDisplayIdleTimeoutSec = displayAndBrightness.turnOffScreen.idleTimeout;
-          TurnOffDisplayIdleTimeoutWhenLockedSec = displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked;
-        };
-      };
-
-      keyboard = {
-        "${cfgSectName}/Keyboard" = {
-          UseProfileSpecificKeyboardBrightness =
-            if (changeKeyboardBrightness.enable != null) then
-              changeKeyboardBrightness.enable
-            else if (changeKeyboardBrightness.percentage != null) then
-              true
-            else
-              null;
-          KeyboardBrightness = changeKeyboardBrightness.percentage;
-        };
-      };
-
-      performance = {
-        "${cfgSectName}/Performance" = {
-          PowerProfile = otherSettings.switchToPowerProfile;
-        };
-      };
-
-      runScripts = {
-        "${cfgSectName}/RunScript" = {
-          ProfileLoadCommand = runCustomScripts."whenEnteringOn${capitalize(profile)}PowerState";
-          ProfileUnloadCommand = runCustomScripts."whenExitingOn${capitalize(profile)}PowerState";
-          IdleTimeoutCommand = runCustomScripts.afterAPeriodOfInactivity.script;
-          RunScriptIdleTimeoutSec = runCustomScripts.afterAPeriodOfInactivity.idleTimeout;
-        };
-      };
-
-    in
-      suspendAndShutdown
-      // display
-      // keyboard
-      // performance
-      // runScripts;
-
-  generalConfig =
-    let
-      batteryLevels = cfg.powerdevil.batteryLevels;
-      otherSettings = cfg.powerdevil.otherSettings;
-
-    in
-      {
-        BatteryManagement = {
-          BatteryLowLevel = batteryLevels.lowLevel;
-          BatteryCriticalLevel = batteryLevels.criticalLevel;
-          BatteryCriticalAction = batteryLevels.atCriticalLevel;
-          PeripheralBatteryLowLevel = batteryLevels.lowLevelForPeripheralDevice;
-        };
-
-        General = {
-          pausePlayersOnSuspend = otherSettings.pauseMediaPlayersWhenSuspending;
-        };
-      };
-
-
   # =============================================
   # === modified options modules declarations ===
   # =============================================
@@ -559,8 +461,114 @@ let
     }
   ];
 
+
+  # ==================================
+  # === configuration declarations ===
+  # ==================================
+
+  # By the same logic as generateOptionsForProfile, we can generate the
+  # configuration. cfgSectName is here the name of the section in powerdevilrc,
+  # while profile is the name of the "namespace" where we should draw the
+  # options from (i.e. powerdevil.AC or powerdevil.battery).
+  generateConfigForProfile = cfgSectName: profile:
+    let
+      suspendSession = cfg.powerdevil.${profile}.suspendSession;
+      displayAndBrightness = cfg.powerdevil.${profile}.displayAndBrightness;
+      changeKeyboardBrightness = displayAndBrightness.changeKeyboardBrightness;
+      otherSettings = cfg.powerdevil.${profile}.otherSettings;
+      runCustomScripts = otherSettings.runCustomScripts;
+
+      suspendAndShutdown = {
+        "${cfgSectName}/SuspendAndShutdown" = {
+          AutoSuspendAction = suspendSession.afterAPeriodOfInactivity.action;
+          AutoSuspendIdleTimeoutSec = suspendSession.afterAPeriodOfInactivity.idleTimeout;
+          PowerButtonAction = suspendSession.whenPowerButtonPressed;
+          LidAction = suspendSession.whenLaptopLidClosed;
+          InhibitLidActionWhenExternalMonitorPresent = ! suspendSession.evenWhenAnExternalMonitorIsConnected;
+          SleepMode = suspendSession.whenSleepingEnter;
+        };
+      };
+
+      display = {
+        "${cfgSectName}/Display" = {
+          UseProfileSpecificDisplayBrightness =
+            if (displayAndBrightness.changeScreenBrightness.enable != null) then
+              displayAndBrightness.changeScreenBrightness.enable
+            else if (displayAndBrightness.changeScreenBrightness.percentage != null) then
+              true
+            else
+              null;
+          DisplayBrightness = displayAndBrightness.changeScreenBrightness.percentage;
+          DimDisplayIdleTimeoutSec = displayAndBrightness.dimAutomatically.idleTimeout;
+          TurnOffDisplayIdleTimeoutSec = displayAndBrightness.turnOffScreen.idleTimeout;
+          TurnOffDisplayIdleTimeoutWhenLockedSec = displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked;
+        };
+      };
+
+      keyboard = {
+        "${cfgSectName}/Keyboard" = {
+          UseProfileSpecificKeyboardBrightness =
+            if (changeKeyboardBrightness.enable != null) then
+              changeKeyboardBrightness.enable
+            else if (changeKeyboardBrightness.percentage != null) then
+              true
+            else
+              null;
+          KeyboardBrightness = changeKeyboardBrightness.percentage;
+        };
+      };
+
+      performance = {
+        "${cfgSectName}/Performance" = {
+          PowerProfile = otherSettings.switchToPowerProfile;
+        };
+      };
+
+      runScripts = {
+        "${cfgSectName}/RunScript" = {
+          ProfileLoadCommand = runCustomScripts."whenEnteringOn${capitalize(profile)}PowerState";
+          ProfileUnloadCommand = runCustomScripts."whenExitingOn${capitalize(profile)}PowerState";
+          IdleTimeoutCommand = runCustomScripts.afterAPeriodOfInactivity.script;
+          RunScriptIdleTimeoutSec = runCustomScripts.afterAPeriodOfInactivity.idleTimeout;
+        };
+      };
+
+    in
+      suspendAndShutdown
+      // display
+      // keyboard
+      // performance
+      // runScripts;
+
+  generalConfig =
+    let
+      batteryLevels = cfg.powerdevil.batteryLevels;
+      otherSettings = cfg.powerdevil.otherSettings;
+
+    in
+      {
+        BatteryManagement = {
+          BatteryLowLevel = batteryLevels.lowLevel;
+          BatteryCriticalLevel = batteryLevels.criticalLevel;
+          BatteryCriticalAction = batteryLevels.atCriticalLevel;
+          PeripheralBatteryLowLevel = batteryLevels.lowLevelForPeripheralDevice;
+        };
+
+        General = {
+          pausePlayersOnSuspend = otherSettings.pauseMediaPlayersWhenSuspending;
+        };
+      };
+
 in
 {
+  options = {
+    programs.plasma.powerdevil =
+      (generateOptionsForProfile "AC")
+      // (generateOptionsForProfile "battery")
+      // (generateOptionsForProfile "lowBattery")
+      // generalOptions;
+  };
+
   imports =
     (generateModifiedOptionsModulesForProfile "AC")
     ++ (generateModifiedOptionsModulesForProfile "battery")
@@ -572,14 +580,6 @@ in
     ++ (generateAssertionsForProfile "battery")
     ++ (generateAssertionsForProfile "lowBattery")
     ++ generalAssertions;
-
-  options = {
-    programs.plasma.powerdevil =
-      (generateOptionsForProfile "AC")
-      // (generateOptionsForProfile "battery")
-      // (generateOptionsForProfile "lowBattery")
-      // generalOptions;
-  };
 
   config.programs.plasma.configFile = lib.mkIf cfg.enable {
     powerdevilrc = lib.filterAttrsRecursive (k: v: v != null) (

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -157,6 +157,22 @@ let
         '';
       };
     };
+    changeScreenBrightness = {
+      enable = lib.mkOption {
+        type = with lib.types; nullOr bool;
+        default = null;
+        example = true;
+        description = "Enable or disable screen brightness changing.";
+      };
+      percentage = lib.mkOption {
+        type = with lib.types; nullOr (ints.between 0 100);
+        default = null;
+        example = 70;
+        description = ''
+          The screen brightness percentage when on ${type}.
+        '';
+      };
+    };
   };
 
   # By the same logic as createPowerDevilOptions, we can generate the
@@ -185,6 +201,14 @@ let
         else
           null;
       DimDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.dimDisplay.idleTimeout;
+      UseProfileSpecificDisplayBrightness=
+        if (cfg.powerdevil.${optionsName}.changeScreenBrightness.enable != null) then
+          cfg.powerdevil.${optionsName}.changeScreenBrightness.enable
+        else if (cfg.powerdevil.${optionsName}.changeScreenBrightness.percentage != null) then
+          true
+        else
+          null;
+      DisplayBrightness=cfg.powerdevil.${optionsName}.changeScreenBrightness.percentage;
     };
   };
 in
@@ -260,6 +284,13 @@ in
             || cfg.powerdevil.${type}.dimDisplay.idleTimeout == null
           );
           message = "Cannot set programs.plasma.powerdevil.${type}.dimDisplay.idleTimeout when programs.plasma.powerdevil.${type}.dimDisplay.enable is disabled.";
+        }
+        {
+          assertion = (
+            cfg.powerdevil.${type}.changeScreenBrightness.enable != false
+            || cfg.powerdevil.${type}.changeScreenBrightness.percentage == null
+          );
+          message = "Cannot set programs.plasma.powerdevil.${type}.changeScreenBrightness.percentage when programs.plasma.powerdevil.${type}.changeScreenBrightness.enable is disabled.";
         }
       ];
     in

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -3,7 +3,7 @@ let
   cfg = config.programs.plasma;
 
   afterAPeriodOfInactivityActions = {
-    nothing = 0;
+    doNothing = 0;
     sleep = 1;
     hibernate = 2;
     shutDown = 8;
@@ -12,7 +12,7 @@ let
   # Values can be found at:
   # https://github.com/KDE/powerdevil/blob/master/daemon/powerdevilenums.h
   whenPowerButtonPressedActions = {
-    nothing = 0;
+    doNothing = 0;
     sleep = 1;
     hibernate = 2;
     shutDown = 8;
@@ -25,7 +25,7 @@ let
     doNothing = 0;
     sleep = 1;
     hibernate = 2;
-    shutdown = 8;
+    shutDown = 8;
     lockScreen = 32;
     turnOffScreen = 64;
   };
@@ -50,7 +50,7 @@ let
               )
             );
           default = null;
-          example = "nothing";
+          example = "doNothing";
           description = ''
             The action, when on ${type}, to perform after a certain period of inactivity.
           '';
@@ -82,7 +82,7 @@ let
             )
           );
         default = null;
-        example = "nothing";
+        example = "doNothing";
         description = ''
           The action, when on ${type}, to perform when the power button is pressed.
         '';
@@ -100,7 +100,7 @@ let
             )
           );
         default = null;
-        example = "shutdown";
+        example = "shutDown";
         description = ''
           The action, when on ${type}, to perform when the laptop lid is closed.
         '';
@@ -397,10 +397,10 @@ in
       createAssertions = type: [
         {
           assertion = (
-            cfg.powerdevil.${type}.suspendSession.afterAPeriodOfInactivity.action != afterAPeriodOfInactivityActions.nothing
+            cfg.powerdevil.${type}.suspendSession.afterAPeriodOfInactivity.action != afterAPeriodOfInactivityActions.doNothing
             || cfg.powerdevil.${type}.suspendSession.afterAPeriodOfInactivity.idleTimeout == null
           );
-          message = "Setting programs.plasma.powerdevil.${type}.suspendSession.afterAPeriodOfInactivity.idleTimeout for autosuspend-action \"nothing\" is not supported.";
+          message = "Setting programs.plasma.powerdevil.${type}.suspendSession.afterAPeriodOfInactivity.idleTimeout for autosuspend-action \"doNothing\" is not supported.";
         }
         {
           assertion = (

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -64,7 +64,7 @@ let
   # Since AC and battery allows the same options we create a function here which
   # can generate the options by just specifying the type (i.e. "AC" or
   # "battery").
-  createPowerDevilOptions = profile: {
+  generateOptionsForProfile = profile: {
     suspendSession = {
       afterAPeriodOfInactivity = {
         action = lib.mkOption {
@@ -286,7 +286,7 @@ let
     };
   };
 
-  # By the same logic as createPowerDevilOptions, we can generate the
+  # By the same logic as generateOptionsForProfile, we can generate the
   # configuration. cfgSectName is here the name of the section in powerdevilrc,
   # while optionsName is the name of the "namespace" where we should draw the
   # options from (i.e. powerdevil.AC or powerdevil.battery).
@@ -517,9 +517,9 @@ in
 
   options = {
     programs.plasma.powerdevil = {
-      AC = (createPowerDevilOptions "AC");
-      battery = (createPowerDevilOptions "battery");
-      lowBattery = (createPowerDevilOptions "lowBattery");
+      AC = (generateOptionsForProfile "AC");
+      battery = (generateOptionsForProfile "battery");
+      lowBattery = (generateOptionsForProfile "lowBattery");
       batteryLevels = {
         lowLevel = lib.mkOption {
           type = with lib.types;

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -72,9 +72,7 @@ let
             nullOr (enum (builtins.attrNames afterAPeriodOfInactivityActions));
           default = null;
           example = "doNothing";
-          description = ''
-            The action, when on ${type}, to perform after a certain period of inactivity.
-          '';
+          description = "The action, when on ${type}, to perform after a certain period of inactivity.";
           apply = action:
             if (action == null) then
               null
@@ -87,10 +85,7 @@ let
             nullOr (ints.between 60 604800);
           default = null;
           example = 600;
-          description = ''
-            The duration (in seconds), when on ${type}, the computer must be idle
-            until the auto-suspend action is executed.
-          '';
+          description = "The duration (in seconds), when on ${type}, the computer must be idle until the auto-suspend action is executed.";
         };
       };
 
@@ -99,9 +94,7 @@ let
           nullOr (enum (builtins.attrNames whenPowerButtonPressedActions));
         default = null;
         example = "doNothing";
-        description = ''
-          The action, when on ${type}, to perform when the power button is pressed.
-        '';
+        description = "The action, when on ${type}, to perform when the power button is pressed.";
         apply = action:
           if (action == null) then
             null
@@ -114,9 +107,7 @@ let
           nullOr (enum (builtins.attrNames whenLaptopLidClosedActions));
         default = null;
         example = "shutDown";
-        description = ''
-          The action, when on ${type}, to perform when the laptop lid is closed.
-        '';
+        description = "The action, when on ${type}, to perform when the laptop lid is closed.";
         apply = action:
           if (action == null) then
             null
@@ -129,9 +120,7 @@ let
           nullOr bool;
         default = null;
         example = false;
-        description = ''
-          If enabled, the lid action will be executed even when an external monitor is connected.
-        '';
+        description = "If enabled, the lid action will be executed even when an external monitor is connected.";
       };
 
       whenSleepingEnter = lib.mkOption {
@@ -139,9 +128,7 @@ let
           nullOr (enum (builtins.attrNames whenSleepingEnterActions));
         default = null;
         example = "standbyThenHibernate";
-        description = ''
-          The state, when on ${type}, to enter when sleeping.
-        '';
+        description = "The state, when on ${type}, to enter when sleeping.";
         apply = action:
           if (action == null) then
             null
@@ -157,9 +144,7 @@ let
             nullOr bool;
           default = null;
           example = true;
-          description = ''
-            Enable or disable screen brightness changing.
-          '';
+          description = "Enable or disable screen brightness changing.";
         };
 
         percentage = lib.mkOption {
@@ -167,9 +152,7 @@ let
             nullOr (ints.between 1 100);
           default = null;
           example = 70;
-          description = ''
-            The screen brightness percentage when on ${type}.
-          '';
+          description = "The screen brightness percentage when on ${type}.";
         };
       };
 
@@ -181,10 +164,7 @@ let
               (ints.between 10 604800));
           default = null;
           example = 300;
-          description = ''
-            The duration (in seconds), when on ${type}, the computer must be idle
-            until the display starts dimming.
-          '';
+          description = "The duration (in seconds), when on ${type}, the computer must be idle until the display starts dimming.";
           apply = timeout:
             if (timeout == null) then
               null
@@ -203,10 +183,7 @@ let
               (ints.between 30 604800));
           default = null;
           example = 300;
-          description = ''
-            The duration (in seconds), when on ${type}, the computer must be idle
-            (when unlocked) until the display turns off.
-          '';
+          description = "The duration (in seconds), when on ${type}, the computer must be idle (when unlocked) until the display turns off.";
           apply = timeout:
             if (timeout == null) then
               null
@@ -224,10 +201,7 @@ let
               (ints.between 10 604800));
           default = null;
           example = 60;
-          description = ''
-            The duration (in seconds), when on ${type}, the computer must be idle
-            (when locked) until the display turns off.
-          '';
+          description = "The duration (in seconds), when on ${type}, the computer must be idle (when locked) until the display turns off.";
           apply = timeout:
             if (timeout == null) then
               null
@@ -246,9 +220,7 @@ let
             nullOr bool;
           default = null;
           example = true;
-          description = ''
-            Enable or disable keyboard brightness changing.
-          '';
+          description = "Enable or disable keyboard brightness changing.";
         };
 
         percentage = lib.mkOption {
@@ -256,9 +228,7 @@ let
             nullOr (ints.between 0 100);
           default = null;
           example = 70;
-          description = ''
-            The keyboard brightness percentage when on ${type}.
-          '';
+          description = "The keyboard brightness percentage when on ${type}.";
         };
       };
     };
@@ -270,9 +240,7 @@ let
             nullOr (enum (builtins.attrNames switchToPowerProfileActions));
         default = null;
         example = "performance";
-        description = ''
-          The power profile, when on ${type}, adopted by the computer.
-        '';
+        description = "The power profile, when on ${type}, adopted by the computer.";
         apply = profile:
           if (profile == null || profile == "leaveUnchanged") then
             null
@@ -286,10 +254,7 @@ let
             nullOr str;
           default = null;
           example = "echo 'hello, world'";
-          description = ''
-            A script or the path for a script/program to be run when entering
-            ${type}.
-          '';
+          description = "A script or the path for a script/program to be run when entering ${type}.";
         };
 
         "whenExitingOn${capitalize(type)}PowerState" = lib.mkOption {
@@ -297,10 +262,7 @@ let
             nullOr str;
           default = null;
           example = "echo 'farewwll, world'";
-          description = ''
-            A script or the path for a script/program to be run when exiting
-            ${type}.
-          '';
+          description = "A script or the path for a script/program to be run when exiting ${type}.";
         };
 
         afterAPeriodOfInactivity = {
@@ -309,10 +271,7 @@ let
               nullOr str;
             default = null;
             example = "echo 'are you there, world'";
-            description = ''
-              A script or the path for a script/program to be run after a period
-              of inactivity when on ${type}.
-            '';
+            description = "A script or the path for a script/program to be run after a period of inactivity when on ${type}.";
           };
 
           idleTimeout = lib.mkOption {
@@ -320,10 +279,7 @@ let
               nullOr (ints.between 10 604800);
             default = null;
             example = 600;
-            description = ''
-              The duration (in seconds), when on ${type}, the computer must be
-               idle until the script is run.
-            '';
+            description = "The duration (in seconds), when on ${type}, the computer must be idle until the script is run.";
           };
         };
       };
@@ -482,30 +438,15 @@ in
     )
     (lib.mkRemovedOptionModule
       ["programs" "plasma" "powerdevil" "AC" "displayAndBrightness" "dimAutomatically" "enable"]
-      ''
-      The programs.plasma.powerdevil.AC.displayAndbrightness.dimAutomatically.enable
-      option was removed. If you wish to disable the screen to dim automatically,
-      set the programs.plasma.powerdevil.AC.displayAndbrightness.dimAutomatically.idleTimeout
-      to "never".
-      ''
+      "The programs.plasma.powerdevil.AC.displayAndbrightness.dimAutomatically.enable option was removed. If you wish to disable the screen to dim automatically, set the programs.plasma.powerdevil.AC.displayAndbrightness.dimAutomatically.idleTimeout to \"never\"."
     )
     (lib.mkRemovedOptionModule
       ["programs" "plasma" "powerdevil" "battery" "displayAndBrightness" "dimAutomatically" "enable"]
-      ''
-      The programs.plasma.powerdevil.battery.displayAndbrightness.dimAutomatically.enable
-      option was removed. If you wish to disable the screen to dim automatically,
-      set the programs.plasma.powerdevil.battery.displayAndbrightness.dimAutomatically.idleTimeout
-      to "never".
-      ''
+      "The programs.plasma.powerdevil.battery.displayAndbrightness.dimAutomatically.enable option was removed. If you wish to disable the screen to dim automatically, set the programs.plasma.powerdevil.battery.displayAndbrightness.dimAutomatically.idleTimeout to \"never\"."
     )
     (lib.mkRemovedOptionModule
       ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "dimAutomatically" "enable"]
-      ''
-      The programs.plasma.powerdevil.lowBattery.displayAndbrightness.dimAutomatically.enable
-      option was removed. If you wish to disable the screen to dim automatically,
-      set the programs.plasma.powerdevil.lowBattery.displayAndbrightness.dimAutomatically.idleTimeout
-      to "never".
-      ''
+      "The programs.plasma.powerdevil.lowBattery.displayAndbrightness.dimAutomatically.enable option was removed. If you wish to disable the screen to dim automatically, set the programs.plasma.powerdevil.lowBattery.displayAndbrightness.dimAutomatically.idleTimeout to \"never\"."
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "AC" "turnOffDisplay"]
@@ -572,11 +513,7 @@ in
             nullOr (ints.between 0 100);
           default = null;
           example = "10";
-          description = ''
-            The battery charge will be considered low when it drops to this
-            level. Settings for low battery will be used instead of regular
-            battery settings.
-          '';
+          description = "The battery charge will be considered low when it drops to this level. Settings for low battery will be used instead of regular battery settings.";
         };
 
         criticalLevel = lib.mkOption {
@@ -584,12 +521,7 @@ in
             nullOr (ints.between 0 100);
           default = null;
           example = "5";
-          description = ''
-            The battery charge will be considered critical when it drops to this
-            level. After a brief warning, the system will automaticelly suspend
-            or shutdown, according to the configured critical battery level
-            action.
-          '';
+          description = "The battery charge will be considered critical when it drops to this level. After a brief warning, the system will automaticelly suspend or shutdown, according to the configured critical battery level action.";
         };
 
         atCriticalLevel = lib.mkOption {
@@ -597,9 +529,7 @@ in
             nullOr (enum (builtins.attrNames atCriticalLevelActions));
           default = null;
           example = "hibernate";
-          description = ''
-            The action to perform when the battery reaches critical level.
-          '';
+          description = "The action to perform when the battery reaches critical level.";
           apply = action:
             if (action == null) then
               null
@@ -613,10 +543,7 @@ in
             nullOr (ints.between 0 100);
           default = null;
           example = "10";
-          description = ''
-            The battery charge for peripheral devices will be considered low
-             when it reaches this level.
-          '';
+          description = "The battery charge for peripheral devices will be considered low when it reaches this level.";
         };
       };
 
@@ -626,9 +553,7 @@ in
             nullOr bool;
           default = null;
           example = false;
-          description = ''
-            If enabled, pause media players when the system is suspended.
-          '';
+          description = "If enabled, pause media players when the system is suspended.";
         };
       };
     };

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -138,7 +138,7 @@ let
         };
       };
 
-      turnOffDisplay = {
+      turnOffScreen = {
         idleTimeout = lib.mkOption {
           type = with lib.types; nullOr (either (enum [ "never" ]) (ints.between 30 600000));
           default = null;
@@ -202,9 +202,9 @@ let
       InhibitLidActionWhenExternalMonitorPresent = ! cfg.powerdevil.${optionsName}.suspendSession.evenWhenAnExternalMonitorIsConnected;
     };
     "${cfgSectName}/Display" = {
-      TurnOffDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffDisplay.idleTimeout;
+      TurnOffDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffScreen.idleTimeout;
       TurnOffDisplayIdleTimeoutWhenLockedSec =
-        cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffDisplay.idleTimeoutWhenLocked;
+        cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked;
       DimDisplayWhenIdle =
         if (cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.enable != null) then
           cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.enable
@@ -324,15 +324,15 @@ in
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "AC" "turnOffDisplay"]
-      ["programs" "plasma" "powerdevil" "AC" "displayAndBrightness" "turnOffDisplay"]
+      ["programs" "plasma" "powerdevil" "AC" "displayAndBrightness" "turnOffScreen"]
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "battery" "turnOffDisplay"]
-      ["programs" "plasma" "powerdevil" "battery" "displayAndBrightness" "turnOffDisplay"]
+      ["programs" "plasma" "powerdevil" "battery" "displayAndBrightness" "turnOffScreen"]
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "lowBattery" "turnOffDisplay"]
-      ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "turnOffDisplay"]
+      ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "turnOffScreen"]
     )
   ];
 
@@ -348,10 +348,10 @@ in
         }
         {
           assertion = (
-            cfg.powerdevil.${type}.displayAndBrightness.turnOffDisplay.idleTimeout != -1
-            || cfg.powerdevil.${type}.displayAndBrightness.turnOffDisplay.idleTimeoutWhenLocked == null
+            cfg.powerdevil.${type}.displayAndBrightness.turnOffScreen.idleTimeout != -1
+            || cfg.powerdevil.${type}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked == null
           );
-          message = "Setting programs.plasma.powerdevil.${type}.displayAndBrightness.turnOffDisplay.idleTimeoutWhenLocked for idleTimeout \"never\" is not supported.";
+          message = "Setting programs.plasma.powerdevil.${type}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked for idleTimeout \"never\" is not supported.";
         }
         {
           assertion = (

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -288,53 +288,53 @@ let
 
   # By the same logic as generateOptionsForProfile, we can generate the
   # configuration. cfgSectName is here the name of the section in powerdevilrc,
-  # while optionsName is the name of the "namespace" where we should draw the
+  # while profile is the name of the "namespace" where we should draw the
   # options from (i.e. powerdevil.AC or powerdevil.battery).
-  createPowerDevilConfig = cfgSectName: optionsName: {
+  createPowerDevilConfig = cfgSectName: profile: {
     "${cfgSectName}/SuspendAndShutdown" = {
-      AutoSuspendAction = cfg.powerdevil.${optionsName}.suspendSession.afterAPeriodOfInactivity.action;
-      AutoSuspendIdleTimeoutSec = cfg.powerdevil.${optionsName}.suspendSession.afterAPeriodOfInactivity.idleTimeout;
-      PowerButtonAction = cfg.powerdevil.${optionsName}.suspendSession.whenPowerButtonPressed;
-      LidAction = cfg.powerdevil.${optionsName}.suspendSession.whenLaptopLidClosed;
-      InhibitLidActionWhenExternalMonitorPresent = ! cfg.powerdevil.${optionsName}.suspendSession.evenWhenAnExternalMonitorIsConnected;
-      SleepMode = cfg.powerdevil.${optionsName}.suspendSession.whenSleepingEnter;
+      AutoSuspendAction = cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.action;
+      AutoSuspendIdleTimeoutSec = cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.idleTimeout;
+      PowerButtonAction = cfg.powerdevil.${profile}.suspendSession.whenPowerButtonPressed;
+      LidAction = cfg.powerdevil.${profile}.suspendSession.whenLaptopLidClosed;
+      InhibitLidActionWhenExternalMonitorPresent = ! cfg.powerdevil.${profile}.suspendSession.evenWhenAnExternalMonitorIsConnected;
+      SleepMode = cfg.powerdevil.${profile}.suspendSession.whenSleepingEnter;
     };
 
     "${cfgSectName}/Display" = {
       UseProfileSpecificDisplayBrightness=
-        if (cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.enable != null) then
-          cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.enable
-        else if (cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.percentage != null) then
+        if (cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable != null) then
+          cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable
+        else if (cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage != null) then
           true
         else
           null;
-      DisplayBrightness=cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.percentage;
-      DimDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.idleTimeout;
-      TurnOffDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffScreen.idleTimeout;
+      DisplayBrightness=cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage;
+      DimDisplayIdleTimeoutSec = cfg.powerdevil.${profile}.displayAndBrightness.dimAutomatically.idleTimeout;
+      TurnOffDisplayIdleTimeoutSec = cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeout;
       TurnOffDisplayIdleTimeoutWhenLockedSec =
-        cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked;
+        cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked;
     };
 
     "${cfgSectName}/Keyboard" = {
       UseProfileSpecificKeyboardBrightness=
-        if (cfg.powerdevil.${optionsName}.displayAndBrightness.changeKeyboardBrightness.enable != null) then
-          cfg.powerdevil.${optionsName}.displayAndBrightness.changeKeyboardBrightness.enable
-        else if (cfg.powerdevil.${optionsName}.displayAndBrightness.changeKeyboardBrightness.percentage != null) then
+        if (cfg.powerdevil.${profile}.displayAndBrightness.changeKeyboardBrightness.enable != null) then
+          cfg.powerdevil.${profile}.displayAndBrightness.changeKeyboardBrightness.enable
+        else if (cfg.powerdevil.${profile}.displayAndBrightness.changeKeyboardBrightness.percentage != null) then
           true
         else
           null;
-      KeyboardBrightness=cfg.powerdevil.${optionsName}.displayAndBrightness.changeKeyboardBrightness.percentage;
+      KeyboardBrightness=cfg.powerdevil.${profile}.displayAndBrightness.changeKeyboardBrightness.percentage;
     };
 
     "${cfgSectName}/Performance" = {
-      PowerProfile=cfg.powerdevil.${optionsName}.otherSettings.switchToPowerProfile;
+      PowerProfile=cfg.powerdevil.${profile}.otherSettings.switchToPowerProfile;
     };
 
     "${cfgSectName}/RunScript" = {
-      ProfileLoadCommand = cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts."whenEnteringOn${capitalize(optionsName)}PowerState";
-      ProfileUnloadCommand=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts."whenExitingOn${capitalize(optionsName)}PowerState";
-      IdleTimeoutCommand=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.script;
-      RunScriptIdleTimeoutSec=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.idleTimeout;
+      ProfileLoadCommand = cfg.powerdevil.${profile}.otherSettings.runCustomScripts."whenEnteringOn${capitalize(profile)}PowerState";
+      ProfileUnloadCommand=cfg.powerdevil.${profile}.otherSettings.runCustomScripts."whenExitingOn${capitalize(profile)}PowerState";
+      IdleTimeoutCommand=cfg.powerdevil.${profile}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.script;
+      RunScriptIdleTimeoutSec=cfg.powerdevil.${profile}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.idleTimeout;
     };
   };
 

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -71,6 +71,16 @@ let
         '';
         apply = action: if (action == null) then null else powerButtonActions."${action}";
       };
+
+      whenLaptopLidClosed = lib.mkOption {
+        type = with lib.types; nullOr (enum (builtins.attrNames whenLaptopLidClosedActions));
+        default = null;
+        example = "shutdown";
+        description = ''
+          The action, when on ${type}, to perform when the laptop lid is closed.
+        '';
+        apply = action: if (action == null) then null else whenLaptopLidClosedActions."${action}";
+      };
     };
 
     displayAndBrightness = {};
@@ -85,15 +95,6 @@ let
         The state, when on ${type}, to enter when sleeping.
       '';
       apply = action: if (action == null) then null else whenSleepingEnterActions."${action}";
-    };
-    whenLaptopLidClosed = lib.mkOption {
-      type = with lib.types; nullOr (enum (builtins.attrNames whenLaptopLidClosedActions));
-      default = null;
-      example = "shutdown";
-      description = ''
-        The action, when on ${type}, to perform when the laptop lid is closed.
-      '';
-      apply = action: if (action == null) then null else whenLaptopLidClosedActions."${action}";
     };
     inhibitLidActionWhenExternalMonitorConnected = lib.mkOption {
       type = with lib.types; nullOr bool;
@@ -193,7 +194,7 @@ let
       AutoSuspendAction = cfg.powerdevil.${optionsName}.suspendSession.autoSuspend.action;
       AutoSuspendIdleTimeoutSec = cfg.powerdevil.${optionsName}.suspendSession.autoSuspend.idleTimeout;
       SleepMode = cfg.powerdevil.${optionsName}.whenSleepingEnter;
-      LidAction = cfg.powerdevil.${optionsName}.whenLaptopLidClosed;
+      LidAction = cfg.powerdevil.${optionsName}.suspendSession.whenLaptopLidClosed;
       InhibitLidActionWhenExternalMonitorPresent =
         cfg.powerdevil.${optionsName}.inhibitLidActionWhenExternalMonitorConnected;
     };
@@ -257,6 +258,18 @@ in
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "lowBattery" "powerButtonAction"]
       ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "powerButtonAction"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "AC" "whenLaptopLidClosed"]
+      ["programs" "plasma" "powerdevil" "AC" "suspendSession" "whenLaptopLidClosed"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "battery" "whenLaptopLidClosed"]
+      ["programs" "plasma" "powerdevil" "battery" "suspendSession" "whenLaptopLidClosed"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "lowBattery" "whenLaptopLidClosed"]
+      ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "whenLaptopLidClosed"]
     )
   ];
 

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -2,6 +2,13 @@
 let
   cfg = config.programs.plasma;
 
+  autoSuspendActions = {
+    nothing = 0;
+    sleep = 1;
+    hibernate = 2;
+    shutDown = 8;
+  };
+
   # Values can be found at:
   # https://github.com/KDE/powerdevil/blob/master/daemon/powerdevilenums.h
   powerButtonActions = {
@@ -14,19 +21,6 @@ let
     turnOffScreen = 64;
   };
 
-  autoSuspendActions = {
-    nothing = 0;
-    hibernate = 2;
-    sleep = 1;
-    shutDown = 8;
-  };
-
-  whenSleepingEnterActions = {
-    standby = 1;
-    hybridSleep = 2;
-    standbyThenHibernate = 3;
-  };
-
   whenLaptopLidClosedActions = {
     doNothing = 0;
     sleep = 1;
@@ -34,6 +28,12 @@ let
     shutdown = 8;
     lockScreen = 32;
     turnOffScreen = 64;
+  };
+
+  whenSleepingEnterActions = {
+    standby = 1;
+    hybridSleep = 2;
+    standbyThenHibernate = 3;
   };
 
   # Since AC and battery allows the same options we create a function here which

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -120,7 +120,7 @@ let
         };
       };
 
-      dimDisplay = {
+      dimAutomatically = {
         enable = lib.mkOption {
           type = with lib.types; nullOr bool;
           default = null;
@@ -206,13 +206,13 @@ let
       TurnOffDisplayIdleTimeoutWhenLockedSec =
         cfg.powerdevil.${optionsName}.displayAndBrightness.turnOffDisplay.idleTimeoutWhenLocked;
       DimDisplayWhenIdle =
-        if (cfg.powerdevil.${optionsName}.displayAndBrightness.dimDisplay.enable != null) then
-          cfg.powerdevil.${optionsName}.displayAndBrightness.dimDisplay.enable
-        else if (cfg.powerdevil.${optionsName}.displayAndBrightness.dimDisplay.idleTimeout != null) then
+        if (cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.enable != null) then
+          cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.enable
+        else if (cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.idleTimeout != null) then
           true
         else
           null;
-      DimDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.dimDisplay.idleTimeout;
+      DimDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.displayAndBrightness.dimAutomatically.idleTimeout;
       UseProfileSpecificDisplayBrightness=
         if (cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.enable != null) then
           cfg.powerdevil.${optionsName}.displayAndBrightness.changeScreenBrightness.enable
@@ -312,15 +312,15 @@ in
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "AC" "dimDisplay"]
-      ["programs" "plasma" "powerdevil" "AC" "displayAndBrightness" "dimDisplay"]
+      ["programs" "plasma" "powerdevil" "AC" "displayAndBrightness" "dimAutomatically"]
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "battery" "dimDisplay"]
-      ["programs" "plasma" "powerdevil" "battery" "displayAndBrightness" "dimDisplay"]
+      ["programs" "plasma" "powerdevil" "battery" "displayAndBrightness" "dimAutomatically"]
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "lowBattery" "dimDisplay"]
-      ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "dimDisplay"]
+      ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "dimAutomatically"]
     )
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "AC" "turnOffDisplay"]
@@ -355,10 +355,10 @@ in
         }
         {
           assertion = (
-            cfg.powerdevil.${type}.displayAndBrightness.dimDisplay.enable != false
-            || cfg.powerdevil.${type}.displayAndBrightness.dimDisplay.idleTimeout == null
+            cfg.powerdevil.${type}.displayAndBrightness.dimAutomatically.enable != false
+            || cfg.powerdevil.${type}.displayAndBrightness.dimAutomatically.idleTimeout == null
           );
-          message = "Cannot set programs.plasma.powerdevil.${type}.displayAndBrightness.dimDisplay.idleTimeout when programs.plasma.powerdevil.${type}.displayAndBrightness.dimDisplay.enable is disabled.";
+          message = "Cannot set programs.plasma.powerdevil.${type}.displayAndBrightness.dimAutomatically.idleTimeout when programs.plasma.powerdevil.${type}.displayAndBrightness.dimAutomatically.enable is disabled.";
         }
         {
           assertion = (

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -503,6 +503,9 @@ in
           );
           message = "Cannot set programs.plasma.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage when programs.plasma.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable is disabled.";
         }
+      ];
+
+      generalAssertions = [
         {
           assertion = (
             cfg.powerdevil.batteryLevels.lowLevel == null
@@ -512,8 +515,12 @@ in
           message = "programs.plasma.powerdevil.batteryLevels.criticalLevel cannot be greater than programs.plasma.powerdevil.batteryLevels.lowLevel.";
         }
       ];
+
     in
-    (createAssertionsForProfile "AC") ++ (createAssertionsForProfile "battery") ++ (createAssertionsForProfile "lowBattery");
+      (createAssertionsForProfile "AC")
+      ++ (createAssertionsForProfile "battery")
+      ++ (createAssertionsForProfile "lowBattery")
+      ++ generalAssertions;
 
   options = {
     programs.plasma.powerdevil = {

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -399,134 +399,72 @@ let
     };
   };
 
+  generateModifiedOptionsModules = profile:
+    [
+      (lib.mkRenamedOptionModule
+        ["programs" "plasma" "powerdevil" "${profile}" "autoSuspend"]
+        ["programs" "plasma" "powerdevil" "${profile}" "suspendSession" "afterAPeriodOfInactivity"]
+      )
+      (lib.mkRenamedOptionModule
+        ["programs" "plasma" "powerdevil" "${profile}" "powerButtonAction"]
+        ["programs" "plasma" "powerdevil" "${profile}" "suspendSession" "whenPowerButtonPressed"]
+      )
+      (lib.mkRenamedOptionModule
+        ["programs" "plasma" "powerdevil" "${profile}" "whenLaptopLidClosed"]
+        ["programs" "plasma" "powerdevil" "${profile}" "suspendSession" "whenLaptopLidClosed"]
+      )
+      (lib.mkRenamedOptionModule
+        ["programs" "plasma" "powerdevil" "${profile}" "inhibitLidActionWhenExternalMonitorConnected"]
+        ["programs" "plasma" "powerdevil" "${profile}" "suspendSession" "evenWhenAnExternalMonitorIsConnected"]
+      )
+      (lib.mkRenamedOptionModule
+        ["programs" "plasma" "powerdevil" "${profile}" "whenSleepingEnter"]
+        ["programs" "plasma" "powerdevil" "${profile}" "suspendSession" "whenSleepingEnter"]
+      )
+      (lib.mkRenamedOptionModule
+        ["programs" "plasma" "powerdevil" "${profile}" "changeScreenBrightness"]
+        ["programs" "plasma" "powerdevil" "${profile}" "displayAndBrightness" "changeScreenBrightness"]
+      )
+      (lib.mkRenamedOptionModule
+        ["programs" "plasma" "powerdevil" "${profile}" "dimDisplay"]
+        ["programs" "plasma" "powerdevil" "${profile}" "displayAndBrightness" "dimAutomatically"]
+      )
+      (lib.mkRemovedOptionModule
+        ["programs" "plasma" "powerdevil" "${profile}" "displayAndBrightness" "dimAutomatically" "enable"]
+        "The programs.plasma.powerdevil.${profile}.displayAndbrightness.dimAutomatically.enable option was removed. If you wish to disable the screen to dim automatically, set the programs.plasma.powerdevil.${profile}.displayAndbrightness.dimAutomatically.idleTimeout to \"never\"."
+      )
+      (lib.mkRenamedOptionModule
+        ["programs" "plasma" "powerdevil" "${profile}" "turnOffDisplay"]
+        ["programs" "plasma" "powerdevil" "${profile}" "displayAndBrightness" "turnOffScreen"]
+      )
+    ];
+
+    generalModifiedOptionsModules = [
+      (lib.mkRenamedOptionModule
+        ["programs" "plasma" "powerdevil" "powerButtonAction"]
+        ["programs" "plasma" "powerdevil" "AC" "powerButtonAction"]
+      )
+      (lib.mkRenamedOptionModule
+        ["programs" "plasma" "powerdevil" "autoSuspend"]
+        ["programs" "plasma" "powerdevil" "AC" "autoSuspend"]
+      )
+      (lib.mkRenamedOptionModule
+        ["programs" "plasma" "powerdevil" "turnOffDisplay"]
+        ["programs" "plasma" "powerdevil" "AC" "turnOffDisplay"]
+      )
+      (lib.mkRenamedOptionModule
+        ["programs" "plasma" "powerdevil" "general" "pausePlayersOnSuspend"]
+        ["programs" "plasma" "powerdevil" "otherSettings" "pauseMediaPlayersWhenSuspending"]
+      )
+    ];
+
 in
 {
-  imports = [
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "powerButtonAction"]
-      ["programs" "plasma" "powerdevil" "AC" "powerButtonAction"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "autoSuspend"]
-      ["programs" "plasma" "powerdevil" "AC" "autoSuspend"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "turnOffDisplay"]
-      ["programs" "plasma" "powerdevil" "AC" "turnOffDisplay"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "AC" "autoSuspend"]
-      ["programs" "plasma" "powerdevil" "AC" "suspendSession" "afterAPeriodOfInactivity"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "battery" "autoSuspend"]
-      ["programs" "plasma" "powerdevil" "battery" "suspendSession" "afterAPeriodOfInactivity"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "lowBattery" "autoSuspend"]
-      ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "afterAPeriodOfInactivity"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "AC" "powerButtonAction"]
-      ["programs" "plasma" "powerdevil" "AC" "suspendSession" "whenPowerButtonPressed"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "battery" "powerButtonAction"]
-      ["programs" "plasma" "powerdevil" "battery" "suspendSession" "whenPowerButtonPressed"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "lowBattery" "powerButtonAction"]
-      ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "whenPowerButtonPressed"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "AC" "whenLaptopLidClosed"]
-      ["programs" "plasma" "powerdevil" "AC" "suspendSession" "whenLaptopLidClosed"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "battery" "whenLaptopLidClosed"]
-      ["programs" "plasma" "powerdevil" "battery" "suspendSession" "whenLaptopLidClosed"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "lowBattery" "whenLaptopLidClosed"]
-      ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "whenLaptopLidClosed"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "AC" "inhibitLidActionWhenExternalMonitorConnected"]
-      ["programs" "plasma" "powerdevil" "AC" "suspendSession" "evenWhenAnExternalMonitorIsConnected"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "battery" "inhibitLidActionWhenExternalMonitorConnected"]
-      ["programs" "plasma" "powerdevil" "battery" "suspendSession" "evenWhenAnExternalMonitorIsConnected"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "lowBattery" "inhibitLidActionWhenExternalMonitorConnected"]
-      ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "evenWhenAnExternalMonitorIsConnected"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "AC" "whenSleepingEnter"]
-      ["programs" "plasma" "powerdevil" "AC" "suspendSession" "whenSleepingEnter"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "battery" "whenSleepingEnter"]
-      ["programs" "plasma" "powerdevil" "battery" "suspendSession" "whenSleepingEnter"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "lowBattery" "whenSleepingEnter"]
-      ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "whenSleepingEnter"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "AC" "changeScreenBrightness"]
-      ["programs" "plasma" "powerdevil" "AC" "displayAndBrightness" "changeScreenBrightness"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "battery" "changeScreenBrightness"]
-      ["programs" "plasma" "powerdevil" "battery" "displayAndBrightness" "changeScreenBrightness"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "lowBattery" "changeScreenBrightness"]
-      ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "changeScreenBrightness"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "AC" "dimDisplay"]
-      ["programs" "plasma" "powerdevil" "AC" "displayAndBrightness" "dimAutomatically"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "battery" "dimDisplay"]
-      ["programs" "plasma" "powerdevil" "battery" "displayAndBrightness" "dimAutomatically"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "lowBattery" "dimDisplay"]
-      ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "dimAutomatically"]
-    )
-    (lib.mkRemovedOptionModule
-      ["programs" "plasma" "powerdevil" "AC" "displayAndBrightness" "dimAutomatically" "enable"]
-      "The programs.plasma.powerdevil.AC.displayAndbrightness.dimAutomatically.enable option was removed. If you wish to disable the screen to dim automatically, set the programs.plasma.powerdevil.AC.displayAndbrightness.dimAutomatically.idleTimeout to \"never\"."
-    )
-    (lib.mkRemovedOptionModule
-      ["programs" "plasma" "powerdevil" "battery" "displayAndBrightness" "dimAutomatically" "enable"]
-      "The programs.plasma.powerdevil.battery.displayAndbrightness.dimAutomatically.enable option was removed. If you wish to disable the screen to dim automatically, set the programs.plasma.powerdevil.battery.displayAndbrightness.dimAutomatically.idleTimeout to \"never\"."
-    )
-    (lib.mkRemovedOptionModule
-      ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "dimAutomatically" "enable"]
-      "The programs.plasma.powerdevil.lowBattery.displayAndbrightness.dimAutomatically.enable option was removed. If you wish to disable the screen to dim automatically, set the programs.plasma.powerdevil.lowBattery.displayAndbrightness.dimAutomatically.idleTimeout to \"never\"."
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "AC" "turnOffDisplay"]
-      ["programs" "plasma" "powerdevil" "AC" "displayAndBrightness" "turnOffScreen"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "battery" "turnOffDisplay"]
-      ["programs" "plasma" "powerdevil" "battery" "displayAndBrightness" "turnOffScreen"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "lowBattery" "turnOffDisplay"]
-      ["programs" "plasma" "powerdevil" "lowBattery" "displayAndBrightness" "turnOffScreen"]
-    )
-    (lib.mkRenamedOptionModule
-      ["programs" "plasma" "powerdevil" "general" "pausePlayersOnSuspend"]
-      ["programs" "plasma" "powerdevil" "otherSettings" "pauseMediaPlayersWhenSuspending"]
-    )
-  ];
+  imports =
+    (generateModifiedOptionsModules "AC")
+    ++ (generateModifiedOptionsModules "battery")
+    ++ (generateModifiedOptionsModules "lowBattery")
+    ++ generalModifiedOptionsModules;
 
   config.assertions =
     let

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -413,7 +413,7 @@ let
   # === modified options modules declarations ===
   # =============================================
 
-  generateModifiedOptionsModules = profile:
+  generateModifiedOptionsModulesForProfile = profile:
     [
       (lib.mkRenamedOptionModule
         ["programs" "plasma" "powerdevil" "${profile}" "autoSuspend"]
@@ -515,9 +515,9 @@ let
 in
 {
   imports =
-    (generateModifiedOptionsModules "AC")
-    ++ (generateModifiedOptionsModules "battery")
-    ++ (generateModifiedOptionsModules "lowBattery")
+    (generateModifiedOptionsModulesForProfile "AC")
+    ++ (generateModifiedOptionsModulesForProfile "battery")
+    ++ (generateModifiedOptionsModulesForProfile "lowBattery")
     ++ generalModifiedOptionsModules;
 
   config.assertions =

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -481,7 +481,7 @@ in
 
   config.assertions =
     let
-      createAssertions = profile: [
+      createAssertionsForProfile = profile: [
         {
           assertion = (
             cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.action != afterAPeriodOfInactivityActions.doNothing
@@ -513,7 +513,7 @@ in
         }
       ];
     in
-    (createAssertions "AC") ++ (createAssertions "battery") ++ (createAssertions "lowBattery");
+    (createAssertionsForProfile "AC") ++ (createAssertionsForProfile "battery") ++ (createAssertionsForProfile "lowBattery");
 
   options = {
     programs.plasma.powerdevil = {

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -262,6 +262,32 @@ let
               timeout;
         };
       };
+
+      changeKeyboardBrightness = {
+        enable = lib.mkOption {
+          type = with lib.types;
+            nullOr (
+              bool
+            );
+          default = null;
+          example = true;
+          description = ''
+            Enable or disable keyboard brightness changing.
+          '';
+        };
+
+        percentage = lib.mkOption {
+          type = with lib.types;
+            nullOr (
+              ints.between 0 100
+            );
+          default = null;
+          example = 70;
+          description = ''
+            The keyboard brightness percentage when on ${type}.
+          '';
+        };
+      };
     };
 
     otherSettings = {
@@ -382,6 +408,16 @@ let
       ProfileUnloadCommand=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts."whenExitingOn${capitalize(optionsName)}PowerState";
       IdleTimeoutCommand=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.script;
       RunScriptIdleTimeoutSec=cfg.powerdevil.${optionsName}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.idleTimeout;
+    };
+    "${cfgSectName}/Keyboard" = {
+      UseProfileSpecificKeyboardBrightness=
+        if (cfg.powerdevil.${optionsName}.displayAndBrightness.changeKeyboardBrightness.enable != null) then
+          cfg.powerdevil.${optionsName}.displayAndBrightness.changeKeyboardBrightness.enable
+        else if (cfg.powerdevil.${optionsName}.displayAndBrightness.changeKeyboardBrightness.percentage != null) then
+          true
+        else
+          null;
+      KeyboardBrightness=cfg.powerdevil.${optionsName}.displayAndBrightness.changeKeyboardBrightness.percentage;
     };
   };
 in

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -350,65 +350,94 @@ let
   # configuration. cfgSectName is here the name of the section in powerdevilrc,
   # while profile is the name of the "namespace" where we should draw the
   # options from (i.e. powerdevil.AC or powerdevil.battery).
-  generateConfigForProfile = cfgSectName: profile: {
-    "${cfgSectName}/SuspendAndShutdown" = {
-      AutoSuspendAction = cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.action;
-      AutoSuspendIdleTimeoutSec = cfg.powerdevil.${profile}.suspendSession.afterAPeriodOfInactivity.idleTimeout;
-      PowerButtonAction = cfg.powerdevil.${profile}.suspendSession.whenPowerButtonPressed;
-      LidAction = cfg.powerdevil.${profile}.suspendSession.whenLaptopLidClosed;
-      InhibitLidActionWhenExternalMonitorPresent = ! cfg.powerdevil.${profile}.suspendSession.evenWhenAnExternalMonitorIsConnected;
-      SleepMode = cfg.powerdevil.${profile}.suspendSession.whenSleepingEnter;
-    };
+  generateConfigForProfile = cfgSectName: profile:
+    let
+      suspendSession = cfg.powerdevil.${profile}.suspendSession;
+      displayAndBrightness = cfg.powerdevil.${profile}.displayAndBrightness;
+      changeKeyboardBrightness = displayAndBrightness.changeKeyboardBrightness;
+      otherSettings = cfg.powerdevil.${profile}.otherSettings;
+      runCustomScripts = otherSettings.runCustomScripts;
 
-    "${cfgSectName}/Display" = {
-      UseProfileSpecificDisplayBrightness=
-        if (cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable != null) then
-          cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.enable
-        else if (cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage != null) then
-          true
-        else
-          null;
-      DisplayBrightness=cfg.powerdevil.${profile}.displayAndBrightness.changeScreenBrightness.percentage;
-      DimDisplayIdleTimeoutSec = cfg.powerdevil.${profile}.displayAndBrightness.dimAutomatically.idleTimeout;
-      TurnOffDisplayIdleTimeoutSec = cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeout;
-      TurnOffDisplayIdleTimeoutWhenLockedSec =
-        cfg.powerdevil.${profile}.displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked;
-    };
+      suspendAndShutdown = {
+        "${cfgSectName}/SuspendAndShutdown" = {
+          AutoSuspendAction = suspendSession.afterAPeriodOfInactivity.action;
+          AutoSuspendIdleTimeoutSec = suspendSession.afterAPeriodOfInactivity.idleTimeout;
+          PowerButtonAction = suspendSession.whenPowerButtonPressed;
+          LidAction = suspendSession.whenLaptopLidClosed;
+          InhibitLidActionWhenExternalMonitorPresent = ! suspendSession.evenWhenAnExternalMonitorIsConnected;
+          SleepMode = suspendSession.whenSleepingEnter;
+        };
+      };
 
-    "${cfgSectName}/Keyboard" = {
-      UseProfileSpecificKeyboardBrightness=
-        if (cfg.powerdevil.${profile}.displayAndBrightness.changeKeyboardBrightness.enable != null) then
-          cfg.powerdevil.${profile}.displayAndBrightness.changeKeyboardBrightness.enable
-        else if (cfg.powerdevil.${profile}.displayAndBrightness.changeKeyboardBrightness.percentage != null) then
-          true
-        else
-          null;
-      KeyboardBrightness=cfg.powerdevil.${profile}.displayAndBrightness.changeKeyboardBrightness.percentage;
-    };
+      display = {
+        "${cfgSectName}/Display" = {
+          UseProfileSpecificDisplayBrightness =
+            if (displayAndBrightness.changeScreenBrightness.enable != null) then
+              displayAndBrightness.changeScreenBrightness.enable
+            else if (displayAndBrightness.changeScreenBrightness.percentage != null) then
+              true
+            else
+              null;
+          DisplayBrightness = displayAndBrightness.changeScreenBrightness.percentage;
+          DimDisplayIdleTimeoutSec = displayAndBrightness.dimAutomatically.idleTimeout;
+          TurnOffDisplayIdleTimeoutSec = displayAndBrightness.turnOffScreen.idleTimeout;
+          TurnOffDisplayIdleTimeoutWhenLockedSec = displayAndBrightness.turnOffScreen.idleTimeoutWhenLocked;
+        };
+      };
 
-    "${cfgSectName}/Performance" = {
-      PowerProfile=cfg.powerdevil.${profile}.otherSettings.switchToPowerProfile;
-    };
+      keyboard = {
+        "${cfgSectName}/Keyboard" = {
+          UseProfileSpecificKeyboardBrightness =
+            if (changeKeyboardBrightness.enable != null) then
+              changeKeyboardBrightness.enable
+            else if (changeKeyboardBrightness.percentage != null) then
+              true
+            else
+              null;
+          KeyboardBrightness = changeKeyboardBrightness.percentage;
+        };
+      };
 
-    "${cfgSectName}/RunScript" = {
-      ProfileLoadCommand = cfg.powerdevil.${profile}.otherSettings.runCustomScripts."whenEnteringOn${capitalize(profile)}PowerState";
-      ProfileUnloadCommand=cfg.powerdevil.${profile}.otherSettings.runCustomScripts."whenExitingOn${capitalize(profile)}PowerState";
-      IdleTimeoutCommand=cfg.powerdevil.${profile}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.script;
-      RunScriptIdleTimeoutSec=cfg.powerdevil.${profile}.otherSettings.runCustomScripts.afterAPeriodOfInactivity.idleTimeout;
-    };
-  };
+      performance = {
+        "${cfgSectName}/Performance" = {
+          PowerProfile = otherSettings.switchToPowerProfile;
+        };
+      };
 
-  generalConfig = {
-    BatteryManagement = {
-      BatteryLowLevel = cfg.powerdevil.batteryLevels.lowLevel;
-      BatteryCriticalLevel = cfg.powerdevil.batteryLevels.criticalLevel;
-      BatteryCriticalAction = cfg.powerdevil.batteryLevels.atCriticalLevel;
-      PeripheralBatteryLowLevel = cfg.powerdevil.batteryLevels.lowLevelForPeripheralDevice;
-    };
-    General = {
-      pausePlayersOnSuspend = cfg.powerdevil.otherSettings.pauseMediaPlayersWhenSuspending;
-    };
-  };
+      runScripts = {
+        "${cfgSectName}/RunScript" = {
+          ProfileLoadCommand = runCustomScripts."whenEnteringOn${capitalize(profile)}PowerState";
+          ProfileUnloadCommand = runCustomScripts."whenExitingOn${capitalize(profile)}PowerState";
+          IdleTimeoutCommand = runCustomScripts.afterAPeriodOfInactivity.script;
+          RunScriptIdleTimeoutSec = runCustomScripts.afterAPeriodOfInactivity.idleTimeout;
+        };
+      };
+
+    in
+      suspendAndShutdown
+      // display
+      // keyboard
+      // performance
+      // runScripts;
+
+  generalConfig =
+    let
+      batteryLevels = cfg.powerdevil.batteryLevels;
+      otherSettings = cfg.powerdevil.otherSettings;
+
+    in
+      {
+        BatteryManagement = {
+          BatteryLowLevel = batteryLevels.lowLevel;
+          BatteryCriticalLevel = batteryLevels.criticalLevel;
+          BatteryCriticalAction = batteryLevels.atCriticalLevel;
+          PeripheralBatteryLowLevel = batteryLevels.lowLevelForPeripheralDevice;
+        };
+
+        General = {
+          pausePlayersOnSuspend = otherSettings.pauseMediaPlayersWhenSuspending;
+        };
+      };
 
 
   # =============================================

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -81,6 +81,15 @@ let
         '';
         apply = action: if (action == null) then null else whenLaptopLidClosedActions."${action}";
       };
+
+      inhibitLidActionWhenExternalMonitorConnected = lib.mkOption {
+        type = with lib.types; nullOr bool;
+        default = null;
+        example = true;
+        description = ''
+          If enabled, the lid action will be inhibited when an external monitor is connected.
+        '';
+      };
     };
 
     displayAndBrightness = {};
@@ -95,14 +104,6 @@ let
         The state, when on ${type}, to enter when sleeping.
       '';
       apply = action: if (action == null) then null else whenSleepingEnterActions."${action}";
-    };
-    inhibitLidActionWhenExternalMonitorConnected = lib.mkOption {
-      type = with lib.types; nullOr bool;
-      default = null;
-      example = true;
-      description = ''
-        If enabled, the lid action will be inhibited when an external monitor is connected.
-      '';
     };
     turnOffDisplay = {
       idleTimeout = lib.mkOption {
@@ -196,7 +197,7 @@ let
       SleepMode = cfg.powerdevil.${optionsName}.whenSleepingEnter;
       LidAction = cfg.powerdevil.${optionsName}.suspendSession.whenLaptopLidClosed;
       InhibitLidActionWhenExternalMonitorPresent =
-        cfg.powerdevil.${optionsName}.inhibitLidActionWhenExternalMonitorConnected;
+        cfg.powerdevil.${optionsName}.suspendSession.inhibitLidActionWhenExternalMonitorConnected;
     };
     "${cfgSectName}/Display" = {
       TurnOffDisplayIdleTimeoutSec = cfg.powerdevil.${optionsName}.turnOffDisplay.idleTimeout;
@@ -270,6 +271,18 @@ in
     (lib.mkRenamedOptionModule
       ["programs" "plasma" "powerdevil" "lowBattery" "whenLaptopLidClosed"]
       ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "whenLaptopLidClosed"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "AC" "inhibitLidActionWhenExternalMonitorConnected"]
+      ["programs" "plasma" "powerdevil" "AC" "suspendSession" "inhibitLidActionWhenExternalMonitorConnected"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "battery" "inhibitLidActionWhenExternalMonitorConnected"]
+      ["programs" "plasma" "powerdevil" "battery" "suspendSession" "inhibitLidActionWhenExternalMonitorConnected"]
+    )
+    (lib.mkRenamedOptionModule
+      ["programs" "plasma" "powerdevil" "lowBattery" "inhibitLidActionWhenExternalMonitorConnected"]
+      ["programs" "plasma" "powerdevil" "lowBattery" "suspendSession" "inhibitLidActionWhenExternalMonitorConnected"]
     )
   ];
 


### PR DESCRIPTION
I tried to cover all the options present in the configuration screen. I also made some changes to the code structure with the intention of making it more uniform and organized.

As for the option names, my idea was to mirror the texts of the options on the configuration screen. I think that even with longer names, it will be easier for the end user to assemble their configuration from the screens.

Please consider my contribution as a suggestion and not as an attempt to change for the sake of change. We can and should discuss these changes and, if necessary, reach a compromise in terms of nomenclature and organization.

One more thing: don't be scared by the number of commits, it's just my way of working. I suggest that you analyze the changes based on the final code.
