### PR TITLE
docs(treewide): typos, pass I

### DIFF
--- a/docs/manual/introduction.md
+++ b/docs/manual/introduction.md
@@ -1,7 +1,6 @@
 # Introduction {#intro}
-To get started it may be helpful to check out the
-[getting started section in the README](https://github.com/nix-community/plasma-manager#getting-started).
-This gives a couple examples on how you can get started using plasma-manager,
-either using a flake or traditional nix-channels.
+To get started, check out the [**getting started** section in the README](https://github.com/nix-community/plasma-manager#getting-started).
+There are a couple of examples on how you can get started using `plasma-manager`,
+using either a flake or traditional Nix channels.
 
 More details may be available here in the future!

--- a/docs/manual/preface.md
+++ b/docs/manual/preface.md
@@ -1,10 +1,10 @@
 # Preface {#preface}
-Plasma-Manager is a [Home Manager](https://github.com/nix-community/home-manager)
-module which has as a goal to be able to configure as much of KDE plasma as
-possible, using nix.
+Plasma Manager is a [Home Manager](https://github.com/nix-community/home-manager)
+module capable of configuring as much of KDE Plasma as
+possible, using [Nix](https://nixos.org).
 
 The project has progressed a lot lately, to the extent where
-[most of the configuration options present in KDE Plasma 6 are configurable through plasma-manager](https://github.com/nix-community/plasma-manager#whats-supported).
+[most of the configuration options present in KDE Plasma 6 are configurable through `plasma-manager`](https://github.com/nix-community/plasma-manager#whats-supported).
 
-The main focus of the project has been on KDE plasma 6 for a little while now,
-but it's also possible to use it to some extent on plasma 5 as well.
+The main focus of the project has been on KDE Plasma 6 for a little while now,
+but it's also possible to use it to some extent on Plasma 5 as well.

--- a/modules/apps/ghostwriter.nix
+++ b/modules/apps/ghostwriter.nix
@@ -52,7 +52,7 @@ let
         type = matchingPrefer;
         default = "default";
         description = ''
-          Whether the font matching process prefers exact matches, of best quality matches.
+          Whether the font matching process prefers exact matches, or best quality matches.
 
           `default` corresponds to not setting any enum flag, and `exact` and `quality`
           correspond to `PreferMatch` and `PreferQuality` enum flags respectively.
@@ -72,7 +72,7 @@ let
         type = lib.types.bool;
         default = false;
         description = ''
-          If set to true, this font will try to avoid subpixel antialiasing.
+          If set to `true`, this font will try to avoid subpixel antialiasing.
 
           Corresponds to the `NoSubpixelAntialias` enum flag.
         '';
@@ -81,7 +81,7 @@ let
         type = lib.types.bool;
         default = false;
         description = ''
-          If set to true, this font will not try to find a substitute font when encountering missing glyphs.
+          If set to `true`, this font will not try to find a substitute font when encountering missing glyphs.
 
           Corresponds to the `NoFontMerging` enum flag.
         '';
@@ -90,7 +90,7 @@ let
         type = lib.types.bool;
         default = false;
         description = ''
-          If set to true, this font will not try to apply shaping rules that may be required for some scripts
+          If set to `true`, this font will not try to apply shaping rules that may be required for some scripts
           (e.g. Indic scripts), increasing performance if these rules are not required.
 
           Corresponds to the `PreferNoShaping` enum flag.
@@ -130,7 +130,7 @@ let
         description = ''
           The style hint of this font.
 
-          See https://doc.qt.io/qt-6/qfont.html#StyleHint-enum for more.
+          See https://doc.qt.io/qt-6/qfont.html#StyleHint-enum for more information.
         '';
       };
       weight = lib.mkOption {
@@ -139,7 +139,7 @@ let
         description = ''
           The weight of the font, either as a number between 1 to 1000 or as a pre-defined weight string.
 
-          See https://doc.qt.io/qt-6/qfont.html#Weight-enum for more.
+          See https://doc.qt.io/qt-6/qfont.html#Weight-enum for more information.
         '';
       };
       style = lib.mkOption {
@@ -265,9 +265,9 @@ in
           nullable = true;
           example = "pkgs.kdePackages.ghostwriter";
           extraDescription = ''
-            Use `pkgs.libsForQt5.ghostwriter` in Plasma5 and
-            `pkgs.kdePackages.ghostwriter` in Plasma6. Use
-            `null` if home-manager should not install GhostWriter.
+            Use `pkgs.libsForQt5.ghostwriter` for Plasma 5 and
+            `pkgs.kdePackages.ghostwriter` for Plasma 6. Use
+            `null` if `home-manager` should not install Ghostwriter.
           '';
         };
 
@@ -347,7 +347,7 @@ in
                   ]
                   (
                     lib.lists.findFirstIndex (x: x == focusMode)
-                      (throw "editor.styling.focusMode: Value ${focusMode} isn't present in the enum. This is a bug")
+                      (throw "editor.styling.focusMode: Value ${focusMode} isn't present in the enum. This is a bug.")
                       enumVals
                   );
           };
@@ -580,8 +580,8 @@ in
         type = with lib.types; attrsOf path;
         default = { };
         description = ''
-          Custom themes to be added to the installation. The key is their name.
-          Choose them in `programs.ghostwriter.theme.name`.
+          Custom themes to be added to the installation. The attribute key is mapped to their name.
+          Choose them from `programs.ghostwriter.theme.name`.
         '';
       };
     };

--- a/modules/apps/kate/default.nix
+++ b/modules/apps/kate/default.nix
@@ -38,7 +38,7 @@ let
     else
       lib.lists.findFirstIndex (
         x: x == value
-      ) (throw "getIndexFromEnum (kate): Value ${value} isn't present in the enum. This is a bug") enum;
+      ) (throw "getIndexFromEnum (kate): Value ${value} isn't present in the enum. This is a bug.") enum;
 
   qfont = import ../../../lib/qfont.nix { inherit lib; };
 
@@ -59,7 +59,7 @@ let
         type = matchingPrefer;
         default = "default";
         description = ''
-          Whether the font matching process prefers exact matches, of best quality matches.
+          Whether the font matching process prefers exact matches, or best quality matches.
 
           `default` corresponds to not setting any enum flag, and `exact` and `quality`
           correspond to `PreferMatch` and `PreferQuality` enum flags respectively.
@@ -79,7 +79,7 @@ let
         type = lib.types.bool;
         default = false;
         description = ''
-          If set to true, this font will try to avoid subpixel antialiasing.
+          If set to `true`, this font will try to avoid subpixel antialiasing.
 
           Corresponds to the `NoSubpixelAntialias` enum flag.
         '';
@@ -88,7 +88,7 @@ let
         type = lib.types.bool;
         default = false;
         description = ''
-          If set to true, this font will not try to find a substitute font when encountering missing glyphs.
+          If set to `true`, this font will not try to find a substitute font when encountering missing glyphs.
 
           Corresponds to the `NoFontMerging` enum flag.
         '';
@@ -97,7 +97,7 @@ let
         type = lib.types.bool;
         default = false;
         description = ''
-          If set to true, this font will not try to apply shaping rules that may be required for some scripts
+          If set to `true`, this font will not try to apply shaping rules that may be required for some scripts
           (e.g. Indic scripts), increasing performance if these rules are not required.
 
           Corresponds to the `PreferNoShaping` enum flag.
@@ -237,7 +237,7 @@ in
 {
   options.programs.kate = {
     enable = lib.mkEnableOption ''
-      Enable configuration management for kate.
+      Enable configuration management for Kate, the KDE Advanced Text Editor.
     '';
 
     package =
@@ -250,10 +250,8 @@ in
           nullable = true;
           example = "pkgs.libsForQt5.kate";
           extraDescription = ''
-            Which kate package to install. Use `pkgs.libsForQt5.kate` in Plasma5 and
-            `pkgs.kdePackages.kate` in Plasma6. Use `null` if home-manager should not install kate
-            (use this if you want to manage the settings of this user of a system-wide kate
-            installation).
+            Which Kate package to be installed by `home-manager`. Use `pkgs.libsForQt5.kate` for Plasma 5 and
+            `pkgs.kdePackages.kate` for Plasma 6. Use `null` if `home-manager` should not install Kate.
           '';
         };
 
@@ -261,7 +259,7 @@ in
     #     INDENTATION
     editor = {
       tabWidth = lib.mkOption {
-        description = "The width of a single tab (''\t) sign (in number of spaces).";
+        description = "The width of a single tab (`\t`) sign (in number of spaces).";
         default = 4;
         type = lib.types.int;
       };
@@ -280,7 +278,7 @@ in
 
       indent.autodetect = lib.mkOption {
         description = ''
-          Whether kate should try to detect indentation for each given file and not impose default indentation settings.
+          Whether Kate should try to detect indentation for each given file and not impose default indentation settings.
         '';
         default = true;
         type = lib.types.bool;
@@ -311,7 +309,7 @@ in
       };
 
       indent.undoByShiftTab = lib.mkOption {
-        description = "Whether to unindent the current line by one level with the shortcut Shift+Tab";
+        description = "Whether to unindent the current line by one level with the shortcut Shift+Tab.";
         default = true;
         type = lib.types.bool;
       };
@@ -360,11 +358,12 @@ in
     src = lib.mkOption {
       description = ''
         The path of a theme file for the KDE editor (not the window color scheme).
-        Obtain a custom one by using the GUI settings in kate. If you want to use a system-wide
+        Obtain a custom one by using the GUI settings in Kate. If you want to use a system-wide
         editor color scheme set this path to null. If you set the metadata.name entry in the file
         to a value that matches the name of a system-wide color scheme undesired behaviour may
         occur. The activation will fail if a theme with the filename `<name of your theme>.theme`
-        already exists.'';
+        already exists.
+      '';
       type = lib.types.nullOr lib.types.path;
       default = null;
     };
@@ -419,9 +418,9 @@ in
     default = null;
     type = lib.types.nullOr lib.types.attrs;
     description = ''
-      Add more lsp server settings here. Check out the format on the
-      [KDE page](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html).
-      Note that these are only the settings, the packages have to be installed separately.
+      Add more LSP server settings here. Check out the format on the
+      [Kate Documentation](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html).
+      Note that these are only the settings; the appropriate packages have to be installed separately.
     '';
   };
 

--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -34,7 +34,7 @@ let
         example = "Catppuccin-Mocha";
         description = ''
           Color scheme the profile will use. You can check the files you can
-          use in ~/.local/share/konsole or /run/current-system/share/konsole.
+          use in `$HOME/.local/share/konsole` or `/run/current-system/sw/share/konsole`.
           You might also add a custom color scheme using
           `programs.konsole.customColorSchemes`.
         '';
@@ -70,7 +70,7 @@ let
           example = 12;
           description = ''
             Size of the font.
-            Needs a font to be set due to konsole limitations.
+            Due to Konsole limitations, only a limited range of sizes is possible.
           '';
         };
       };
