### PR TITLE
apps: make package installation optional

### DIFF
--- a/modules/apps/ghostwriter.nix
+++ b/modules/apps/ghostwriter.nix
@@ -262,10 +262,12 @@ in
           "ghostwriter"
         ]
         {
+          nullable = true;
           example = "pkgs.kdePackages.ghostwriter";
           extraDescription = ''
             Use `pkgs.libsForQt5.ghostwriter` in Plasma5 and
-            `pkgs.kdePackages.ghostwriter` in Plasma6.
+            `pkgs.kdePackages.ghostwriter` in Plasma6. Use
+            `null` if home-manager should not install GhostWriter.
           '';
         };
 
@@ -601,7 +603,7 @@ in
         }
       ];
 
-      home.packages = [ cfg.package ];
+      home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
       programs.plasma.configFile = {
         "kde.org/ghostwriter.conf" = (

--- a/modules/apps/kate/default.nix
+++ b/modules/apps/kate/default.nix
@@ -247,6 +247,7 @@ in
           "kate"
         ]
         {
+          nullable = true;
           example = "pkgs.libsForQt5.kate";
           extraDescription = ''
             Which kate package to install. Use `pkgs.libsForQt5.kate` in Plasma5 and

--- a/modules/apps/okular.nix
+++ b/modules/apps/okular.nix
@@ -30,10 +30,11 @@ with lib.types;
           "okular"
         ]
         {
+          nullable = true;
           example = "pkgs.libsForQt5.okular";
           extraDescription = ''
             Which okular package to install. Use `pkgs.libsForQt5.okular` in Plasma5 and
-            `pkgs.kdePackages.okular` in Plasma6.
+            `pkgs.kdePackages.okular` in Plasma6. Use `null` if home-manager should not install Okular.
           '';
         };
 
@@ -193,7 +194,7 @@ with lib.types;
   };
 
   config = {
-    home.packages = lib.mkIf (cfg.enable) [ cfg.package ];
+    home.packages = lib.mkIf (cfg.enable && cfg.package != null) [ cfg.package ];
   };
 
   # ==================================


### PR DESCRIPTION
Users should be able to configure a system-wide installation of `{kate,ghostwriter,okular}` without needing to have a duplicate home manager package. This behaviour was even documented in Kate's `package` option, but did not work as the `nullable` tag wasn't set to true. This commit corrects this behaviour.