### PR TITLE
Create pager widget

### DIFF
--- a/modules/widgets/default.nix
+++ b/modules/widgets/default.nix
@@ -16,6 +16,7 @@ let
       ./kickerdash.nix
       ./kickoff.nix
       ./panel-spacer.nix
+      ./pager.nix
       ./plasma-panel-colorizer.nix
       ./plasmusic-toolbar.nix
       ./system-monitor.nix

--- a/modules/widgets/default.nix
+++ b/modules/widgets/default.nix
@@ -15,8 +15,8 @@ let
       ./kicker.nix
       ./kickerdash.nix
       ./kickoff.nix
-      ./panel-spacer.nix
       ./pager.nix
+      ./panel-spacer.nix
       ./plasma-panel-colorizer.nix
       ./plasmusic-toolbar.nix
       ./system-monitor.nix

--- a/modules/widgets/pager.nix
+++ b/modules/widgets/pager.nix
@@ -1,0 +1,115 @@
+{ lib, ... }:
+
+let
+  inherit (lib) mkOption types;
+  inherit (import ./lib.nix { inherit lib; }) configValueType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+
+  mkBoolOption =
+    description:
+    mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      inherit description;
+    };
+
+in
+{
+  pager = {
+    description = "The desktop pager is a plasma widget that helps you to organize virtual desktops.";
+    opts = {
+      position = mkOption {
+        type = positionType;
+        example = {
+          horizontal = 250;
+          vertical = 50;
+        };
+        description = "The position of the widget. (Only for desktop widget)";
+      };
+
+      size = mkOption {
+        type = sizeType;
+        example = {
+          width = 500;
+          height = 500;
+        };
+        description = "The size of the widget. (Only for desktop widget)";
+      };
+
+      behavior = {
+        general = {
+          showApplicationIconsOnWindowOutlines = mkBoolOption "Show application icons on window outlines.";
+          showOnlyCurrentScreen = mkBoolOption "Show only current screen.";
+          navigationWrapsAround = mkBoolOption "Navigation wraps around.";
+        };
+
+        textDisplay =
+          let
+            options = {
+              noText = null;
+              desktopNumber = "Number";
+              desktopName = "Name";
+            };
+
+          in
+            mkOption {
+              type = with types; nullOr (enum (builtins.attrNames options));
+              default = null;
+              example = "desktopNumber";
+              description = "Choose what to show inside each virtual desktop representation.";
+              apply = option:
+                if (option == null || option == options.noText) then
+                  null
+                else
+                  options."${option}";
+            };
+
+        selectingCurrentVirtualDesktop =
+          let
+            options = {
+              doesNothing = null;
+              showsTheDesktop = "ShowDesktop";
+            };
+
+          in
+            mkOption {
+              type = with types; nullOr (enum (builtins.attrNames options));
+              default = null;
+              example = "showsTheDesktop";
+              description = "Choose which action to take when selecting a virtual desktop representation.";
+              apply = option:
+                if (option == null || option == options.doesNothing) then
+                  null
+                else
+                  options."${option}";
+            };
+      };
+      settings = mkOption {
+        type = configValueType;
+        default = null;
+        description = "Extra configuration options for the widget.";
+        apply = settings: if settings == null then { } else settings;
+      };
+    };
+
+    convert =
+      {
+        position,
+        size,
+        behavior,
+        settings,
+      }:
+      {
+        name = "org.kde.plasma.pager";
+        config = lib.recursiveUpdate {
+          General = lib.filterAttrs (_: v: v != null) ({
+            showWindowIcons = behavior.general.showApplicationIconsOnWindowOutlines;
+            showOnlyCurrentScreen = behavior.general.showOnlyCurrentScreen;
+            wrapPage = behavior.general.navigationWrapsAround;
+            displayedText = behavior.textDisplay;
+            currentDesktopSelected = behavior.selectingCurrentVirtualDesktop;
+          });
+        } settings;
+      };
+  };
+}

--- a/modules/widgets/pager.nix
+++ b/modules/widgets/pager.nix
@@ -73,19 +73,6 @@ in
           description = "What to do on left-mouse click on a desktop rectangle";
           apply = capitalizeWord;
         };