@@ -89,7 +89,7 @@ in
 {
   options.programs.konsole = {
     enable = lib.mkEnableOption ''
-      Enable configuration management for Konsole.
+      Enable configuration management for Konsole, the KDE Terminal.
     '';
 
     defaultProfile = lib.mkOption {
@@ -97,8 +97,8 @@ in
       default = null;
       example = "Catppuccin";
       description = ''
-        The name of the konsole profile file to use by default.
-        To see what options you have, just take a look at ~/.local/share/konsole/
+        The name of the Konsole profile file to use by default.
+        To see what options you have, take a look at `$HOME/.local/share/konsole`
       '';
     };
 
@@ -114,7 +114,7 @@ in
       type = with lib.types; attrsOf path;
       default = { };
       description = ''
-        Custom color schemes to be added to the installation. The key is their name.
+        Custom color schemes to be added to the installation. The attribute key maps to their name.
         Choose them in any profile with `profiles.<profile>.colorScheme = <name>`;
       '';
     };
@@ -124,8 +124,8 @@ in
       default = null;
       example = "Krita dark orange";
       description = ''
-        The colour scheme of the UI. Leave this setting at `null` in order to
-        not override the systems default scheme for for this application.
+        The color scheme of the UI. Leave this setting at `null` in order to
+        not override the system's default scheme for for this application.
       '';
     };
 
@@ -133,7 +133,7 @@ in
       type = with lib.types; nullOr (attrsOf (attrsOf basicSettingsType));
       default = null;
       description = ''
-        Extra config to add to konsolerc.
+        Extra config to add to the `konsolerc`.
       '';
     };
   };

