### PR TITLE
fix(kwin): Standardize Virtual Desktop IDs in KDE Plasma for Consistent Window Rules Configuration

### DIFF
--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -56,6 +56,10 @@ let
     names:
     builtins.listToAttrs (lib.imap1 (i: v: (lib.nameValuePair "Name_${builtins.toString i}" v)) names);
 
+  virtualDesktopIdAttrs =
+    names:
+    builtins.listToAttrs (lib.imap1 (i: v: (lib.nameValuePair "Id_${builtins.toString i}" v)) names);
+
   capitalizeWord =
     word:
     let
@@ -712,6 +716,7 @@ in
           (lib.mkIf (cfg.kwin.virtualDesktops.names != null) {
             Desktops = lib.mkMerge [
               { Number = builtins.length cfg.kwin.virtualDesktops.names; }
+              (virtualDesktopIdAttrs cfg.kwin.virtualDesktops.names)
               (virtualDesktopNameAttrs cfg.kwin.virtualDesktops.names)
             ];
           })

--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -56,9 +56,10 @@ let
     names:
     builtins.listToAttrs (lib.imap1 (i: v: (lib.nameValuePair "Name_${builtins.toString i}" v)) names);
 
+
   virtualDesktopIdAttrs =
-    names:
-    builtins.listToAttrs (lib.imap1 (i: v: (lib.nameValuePair "Id_${builtins.toString i}" v)) names);
+    number:
+    builtins.listToAttrs (map (i: (lib.nameValuePair "Id_${builtins.toString i}" "Desktop_${builtins.toString i}")) (lib.range 1 number));
 
   capitalizeWord =
     word:
@@ -708,7 +709,10 @@ in
 
           # Virtual Desktops
           (lib.mkIf (cfg.kwin.virtualDesktops.number != null) {
-            Desktops.Number = cfg.kwin.virtualDesktops.number;
+            Desktops = lib.mkMerge [
+              { Number = cfg.kwin.virtualDesktops.number; }
+              (virtualDesktopIdAttrs cfg.kwin.virtualDesktops.number)
+            ];
           })
           (lib.mkIf (cfg.kwin.virtualDesktops.rows != null) {
             Desktops.Rows = cfg.kwin.virtualDesktops.rows;
@@ -716,7 +720,7 @@ in
           (lib.mkIf (cfg.kwin.virtualDesktops.names != null) {
             Desktops = lib.mkMerge [
               { Number = builtins.length cfg.kwin.virtualDesktops.names; }
-              (virtualDesktopIdAttrs cfg.kwin.virtualDesktops.names)
+              (virtualDesktopIdAttrs (builtins.length cfg.kwin.virtualDesktops.names))
               (virtualDesktopNameAttrs cfg.kwin.virtualDesktops.names)
             ];
           })


### PR DESCRIPTION
In KDE Plasma, virtual desktops are currently assigned unique IDs that are generated automatically and differ across systems and even builds. This random assignment causes issues when attempting to apply configuration rules that rely on specific desktop IDs. For instance, in the `windowRules` option, the attribute `apply.desktops` allows users to target specific virtual desktops by ID. If these IDs are random, configurations specifying particular desktops (such as assigning certain applications to designated desktops) will not work consistently across systems.

To ensure predictable and controlled behavior, it’s necessary to standardize these IDs so they follow a stable, easily-referenced naming scheme, such as `"Desktop_1"`, `"Desktop_2"`, …, `"Desktop_n"`—where `n` represents the total number of virtual desktops configured. By assigning consistent IDs, configurations in `windowRules` (such as the example shown below) can reliably apply to the intended desktops.

### Example Configuration
```nix
{
  description = "Virtual desktop for browsers";
  apply.desktops = "Desktop_1";  # Standardized ID for consistent reference
  match.window-class = {
    value = mkWmClassPattern appGroups.browsers;
    type = "regex";
  };
}
```

Here, `apply.desktops = "Desktop_1"` references a virtual desktop by a stable ID, ensuring that window rules consistently apply to the same desktop, even after system rebuilds. This approach would prevent configuration breakages and support more granular and stable control over window placements across virtual desktops.