### PR TITLE
fix(plasmusic-toolbar): remove unused preferredPlayerIdentity config to prevent error

### DIFF
--- a/modules/widgets/plasmusic-toolbar.nix
+++ b/modules/widgets/plasmusic-toolbar.nix
@@ -265,7 +265,6 @@ in
           else if source == "auto" then
             {
               choosePlayerAutomatically = true;
-              preferredPlayerIdentity = null;
             }
           else
             {


### PR DESCRIPTION
Removed `preferredPlayerIdentity` assignment from `plasmusic-toolbar` module to fix DBus error caused by an incomplete config parameter. The error occurred during the application of desktop scripts, generating an invalid config line in `preferredPlayerIdentity`.