--- a/modules/apps/okular.nix
+++ b/modules/apps/okular.nix
@@ -42,25 +42,25 @@ with lib.types;
     #     GENERAL
     general = {
       smoothScrolling = lib.mkOption {
-        description = "Use smooth scrolling.";
+        description = "Whether to use smooth scrolling.";
         default = null;
         type = nullOr bool;
       };
 
       showScrollbars = lib.mkOption {
-        description = "Show scrollbars.";
+        description = "Whether to show scrollbars in the document viewer.";
         default = null;
         type = nullOr bool;
       };
 
       openFileInTabs = lib.mkOption {
-        description = "Open files in tabs.";
+        description = "Whether to open files in tabs.";
         default = null;
         type = nullOr bool;
       };
 
       viewContinuous = lib.mkOption {
-        description = "Open in continous mode by default.";
+        description = "Whether to open in continous mode by default.";
         default = null;
         type = nullOr bool;
       };
@@ -108,14 +108,14 @@ with lib.types;
       mouseMode = lib.mkOption {
         description = ''
           Changes what the mouse does.
-          See https://docs.kde.org/stable5/en/okular/okular/menutools.html for
-          the full description.
-          Browse - Click-and-drag with left mouse button.
-          Zoom - Zoom in with left mouse button. Reset zoom with right mouse button.
-          Rectangle Selection - Draw area selection with left mouse button. Display options with right mouse button.
-          Text Selection - Select text with left mouse button. Display options with right mouse button.
-          Table Selection - Similar to text selection but allows for transforming the document into a table.
-          Magnifier - Activates the magnifier with left mouse button.
+          See the [Okular Documentation](https://docs.kde.org/stable5/en/okular/okular/menutools.html) for the full description.
+
+          - `Browse`: Click-and-drag with left mouse button.
+          - `Zoom`: Zoom in with left mouse button. Reset zoom with right mouse button.
+          - `RectSelect`: Draw area selection with left mouse button. Display options with right mouse button.
+          - `TextSelect`: Select text with left mouse button. Display options with right mouse button.
+          - `TableSelect`: Similar to text selection but allows for transforming the document into a table.
+          - `Magnifier`: Activates the magnifier with left mouse button.
         '';
         default = null;
         type = nullOr (enum [
@@ -134,7 +134,7 @@ with lib.types;
     #     ACCESSIBILITY
     accessibility = {
       highlightLinks = lib.mkOption {
-        description = "Draw borders around links.";
+        description = "Whether to draw borders around links.";
         default = null;
         type = nullOr bool;
       };
@@ -175,13 +175,13 @@ with lib.types;
     #     PERFORMANCE
     performance = {
       enableTransparencyEffects = lib.mkOption {
-        description = "Enable transparancey effects. This may increase CPU usage.";
+        description = "Whether to enable transparancy effects. This may increase CPU usage.";
         default = null;
         type = nullOr bool;
       };
 
       memoryUsage = lib.mkOption {
-        description = "Memory usage of Okular. This impacts the speed performance of Okular as it determines how much computation results are kept in memory and not recomputed.";
+        description = "Memory usage profile for Okular. This may impact the speed performance of Okular, as it determines how many computation results are kept in memory.";
         default = null;
         type = nullOr (enum [
           "Low"

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -22,6 +22,6 @@
   ];
 
   options.programs.plasma.enable = lib.mkEnableOption ''
-    Enable configuration management for KDE Plasma.
+    Whether to enable declarative configuration options for the KDE Plasma Desktop.
   '';
 }

--- a/modules/desktop.nix
+++ b/modules/desktop.nix
@@ -277,7 +277,7 @@ in
         default = null;
         example = "topToBottom";
         description = ''
-          The direction, in which desktop icons are to be arranged.
+          The direction in which desktop icons are to be arranged.
         '';
       };
 
@@ -302,8 +302,8 @@ in
         example = true;
         description = ''
           Locks the position of all desktop icons to the order and placement
-          defined by `arrangement`, `alignment` and the `sorting` options
-          so they can’t be manually moved.
+          defined by `arrangement`, `alignment` and the `sorting` options,
+          so they cannot be manually moved.
         '';
       };
 
@@ -313,8 +313,8 @@ in
           default = null;
           example = "type";
           description = ''
-            Specifies the sort mode for the desktop icons. By default they are
-            sorted by name.
+            Specifies the sort mode for the desktop icons. By default, they are
+            sorted by `name`.
           '';
           apply = sortMode: if (sortMode == null) then null else desktopIconSortingModeId.${sortMode};
         };
@@ -334,10 +334,10 @@ in
           example = false;
           description = ''
             Folders are sorted separately from files by default. This means
-            folders appear first, sorted for example ascending by name,
+            folders appear first, sorted, for example, ascending by name,
             followed by files, also sorted ascending by name.
-            If this option is disabled, all items are sorted irrespective
-            of their type.
+            If this option is disabled, all items are sorted regardless
+            of type.
           '';
         };
       };
@@ -348,8 +348,8 @@ in
         example = 2;
         description = ''
           The desktop icon size, which is normally configured via a slider
-          with seven possible values ranging from small (0) to large (6).
-          The fourth position (3) is the default.
+          with seven possible values ranging from small (`0`) to large (`6`).
+          The fourth position (`3`) is the default.
         '';
       };
 
@@ -360,7 +360,8 @@ in
         description = ''
           Enables the arrow button when hovering over a folder on the desktop
           which shows a preview popup of the folder’s contents.
-          Is enabled by default.
+
+          Enabled by default.
         '';
       };
 
@@ -382,7 +383,7 @@ in
         type = lib.types.nullOr mouseActionNamesEnum;
         default = null;
         example = "appLauncher";
-        description = "Action for a left click on the desktop.";
+        description = "Action for a left mouse click on the desktop.";
         apply = value: if (value == null) then null else mouseActions.${value};
       };
 
@@ -390,7 +391,7 @@ in
         type = lib.types.nullOr mouseActionNamesEnum;
         default = null;
         example = "switchWindow";
-        description = "Action for a click on the desktop with the middle mouse button.";
+        description = "Action for a middle mouse click on the desktop.";
         apply = value: if (value == null) then null else mouseActions.${value};
       };
 
@@ -398,7 +399,7 @@ in
         type = lib.types.nullOr mouseActionNamesEnum;
         default = null;
         example = "contextMenu";
-        description = "Action for a right click on the desktop.";
+        description = "Action for a right mouse click on the desktop.";
         apply = value: if (value == null) then null else mouseActions.${value};
       };
 

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -96,7 +96,7 @@ in
       default = { };
       description = ''
         An attribute set where the keys are file names (relative to
-        HOME) and the values are attribute sets that represent
+        `$HOME`) and the values are attribute sets that represent
         configuration groups and settings inside those groups.
       '';
     };
@@ -105,7 +105,7 @@ in
       default = { };
       description = ''
         An attribute set where the keys are file names (relative to
-        XDG_CONFIG_HOME) and the values are attribute sets that
+        `$XDG_CONFIG_HOME`) and the values are attribute sets that
         represent configuration groups and settings inside those groups.
       '';
     };
@@ -114,7 +114,7 @@ in
       default = { };
       description = ''
         An attribute set where the keys are file names (relative to
-        XDG_DATA_HOME) and the values are attribute sets that
+        `$XDG_DATA_HOME`) and the values are attribute sets that
         represent configuration groups and settings inside those groups.
       '';
     };
@@ -122,10 +122,10 @@ in
       type = lib.types.bool;
       default = false;
       description = ''
-        Wether to discard changes made outside plasma-manager. If enabled all
-        settings not specified explicitly in plasma-manager will be set to the
+        Wether to discard changes made outside `plasma-manager`. If enabled, all
+        settings not specified explicitly in `plasma-manager` will be set to the
         default on next login. This will automatically delete a lot of
-        kde-plasma config-files on each generation so be careful with this
+        KDE Plasma configuration files on each generation, so do be careful with this
         option.
       '';
     };
@@ -133,14 +133,14 @@ in
       type = lib.types.listOf lib.types.str;
       default = defaultResetFiles;
       description = ''
-        Config-files which should be deleted on each generation.
+        Configuration files which should be explicitly deleted on each generation.
       '';
     };
     resetFilesExclude = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
       description = ''
-        Config-files which explicitly should not be deleted on each generation.
+        Configuration files which explicitly should not be deleted on each generation, if `overrideConfig` is enabled.
       '';
     };
     immutableByDefault = lib.mkEnableOption "Make keys written by plasma-manager immutable by default.";

--- a/modules/fonts.nix
+++ b/modules/fonts.nix
@@ -20,7 +20,7 @@ let
         type = matchingPrefer;
         default = "default";
         description = ''
-          Whether the font matching process prefers exact matches, of best quality matches.
+          Whether the font matching process prefers exact matches, or best quality matches.
 
           `default` corresponds to not setting any enum flag, and `exact` and `quality`
           correspond to `PreferMatch` and `PreferQuality` enum flags respectively.