-        pagerLayout = lib.mkOption {
-          type =
-            with lib.types;
-            nullOr (enum [
-              "default"
-              "horizontal"
-              "vertical"
-            ]);
-          default = null;
-          example = "horizontal";
-          description = "The layout style used for the presentation of the desktops";
-          apply = capitalizeWord;
-        };
       };
       settings = lib.mkOption {
         type = configValueType;
@@ -116,7 +103,6 @@ in
             wrapPage = general.navigationWrapsAround;
             displayedText = general.displayedText;
             currentDesktopSelected = general.selectingCurrentVirtualDesktop;
-            pagerLayout = general.pagerLayout;
           };
         } settings;
       };

--- a/modules/widgets/pager.nix
+++ b/modules/widgets/pager.nix
@@ -12,7 +12,6 @@ let
       default = null;
       inherit description;
     };
-
 in
 {
   pager = {
@@ -26,7 +25,6 @@ in
         };
         description = "The position of the widget. (Only for desktop widget)";
       };
-
       size = mkOption {
         type = sizeType;
         example = {
@@ -35,14 +33,12 @@ in
         };
         description = "The size of the widget. (Only for desktop widget)";
       };
-
       behavior = {
         general = {
           showApplicationIconsOnWindowOutlines = mkBoolOption "Show application icons on window outlines.";
           showOnlyCurrentScreen = mkBoolOption "Show only current screen.";
           navigationWrapsAround = mkBoolOption "Navigation wraps around.";
         };
-
         textDisplay =
           let
             options = {
@@ -50,20 +46,14 @@ in
               desktopNumber = "Number";
               desktopName = "Name";
             };
-
           in
-            mkOption {
-              type = with types; nullOr (enum (builtins.attrNames options));
-              default = null;
-              example = "desktopNumber";
-              description = "Choose what to show inside each virtual desktop representation.";
-              apply = option:
-                if (option == null || option == options.noText) then
-                  null
-                else
-                  options."${option}";
-            };
-
+          mkOption {
+            type = with types; nullOr (enum (builtins.attrNames options));
+            default = null;
+            example = "desktopNumber";
+            description = "Choose what to show inside each virtual desktop representation.";
+            apply = option: if (option == null || option == options.noText) then null else options."${option}";
+          };
         selectingCurrentVirtualDesktop =
           let
             options = {
@@ -72,17 +62,14 @@ in
             };
 
           in
-            mkOption {
-              type = with types; nullOr (enum (builtins.attrNames options));
-              default = null;
-              example = "showsTheDesktop";
-              description = "Choose which action to take when selecting a virtual desktop representation.";
-              apply = option:
-                if (option == null || option == options.doesNothing) then
-                  null
-                else
-                  options."${option}";
-            };
+          mkOption {
+            type = with types; nullOr (enum (builtins.attrNames options));
+            default = null;
+            example = "showsTheDesktop";
+            description = "Choose which action to take when selecting a virtual desktop representation.";
+            apply =
+              option: if (option == null || option == options.doesNothing) then null else options."${option}";
+          };
       };
       settings = mkOption {
         type = configValueType;
@@ -91,7 +78,6 @@ in
         apply = settings: if settings == null then { } else settings;
       };
     };
-
     convert =
       {
         position,
@@ -102,13 +88,13 @@ in
       {
         name = "org.kde.plasma.pager";
         config = lib.recursiveUpdate {
-          General = lib.filterAttrs (_: v: v != null) ({
+          General = lib.filterAttrs (_: v: v != null) {
             showWindowIcons = behavior.general.showApplicationIconsOnWindowOutlines;
             showOnlyCurrentScreen = behavior.general.showOnlyCurrentScreen;
             wrapPage = behavior.general.navigationWrapsAround;
             displayedText = behavior.textDisplay;
             currentDesktopSelected = behavior.selectingCurrentVirtualDesktop;
-          });
+          };
         } settings;
       };
   };


### PR DESCRIPTION
Create a widget for pager. It covers the options:

- General
  - Show application icons on window outline
  - Show only current screen
  - Navigation wraps around
- Text display
  - No text
  - Desktop number
  - Desktop name
- Selecting current virtual desktop
  - Does nothing
  - Shows the desktop
