### PR TITLE
Add option to disable pasting with middle click

### DIFF
--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -77,6 +77,15 @@ in
       '';
     };
 
+    enableMiddleClickPaste = lib.mkOption {
+      type = with lib.types; nullOr bool;
+      default = null;
+      example = false;
+      description = ''
+        Clicking the middle mouse button pastes clipboard content";
+      '';
+    };
+
     tooltipDelay = lib.mkOption {
       type = with lib.types; nullOr ints.positive;
       default = null;
@@ -324,8 +333,9 @@ in
               lib.mkIf (cfg.workspace.windowDecorations.theme != null) {
                 "org.kde.kdecoration2".library = cfg.workspace.windowDecorations.library;
                 "org.kde.kdecoration2".theme = cfg.workspace.windowDecorations.theme;
-              }
-            );
+              }) // (lib.mkIf (cfg.workspace.enableMiddleClickPaste != null) {
+                Wayland.EnablePrimarySelection = cfg.workspace.enableMiddleClickPaste;
+              });
           }
           # We add persistence to some keys in order to not reset the themes on
           # each generation when we use overrideConfig.

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -333,7 +333,7 @@ in
               lib.mkIf (cfg.workspace.windowDecorations.theme != null) {
                 "org.kde.kdecoration2".library = cfg.workspace.windowDecorations.library;
                 "org.kde.kdecoration2".theme = cfg.workspace.windowDecorations.theme;
-              }) // (lib.mkIf (cfg.workspace.enableMiddleClickPaste != null) {
+              }) // (lib.optionalAttrs (cfg.workspace.enableMiddleClickPaste != null) {
                 Wayland.EnablePrimarySelection = cfg.workspace.enableMiddleClickPaste;
               });
           }


### PR DESCRIPTION
Adds a simple option to disable or enable pasting with the middle mouse button on Wayland.