@@ -40,7 +40,7 @@ let
         type = types.bool;
         default = false;
         description = ''
-          If set to true, this font will try to avoid subpixel antialiasing.
+          If set to `true`, this font will try to avoid subpixel antialiasing.
 
           Corresponds to the `NoSubpixelAntialias` enum flag.
         '';
@@ -49,7 +49,7 @@ let
         type = types.bool;
         default = false;
         description = ''
-          If set to true, this font will not try to find a substitute font when encountering missing glyphs.
+          If set to `true`, this font will not try to find a substitute font when encountering missing glyphs.
 
           Corresponds to the `NoFontMerging` enum flag.
         '';
@@ -203,7 +203,7 @@ in
     general = mkOption {
       type = types.nullOr fontType;
       default = null;
-      description = "The main font of the system.";
+      description = "The main font for the Plasma desktop.";
       example = lib.literalExpression ''
         {
           family = "Noto Sans";
@@ -214,7 +214,7 @@ in
     fixedWidth = mkOption {
       type = types.nullOr fontType;
       default = null;
-      description = "The fixed width or monospace font of the system.";
+      description = "The fixed width or monospace font for the Plasma desktop.";
       example = lib.literalExpression ''
         {
           family = "Iosevka";
@@ -258,7 +258,7 @@ in
     windowTitle = mkOption {
       type = types.nullOr fontType;
       default = null;
-      description = "The font used for windowTitles.";
+      description = "The font used for window titles.";
       example = lib.literalExpression ''
         {
           family = "Noto Sans";

--- a/modules/hotkeys.nix
+++ b/modules/hotkeys.nix
@@ -29,7 +29,7 @@ let
         comment = lib.mkOption {
           type = lib.types.str;
           default = name;
-          description = "Optional comment to display in the KDE settings UI.";
+          description = "Optional comment to display in the System Settings app.";
         };
 
         key = lib.mkOption {
@@ -49,26 +49,28 @@ let
           description = "The command to execute.";
         };
 
-        logs.enabled = lib.mkOption {
-          type = lib.types.bool;
-          default = true;
-          description = "Connect command's stdin and stdout to systemd journal with systemd-cat.";
-        };
+        logs = {
+          enabled = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Connect the command's `stdin` and `stdout` to the systemd journal with `systemd-cat`.";
+          };
 
-        logs.identifier = lib.mkOption {
-          type = lib.types.str;
-          default = lib.trivial.pipe name [
-            lib.strings.toLower
-            (builtins.replaceStrings [ " " ] [ "-" ])
-            (n: "${group.name}-${n}")
-          ];
-          description = "Identifier passed down to systemd-cat.";
-        };
+          identifier = lib.mkOption {
+            type = lib.types.str;
+            default = lib.trivial.pipe name [
+              lib.strings.toLower
+              (builtins.replaceStrings [ " " ] [ "-" ])
+              (n: "${group.name}-${n}")
+            ];
+            description = "Identifier passed down to `systemd-cat`.";
+          };
 
-        logs.extraArgs = lib.mkOption {
-          type = lib.types.str;
-          default = "";
-          description = "Additional arguments provided to systemd-cat.";
+          extraArgs = lib.mkOption {
+            type = lib.types.str;
+            default = "";
+            description = "Additional arguments provided to `systemd-cat`.";
+          };
         };
       };
     };

--- a/modules/input.nix
+++ b/modules/input.nix
@@ -68,7 +68,7 @@ let
         default = null;
         example = true;
         description = ''
-          Enables or disables the touchpad.
+          Whether to enable the touchpad.
         '';
       };
       name = lib.mkOption {
@@ -78,8 +78,8 @@ let
         description = ''
           The name of the touchpad.
 
-          This can be found by looking at the Name attribute in the section in
-          /proc/bus/input/devices belonging to the touchpad.
+          This can be found by looking at the `Name` attribute in the section in
+          the `/proc/bus/input/devices` path belonging to the touchpad.
         '';
       };
       vendorId = lib.mkOption {
@@ -89,8 +89,8 @@ let
         description = ''
           The vendor ID of the touchpad.
 
-          This can be found by looking at the Vendor attribute in the section in
-          /proc/bus/input/devices belonging to the touchpad.
+          This can be found by looking at the `Vendor` attribute in the section in
+          the `/proc/bus/input/devices` path belonging to the touchpad.
         '';
       };
       productId = lib.mkOption {
@@ -100,8 +100,8 @@ let
         description = ''
           The product ID of the touchpad.
 
-          This can be found by looking at the Product attribute in the section
-          in /proc/bus/input/devices belonging to the touchpad.
+          This can be found by looking at the `Product` attribute in the section in
+          the `/proc/bus/input/devices` path belonging to the touchpad.
         '';
       };
       disableWhileTyping = lib.mkOption {
@@ -109,7 +109,7 @@ let
         default = null;
         example = true;
         description = ''
-          Disables the touchpad while typing.
+          Whether to disable the touchpad while typing.
         '';
       };
       leftHanded = lib.mkOption {
@@ -117,7 +117,7 @@ let
         default = null;
         example = false;
         description = ''
-          Swap the left and right buttons.
+          Whether to swap the left and right buttons.
         '';
       };
       middleButtonEmulation = lib.mkOption {
@@ -125,7 +125,7 @@ let
         default = null;
         example = false;
         description = ''
-          Middle click by pressing the left and right buttons at the same time.
+          Whether to enable middle mouse click emulation by pressing the left and right buttons at the same time.
           Activating this increases the click latency by 50ms.
         '';
       };
@@ -142,7 +142,7 @@ let
         default = null;
         example = true;
         description = ''
-          Enables natural scrolling for the touchpad.
+          Whether to enable natural scrolling for the touchpad.
         '';
       };
       tapToClick = lib.mkOption {
@@ -150,7 +150,7 @@ let
         default = null;
         example = true;
         description = ''
-          Enables tap-to-click for the touchpad.
+          Whether to enable tap-to-click for the touchpad.
         '';
       };
       tapAndDrag = lib.mkOption {
@@ -158,7 +158,7 @@ let
         default = null;
         example = true;
         description = ''
-          Enables tap-and-drag for the touchpad.
+          Whether to enable tap-and-drag for the touchpad.
         '';
       };
       tapDragLock = lib.mkOption {
@@ -166,7 +166,7 @@ let
         default = null;
         example = true;
         description = ''
-          Enables tap-and-drag lock for the touchpad.
+          Whether to enable the tap-and-drag lock for the touchpad.
         '';
       };
       scrollMethod = lib.mkOption {
@@ -174,7 +174,7 @@ let
         default = null;
         example = "touchPadEdges";
         description = ''
-          How scrolling is performed on the touchpad.
+          Configure how scrolling is performed on the touchpad.
         '';
         apply = method: if (method == null) then null else scrollMethods."${method}";
       };
@@ -183,7 +183,7 @@ let
         default = null;
         example = "twoFingers";
         description = ''
-          How right-clicking is performed on the touchpad.
+          Configure how right-clicking is performed on the touchpad.
         '';
         apply = method: if (method == null) then null else rightClickMethods."${method}";
       };
@@ -197,7 +197,7 @@ let
         default = null;
         example = "twoFingers";
         description = ''
-          How right-clicking is performed on the touchpad.
+          Configure what a two-finger tap maps to on the touchpad.
         '';
         apply = v: if (v == null) then null else (v == "middleClick");
       };
