### PR TITLE
Add explicit iconOnly option for the taskmanager

### DIFF
--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -240,7 +240,7 @@ in
         behavior,
         launchers,
         settings,
-        iconsOnly
+        iconsOnly,
         ...
       }:
       {

--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -78,6 +78,7 @@ in
         description = "The list of launcher tasks on the widget. Usually .desktop file or executable URLs. Special URLs such as preferred://browser that expand to default applications are supported.";
       };
       appearance = {
+        iconOnly = mkBoolOption "Wheter to show icons only.";
         showTooltips = mkBoolOption "Whether to show tooltips when hovering task buttons.";
         highlightWindows = mkBoolOption "Whether to request the window manager highlight windows when hovering corresponding task tooltips.";
         indicateAudioStreams = mkBoolOption "Whether to indicate applications that are playing audio including an option to mute them.";
@@ -237,7 +238,9 @@ in
         ...
       }:
       {
-        name = "org.kde.plasma.icontasks";
+        name = if appearance.iconOnly
+          then "org.kde.plasma.icontasks"
+          else "org.kde.plasma.taskmanager";
         config = lib.recursiveUpdate {
           General = lib.filterAttrs (_: v: v != null) {
             launchers = launchers;

--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -77,8 +77,13 @@ in
         ];
         description = "The list of launcher tasks on the widget. Usually .desktop file or executable URLs. Special URLs such as preferred://browser that expand to default applications are supported.";
       };
+      iconsOnly = mkOption {
+        type = types.bool;
+        default = true;
+        example = false;
+        description = "Whether to show icons only.";
+      };
       appearance = {
-        iconOnly = mkBoolOption "Wheter to show icons only.";
         showTooltips = mkBoolOption "Whether to show tooltips when hovering task buttons.";
         highlightWindows = mkBoolOption "Whether to request the window manager highlight windows when hovering corresponding task tooltips.";
         indicateAudioStreams = mkBoolOption "Whether to indicate applications that are playing audio including an option to mute them.";
@@ -235,10 +240,11 @@ in
         behavior,
         launchers,
         settings,
+        iconsOnly
         ...
       }:
       {
-        name = if appearance.iconOnly
+        name = if iconsOnly
           then "org.kde.plasma.icontasks"
           else "org.kde.plasma.taskmanager";
         config = lib.recursiveUpdate {


### PR DESCRIPTION
Hello,

I am looking for some guidance to implement an option enabling the Icons-and-Text task manager widget. At the moment, only the Icons task manager widget seems supported by this project.

I couldn't find any documentation on the matter, and this is my first Nix contribution. Looking at [this file](https://github.com/KDE/plasma-desktop/blob/3baa5b8/applets/taskmanager/package/contents/ui/ConfigAppearance.qml#L19), it seems that the icons-only mode is activated when package `org.kde.plasma.icontasks` is used in place of `org.kde.plasma.taskmanager`. However, I'd like to see some validation of the robustness of this approach.

Also, the `iconOnly` boolean may need to be inverted to keep the default behavior to icons-only mode.

I'm currently testing to see if all the options apply to `org.kde.plasma.taskmanager`.