@@ -244,8 +244,8 @@ let
         description = ''
           The name of the mouse.
 
-          This can be found by looking at the Name attribute in the section in
-          /proc/bus/input/devices belonging to the mouse.
+          This can be found by looking at the `Name` attribute in the section in
+          the `/proc/bus/input/devices` path belonging to the mouse.
         '';
       };
       vendorId = lib.mkOption {
@@ -255,8 +255,8 @@ let
         description = ''
           The vendor ID of the mouse.
 
-          This can be found by looking at the Vendor attribute in the section in
-          /proc/bus/input/devices belonging to the mouse.
+          This can be found by looking at the `Vendor` attribute in the section in
+          the `/proc/bus/input/devices` path belonging to the mouse.
         '';
       };
       productId = lib.mkOption {
@@ -266,8 +266,8 @@ let
         description = ''
           The product ID of the mouse.
 
-          This can be found by looking at the Product attribute in the section in
-          /proc/bus/input/devices belonging to the mouse.
+          This can be found by looking at the `Product` attribute in the section in
+          the `/proc/bus/input/devices` path belonging to the mouse.
         '';
       };
       leftHanded = lib.mkOption {
@@ -275,7 +275,7 @@ let
         default = null;
         example = false;
         description = ''
-          Swap the left and right buttons.
+          Whether to swap the left and right buttons.
         '';
       };
       middleButtonEmulation = lib.mkOption {
@@ -283,7 +283,7 @@ let
         default = null;
         example = false;
         description = ''
-          Middle click by pressing the left and right buttons at the same time.
+          Whether to enable middle mouse click emulation by pressing the left and right buttons at the same time.
           Activating this increases the click latency by 50ms.
         '';
       };
@@ -292,7 +292,7 @@ let
         default = null;
         example = 0.5;
         description = ''
-          Mouse acceleration.
+          Set the mouse acceleration.
         '';
       };
       accelerationProfile = lib.mkOption {
@@ -304,7 +304,7 @@ let
           ]);
         default = null;
         example = "none";
-        description = "Mouse acceleration profile.";
+        description = "Set the mouse acceleration profile.";
         apply =
           profile:
           if profile == "none" then
@@ -319,7 +319,7 @@ let
         default = null;
         example = true;
         description = ''
-          Enables natural scrolling for the mouse.
+          Whether to enable natural scrolling for the mouse.
         '';
       };
       scrollSpeed = lib.mkOption {
@@ -327,7 +327,7 @@ let
         default = null;
         example = 1;
         description = ''
-          How fast the scroll wheel moves.
+          Configure how fast the scroll wheel moves.
         '';
       };
     };
@@ -444,7 +444,7 @@ in
       default = null;
       example = 200;
       description = ''
-        How many milliseconds you need to hold a key down before the input
+        Configure how many milliseconds a key must be held down for before the input
         starts repeating.
       '';
     };
@@ -453,7 +453,7 @@ in
       default = null;
       example = 50.0;
       description = ''
-        How quick the inputs should be repeated when holding down a key.
+        Configure how quickly the inputs should be repeated when holding down a key.
       '';
     };
     options = lib.mkOption {

--- a/modules/krunner.nix
+++ b/modules/krunner.nix
@@ -13,13 +13,13 @@ in
         ]);
       default = null;
       example = "center";
-      description = "Position of KRunner on screen.";
+      description = "Set KRunner's position on the screen.";
     };
     activateWhenTypingOnDesktop = lib.mkOption {
       type = with lib.types; nullOr bool;
       default = null;
       example = true;
-      description = "Activate KRunner when typing on the desktop.";
+      description = "Whether to activate KRunner when typing on the desktop.";
     };
     historyBehavior = lib.mkOption {
       type =
@@ -31,7 +31,7 @@ in
         ]);
       default = null;
       example = "disabled";
-      description = "Behavior of KRunner’s history.";
+      description = "Set the behavior of KRunner’s history.";
     };
   };
 

--- a/modules/kscreenlocker.nix
+++ b/modules/kscreenlocker.nix
@@ -13,7 +13,7 @@ in
       default = null;
       example = true;
       description = ''
-        Sets whether the screen will be locked after the specified time.
+        Whether the screen will be locked after the specified time.
       '';
     };
     lockOnResume = lib.mkOption {
@@ -30,7 +30,7 @@ in
       default = null;
       example = 5;
       description = ''
-        Sets the minutes after which the screen is locked.
+        Sets the timeout in minutes after which the screen will be locked.
       '';
     };
 
@@ -39,7 +39,7 @@ in
       default = null;
       example = true;
       description = ''
-        Whether the password is required to unlock the screen.
+        Whether the user password is required to unlock the screen.
       '';
     };
 
@@ -59,7 +59,7 @@ in
       description = ''
         Whether to lock the screen on startup.
 
-        NOTE: This option is not provided in the system settings.
+        **Note:** This option is not provided in the System Settings app.
       '';
     };
 
@@ -86,7 +86,7 @@ in
         default = null;
         example = lib.literalExpression ''"''${pkgs.kdePackages.plasma-workspace-wallpapers}/share/wallpapers/Kay/contents/images/1080x1920.png"'';
         description = ''
-          The wallpaper for the lockscreen. Can be either be the path to an image file or a kpackage.
+          The wallpaper for the lockscreen. Can be either the path to an image file or a KPackage.
         '';
       };
       wallpaperPictureOfTheDay = lib.mkOption {
@@ -96,7 +96,7 @@ in
           provider = "apod";
         };
         description = ''
-          Allows you to set wallpaper using the picture of the day plugin. Needs the provider.
+          Which plugin to fetch the Picture of the Day from.
         '';
       };
       wallpaperSlideShow = lib.mkOption {
@@ -104,8 +104,8 @@ in
         default = null;
         example = lib.literalExpression ''{ path = "''${pkgs.kdePackages.plasma-workspace-wallpapers}/share/wallpapers/"; }'';
         description = ''
-          Allows you to set wallpaper using the slideshow plugin. Needs the path
-          to at least one directory.
+          Allows you to set the wallpaper using the slideshow plugin. Needs the path
+          to at least one directory with wallpaper images.
         '';
       };
       wallpaperPlainColor = lib.mkOption {
@@ -113,7 +113,7 @@ in
         default = null;
         example = "0,64,174,256";
         description = ''
-          Allows you to set wallpaper using a plain color. Color is a comma-seperated R,G,B,A string. Alpha optional (default is 256).
+          Set the wallpaper using a plain color. Color is a comma-seperated R,G,B,A string. The alpha is optional (default is 256).
         '';
       };
     };

--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -73,7 +73,7 @@ let
     else
       lib.lists.findFirstIndex (
         x: x == value
-      ) (throw "getIndexFromEnum (kwin): Value ${value} isn't present in the enum. This is a bug") enum;
+      ) (throw "getIndexFromEnum (kwin): Value ${value} isn't present in the enum. This is a bug.") enum;
 
   convertPoloniumFilter = list: if list == null then null else builtins.concatStringsSep ", " list;
 
@@ -81,7 +81,7 @@ let
     options = {
       id = lib.mkOption {
         type = lib.types.str;
-        description = "The id of the layout.";
+        description = "The ID of the layout.";
         example = "cf5c25c2-4217-4193-add6-b5971cb543f2";
       };
       tiles = lib.mkOption {
@@ -161,7 +161,7 @@ in
       translucency.enable = lib.mkOption {
         type = with lib.types; nullOr bool;
         default = null;
-        description = "Make windows translucent under different conditions.";
+        description = "Make windows translucent under certain conditions.";
       };
       minimization = {
         animation = lib.mkOption {
@@ -174,7 +174,7 @@ in
             ]);
           default = null;
           example = "magiclamp";
-          description = "The effect when windows are minimized.";
+          description = "The effect to be displayed when windows are minimized.";
         };
         duration = lib.mkOption {
           type = with lib.types; nullOr ints.positive;
@@ -182,7 +182,7 @@ in
           example = 50;
           description = ''
             The duration of the minimization effect in milliseconds. Only
-            available when the minimization effect is magic lamp.
+            available when the minimization effect is `magiclamp`.
           '';
         };
       };
@@ -194,7 +194,7 @@ in
       fps.enable = lib.mkOption {
         type = with lib.types; nullOr bool;
         default = null;
-        description = "Display KWin's fps in the corner of the screen;";
+        description = "Display KWin's FPS performance graph in the corner of the screen.";
       };
       cube.enable = lib.mkOption {
         type = with lib.types; nullOr bool;
@@ -211,7 +211,7 @@ in
           ]);
         default = null;
         example = "fade";
-        description = "The animation used when switching virtual desktop.";
+        description = "The animation used when switching through virtual desktops.";
       };
       windowOpenClose = {
         animation = lib.mkOption {
@@ -231,7 +231,7 @@ in
       fallApart.enable = lib.mkOption {
         type = with lib.types; nullOr bool;
         default = null;
-        description = "Closed windows fall into pieces.";
+        description = "Whether to make closed windows break into pieces.";
       };
       blur = {
         enable = lib.mkOption {
@@ -243,13 +243,13 @@ in
           type = with lib.types; nullOr (ints.between 1 15);
           default = null;
           example = 5;
-          description = "Controls the intensity of the blur";
+          description = "Controls the intensity of the blur.";
         };
         noiseStrength = lib.mkOption {
           type = with lib.types; nullOr (ints.between 0 14);
           default = null;
           example = 8;
-          description = "Adds noise to the effect";
+          description = "Adds noise to the blur effect.";
         };
       };
       snapHelper.enable = lib.mkOption {
@@ -265,7 +265,7 @@ in
       dimAdminMode.enable = lib.mkOption {
         type = with lib.types; nullOr bool;
         default = null;
-        description = "Darken the entire when when requesting root privileges.";
+        description = "Darken the entire screen, except for the PolKit window, when requesting `root` privileges.";
       };
       slideBack.enable = lib.mkOption {
         type = with lib.types; nullOr bool;
@@ -300,9 +300,9 @@ in
         default = null;
         example = 8;
         description = ''
-          The amount of virtual desktops. If the names attribute is set as
-          well the number of desktops must be the same as the length of the
-          names list.
+          The amount of virtual desktops. If the `names` attribute is set as
+          well, then the number of desktops must be the same as the length of the
+          `names` list.
         '';
       };
     };
@@ -311,7 +311,7 @@ in
       type = with lib.types; nullOr bool;
       default = null;
       example = true;
-      description = "Maximized windows will not have a border.";
+      description = "Whether to remove the border of maximized windows.";
     };
 
     nightLight = {
@@ -331,7 +331,13 @@ in
           ]);
         default = null;
         example = "times";
-        description = "The mode of the night light effect.";
+        description = ''
+          When to enable the night light effect.
+
+          - `constant` enables it unconditonally.
+          - `location` uses coordinates to figure out the sunset/sunrise times for your location.
+          - `times` allows you to set the times for enabling and disabling night light.
+        '';
         apply = mode: if mode == null then null else capitalizeWord mode;
       };
       location = {
@@ -392,7 +398,7 @@ in
       example = 50;
       description = ''
         Additional distance the cursor needs to travel to cross screen edges. To
-        disable edge-barriers, set this to 0.
+        disable edge barriers, set this to `0`.
       '';
     };
 
@@ -439,7 +445,7 @@ in
           type = with lib.types; nullOr bool;
           default = null;
           example = true;
-          description = "Whether to enable Polonium";
+          description = "Whether to enable Polonium.";
         };
         settings = {
           borderVisibility =
@@ -455,20 +461,20 @@ in
               type = with lib.types; nullOr (enum enumVals);
               default = null;
               example = "noBorderAll";
-              description = "The border visibility setting for Polonium";
+              description = "The border visibility setting for Polonium.";
               apply = getIndexFromEnum enumVals;
             };
           callbackDelay = lib.mkOption {
             type = with lib.types; nullOr (ints.between 1 200);
             default = null;
             example = 100;
-            description = "The callback delay setting for Polonium";
+            description = "The callback delay setting for Polonium.";
           };
           enableDebug = lib.mkOption {
             type = with lib.types; nullOr bool;
             default = null;
             example = true;
-            description = "Whether to enable debug for Polonium";
+            description = "Whether to enable debug mode for Polonium.";
           };
           filter = {
             processes = lib.mkOption {
@@ -478,7 +484,7 @@ in
                 "firefox"
                 "chromium"
               ];
-              description = "The processes to filter for Polonium";
+              description = "The processes to filter for Polonium.";
               apply = convertPoloniumFilter;
             };
             windowTitles = lib.mkOption {
@@ -488,7 +494,7 @@ in
                 "Discord"
                 "Telegram"
               ];
-              description = "The window titles to filter for Polonium";
+              description = "The window titles to filter for Polonium.";
               apply = convertPoloniumFilter;
             };
           };
@@ -507,7 +513,7 @@ in
                 type = with lib.types; nullOr (enum enumVals);
                 default = null;
                 example = "binaryTree";
-                description = "The layout engine setting for Polonium";
+                description = "The layout engine setting for Polonium.";
                 apply = getIndexFromEnum enumVals;
               };
             insertionPoint =
@@ -522,39 +528,39 @@ in
                 type = with lib.types; nullOr (enum enumVals);
                 default = null;
                 example = "top";
-                description = "The insertion point setting for Polonium";
+                description = "The insertion point setting for Polonium.";
                 apply = getIndexFromEnum enumVals;
               };
             rotate = lib.mkOption {
               type = with lib.types; nullOr bool;
               default = null;
               example = true;
-              description = "Whether to rotate layout for Polonium";
+              description = "Whether to rotate the layout for Polonium.";
             };
           };
           maximizeSingleWindow = lib.mkOption {
             type = with lib.types; nullOr bool;
             default = null;
             example = true;
-            description = "Whether to maximize single window for Polonium";
+            description = "Whether to maximize a single window for Polonium.";
           };
           resizeAmount = lib.mkOption {
             type = with lib.types; nullOr (ints.between 1 450);
             default = null;
             example = 100;
-            description = "The resize amount setting for Polonium";
+            description = "The resize amount setting for Polonium.";
           };
           saveOnTileEdit = lib.mkOption {
             type = with lib.types; nullOr bool;
             default = null;
             example = true;
-            description = "Whether to save on tile edit for Polonium";
+            description = "Whether to save on tile edit for Polonium.";
           };
           tilePopups = lib.mkOption {
             type = with lib.types; nullOr bool;
             default = null;
             example = true;
-            description = "Whether to tile popups for Polonium";
+            description = "Whether to tile popups for Polonium.";
           };
         };
       };

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -133,9 +133,9 @@ let
           default = null;
           example = "autohide";
           description = ''
-            The hiding mode of the panel. Here windowscover and windowsbelow are
-            plasma 5 only, while dodgewindows, windowsgobelow and normalpanel are
-            plasma 6 only.
+            The hiding mode of the panel. Here, `windowscover` and `windowsbelow` are
+            Plasma 5-only, while `dodgewindows`, `windowsgobelow` and `normalpanel` are
+            Plasma 6-only.
           '';
         };
         floating = lib.mkEnableOption "Enable or disable floating style.";
@@ -158,10 +158,10 @@ let
           ];
           description = ''
             The widgets to use in the panel. To get the names, it may be useful
-            to look in the share/plasma/plasmoids folder of the nix-package the
-            widget/plasmoid is from. Some packages which include some
-            widgets/plasmoids are for example plasma-desktop and
-            plasma-workspace.
+            to look in the `share/plasma/plasmoids` subdirectory in the Nix Store path the
+            widget/plasmoid is sourced from. Some packages which include some
+            widgets/plasmoids are, for example, `plasma-desktop` and
+            `plasma-workspace`.
           '';
           apply = map widgets.convert;
         };
@@ -175,9 +175,9 @@ let
             ]);
           default = null;
           description = ''
-            The screen the panel should appear on. Can be an int, or a list of ints,
-            starting from 0, representing the ID of the screen the panel should
-            appear on. Alternatively it can be set to "all" if the panel should
+            The screen the panel should appear on. Can be an `int`, or a `list of ints`,
+            starting from `0`, representing the ID of the screen the panel should
+            appear on. Alternatively, it can be set to `all` if the panel should
             appear on all the screens.
           '';
         };
@@ -185,8 +185,8 @@ let
           type = with lib.types; nullOr str;
           default = null;
           description = ''
-            Extra lines to add to the layout.js. See
-            https://develop.kde.org/docs/plasma/scripting/ for inspiration.
+            Extra lines to add to the `layout.js`. See
+            the [KDE Documentation](https://develop.kde.org/docs/plasma/scripting) for information.
           '';
         };
       };

--- a/modules/powerdevil.nix
+++ b/modules/powerdevil.nix
@@ -71,7 +71,7 @@ let
         default = null;
         example = 600;
         description = ''
-          The duration (in seconds), when on ${type}, the computer must be idle
+          The duration (in seconds), when on ${type}, the computer must be idle for
           until the auto-suspend action is executed.
         '';
       };
@@ -108,8 +108,8 @@ let
         default = null;
         example = 300;
         description = ''
-          The duration (in seconds), when on ${type}, the computer must be idle
-          (when unlocked) until the display turns off.
+          The duration (in seconds), when on ${type}, the computer, when unlocked, must be idle for
+          until the display turns off.
         '';
         apply =
           timeout:
@@ -152,7 +152,7 @@ let
         type = with lib.types; nullOr bool;
         default = null;
         example = false;
-        description = "Enable or disable screen dimming.";
+        description = "Whether to enable screen dimming.";
       };
       idleTimeout = lib.mkOption {
         type = with lib.types; nullOr (ints.between 20 600000);
@@ -169,7 +169,7 @@ let
       default = null;
       example = 10;
       description = ''
-        The brightness to set the display to in this mode
+        The brightness to set the display to in this mode.
       '';
     };
     powerProfile = lib.mkOption {
@@ -183,7 +183,7 @@ let
       default = null;
       example = "powerSaving";
       description = ''
-        The Power Profile to Enter in this mode
+        The Power Profile to enter in this mode.
       '';
       apply = profile: if profile == "powerSaving" then "power-saver" else profile;
     };
@@ -329,7 +329,7 @@ in
           default = null;
           example = 10;
           description = ''
-            The battery level considered "low" for the laptop
+            The battery level considered "low" for the laptop.
           '';
         };
         criticalLevel = lib.mkOption {
@@ -337,7 +337,7 @@ in
           default = null;
           example = 2;
           description = ''
-            The battery level considered "critical" for the laptop
+            The battery level considered "critical" for the laptop.
           '';
         };
         criticalAction = lib.mkOption {
@@ -345,7 +345,7 @@ in
           default = null;
           example = "shutDown";
           description = ''
-            The action to perform when Critical Battery Level is reached
+            The action to perform when Critical Battery Level is reached.
           '';
           apply = action: if (action == null) then null else autoCriticalActions."${action}";
         };

--- a/modules/startup.nix
+++ b/modules/startup.nix
@@ -7,7 +7,7 @@ let
 
   textOption = lib.mkOption {
     type = lib.types.str;
-    description = "The content of the startup-script.";
+    description = "The content of the startup script.";
   };
   priorityOption = lib.mkOption {
     type = (lib.types.ints.between 0 8);
@@ -113,7 +113,7 @@ in
       default = { };
       description = ''
         Plasma desktop scripts to be run exactly once at startup. See
-        https://develop.kde.org/docs/plasma/scripting/ for details on plasma
+        the [KDE Documentation](https://develop.kde.org/docs/plasma/scripting) for details on Plasma
         desktop scripts.
       '';
     };

--- a/modules/window-rules.nix
+++ b/modules/window-rules.nix
@@ -78,12 +78,12 @@ let
     options = {
       value = mkOption {
         type = basicValueType;
-        description = "value to set";
+        description = "Value to set.";
       };
       apply = mkOption {
         type = enum (attrNames applyRules);
         default = "initially";
-        description = "how to apply the value";
+        description = "How to apply the value.";
       };
     };
   };
@@ -92,7 +92,7 @@ let
     mkOption {
       type = nullOr (coercedTo str (value: { inherit value; }) (matchOptionType hasMatchWhole));
       default = null;
-      description = "${name} matching";
+      description = "${name} matching.";
     };
   fixMatchName = name: matchNameMap.${name} or name;
   buildMatchRule =
@@ -143,7 +143,7 @@ in
                 window-types = mkOption {
                   type = listOf (enum (attrNames windowTypes));
                   default = [ ];
-                  description = "Window types to match";
+                  description = "Window types to match.";
                   apply = values: foldl' add 0 (map (val: getAttr val windowTypes) values);
                 };
               };
@@ -152,15 +152,15 @@ in
           apply = mkOption {
             type = attrsOf (coercedTo basicValueType (value: { inherit value; }) applyOptionType);
             default = { };
-            description = "Values to apply";
+            description = "Values to apply.";
           };
           description = mkOption {
             type = str;
-            description = "value to set";
+            description = "Value to set.";
           };
         };
       });
-      description = "Kwin window rules";
+      description = "KWin window rules.";
       default = [ ];
     };
   };

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -23,13 +23,13 @@ let
           type = nullOr str;
           default = null;
           example = "Breeze_Snow";
-          description = "The Plasma cursortheme. Run plasma-apply-cursortheme --list-themes for valid options.";
+          description = "The Plasma cursor theme. Run `plasma-apply-cursortheme --list-themes` for valid options.";
         };
         size = lib.mkOption {
           type = nullOr ints.positive;
           default = null;
           example = 24;
-          description = "The size of the cursor. See the settings GUI for allowed sizes for each cursortheme.";
+          description = "The size of the cursor. See the System Settings app for allowed sizes for each cursor theme.";
         };
       };
     };
@@ -73,7 +73,7 @@ in
         ]);
       default = null;
       description = ''
-        Clicking files or folders should open or select them.
+        Whether clicking files or folders should open or select them.
       '';
     };
 
@@ -82,7 +82,7 @@ in
       default = null;
       example = false;
       description = ''
-        Clicking the middle mouse button pastes clipboard content";
+        Whether clicking the middle mouse button pastes the clipboard content.";
       '';
     };
 
@@ -100,7 +100,7 @@ in
       default = null;
       example = "breeze-dark";
       description = ''
-        The Plasma theme. Run plasma-apply-desktoptheme --list-themes for valid options.
+        The Plasma style. Run `plasma-apply-desktoptheme --list-themes` for valid options.
       '';
     };
 
@@ -109,7 +109,7 @@ in
       default = null;
       example = "BreezeDark";
       description = ''
-        The Plasma colorscheme. Run plasma-apply-colorscheme --list-schemes for valid options.
+        The Plasma color scheme. Run `plasma-apply-colorscheme --list-schemes` for valid options.
       '';
     };
 
@@ -121,7 +121,7 @@ in
         size = 24;
       };
       description = ''
-        Allows to configure the cursor in plasma. Both the theme and size are configurable.
+        Submodule for configuring the cursor appearance. Both the theme and size are configurable.
       '';
     };
 
@@ -130,7 +130,7 @@ in
       default = null;
       example = "org.kde.breezedark.desktop";
       description = ''
-        The Plasma look and feel theme. Run plasma-apply-lookandfeel --list for valid options.
+        The Plasma Global Theme. Run `plasma-apply-lookandfeel --list` for valid options.
       '';
     };
 
@@ -148,7 +148,7 @@ in
       default = null;
       example = lib.literalExpression ''"''${pkgs.kdePackages.plasma-workspace-wallpapers}/share/wallpapers/Kay/contents/images/1080x1920.png"'';
       description = ''
-        The Plasma wallpaper. Can be either be the path to an image file or a kpackage.
+        The Plasma desktop wallpaper. Can be either the path to an image file or a KPackage.
       '';
     };
 
@@ -157,7 +157,7 @@ in
       default = null;
       example = lib.literalExpression ''{ path = "''${pkgs.kdePackages.plasma-workspace-wallpapers}/share/wallpapers/"; }'';
       description = ''
-        Allows you to set wallpaper slideshow. Needs a directory of your wallpapers and an interval length.
+        Submodule for configuring the wallpaper slideshow. Needs a directory with wallpapers and an interval length.
       '';
     };
 
@@ -168,7 +168,7 @@ in
         provider = "apod";
       };
       description = ''
-        Allows you to set wallpaper using the picture of the day plugin. Needs the provider.
+        Which plugin to fetch the Picture of the Day from.
       '';
     };
 
@@ -177,7 +177,7 @@ in
       default = null;
       example = "0,64,174,256";
       description = ''
-        Allows you to set wallpaper using a plain color. Color is a comma-seperated R,G,B,A string. Alpha optional (default is 256).
+        Set the wallpaper using a plain color. Color is a comma-seperated R,G,B,A string. The alpha is optional (default is 256).
       '';
     };
 
@@ -187,7 +187,7 @@ in
       example = "stretch";
       description = ''
         Defines how the wallpaper should be displayed on the screen.
-        Applies only to wallpaper, wallpaperPictureOfTheDay or wallpaperSlideShow.
+        Applies only to `wallpaper`, `wallpaperPictureOfTheDay` or `wallpaperSlideShow`.
       '';
     };
 
@@ -196,7 +196,7 @@ in
       default = null;
       example = "freedesktop";
       description = ''
-        The sound-theme to use with plasma.
+        The sound theme to use with Plasma.
       '';
     };
 
@@ -206,9 +206,9 @@ in
         default = null;
         example = "none";
         description = ''
-          The engine for the splash-screen theme. If not specified it will try
-          to set an appropriate engine for you, but if this doesn't work you
-          might want to manually specify this.
+          The engine for the splash screen theme. If not specified, Plasma will try
+          to set an appropriate engine, but this may fail, in which case this option
+          should be specified manually.
         '';
       };
       theme = lib.mkOption {
@@ -216,9 +216,9 @@ in
         default = null;
         example = "None";
         description = ''
-          The splash-screen theme shown at login. To see available values see the
-          Theme key in ~/.config/ksplashrc after applying the splash-screen via
-          the settings app. Can also be set to "None" to disable the splash-screen
+          The splash screen theme shown at login. To view all available values, see the
+          `Theme` key in `$HOME/.config/ksplashrc` after imperatively applying the splash screen via
+          the System Settings app. Can also be set to `None` to disable the splash screen
           altogether.
         '';
       };
@@ -230,10 +230,10 @@ in
         default = null;
         example = "org.kde.kwin.aurorae";
         description = ''
-          The library for the window decorations theme. To see available values
-          see the library key in the org.kde.kdecoration2 section of
-          ~/.config/kwinrc after applying the window-decoration via the
-          settings app.
+          The library for the window decorations theme. To view all available values,
+          see the `library` key in the `org.kde.kdecoration2` section of
+          `$HOME/.config/kwinrc` after imperatively applying the window decoration via the
+          System Settings app.
         '';
       };
       theme = lib.mkOption {
@@ -241,9 +241,9 @@ in
         default = null;
         example = "__aurorae__svg__CatppuccinMocha-Modern";
         description = ''
-          The window decorations theme. To see available values see the theme key
-          in the org.kde.kdecoration2 section of ~/.config/kwinrc after
-          applying the window-decoration via the settings app.
+          The window decorations theme. To view all available values, see the `theme` key
+          in the `org.kde.kdecoration2` section of `$HOME/.config/kwinrc` after
+          imperatively applying the window decoration via the System Settings app.
         '';
       };
     };
@@ -293,9 +293,10 @@ in
           [
             ''
               Setting lookAndFeel together with splashScreen or windowDecorations in
-                      plasma-manager is not recommended since lookAndFeel themes often
-                      override these settings. Consider setting each part in the lookAndFeel
-                      theme manually.''
+              plasma-manager is not recommended since lookAndFeel themes often
+              override these settings. Consider setting each part in the lookAndFeel
+              theme manually.
+            ''
           ]
         else
           [ ]


### PR DESCRIPTION
Fixes typos, rewrites some options for clarity, and adds more `markdown` formatting tags to option descriptions.

Related: https://github.com/nix-community/plasma-manager/issues/399