### PR TITLE
Added tabBox config to kwin module

### DIFF
--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -439,6 +439,67 @@ in
       };
     };
 
+    tabBox = {
+      showTabBox = lib.mkOption {
+        type = with lib.types; nullOr bool;
+        default = null;
+        example = true;
+        description = "Whether to show the Task Switcher.";
+      };
+      layoutName =
+        let
+          enumVals = [
+            "sidebar"
+            "compact"
+            "coverswitch"
+            "flipswitch"
+            "big_icons"
+            "thumbnail_grid"
+          ];
+        in
+        lib.mkOption {
+          type = with lib.types; nullor (enum enumVals);
+          default = null;
+          example = "sidebar";
+          description = "The visualisation type of Task Switcher.";
+        };
+      sortOrder =
+        let
+          switchingModeId = {
+            recent = 0;
+            stacking = 1;
+          };
+        in
+        lib.mkOption {
+          type = with lib.types; nullOr (enum (builtins.attrNames switchingModeId));
+          default = null;
+          example = "recent";
+          description = "The sorting order of Task Switcher.";
+          apply = sortOrder: if (sortOrder == null) then null else switchingModeId.${sortOrder};
+        };
+      includeShowDesktop = lib.mkOption {
+        type = with lib.types; nullor bool;
+        default = null;
+        example = true;
+        description = "Include 'Show Desktop' entry in Task Switcher.";
+        apply = showDesktopMode: if showDesktopMode == true then 1 else null;
+      };
+      oneWindowPerApp = lib.mkOption {
+        type = with lib.types; nullor bool;
+        default = null;
+        example = true;
+        description = "Show only one window per application in Task Switcher.";
+        apply = applicationMode: if applicationMode == true then 1 else null;
+      };
+      minimisedFirst = lib.mkOption {
+        type = with lib.types; nullor bool;
+        default = null;
+        example = true;
+        description = "Order minimised windows after non-minimised ones in Task Switcher.";
+        apply = minimisedMode: if minimisedMode == true then 1 else null;
+      };
+    };
+
     scripts = {
       polonium = {
         enable = lib.mkOption {
@@ -763,6 +824,18 @@ in
               TilePopups = cfg.kwin.scripts.polonium.settings.tilePopups;
               TimerDelay = cfg.kwin.scripts.polonium.settings.callbackDelay;
             };
+          })
+          (lib.mkIf (cfg.kwin.tabBox.showTabBox != null) { TabBox.ShowTabBox = cfg.kwin.tabBox.showTabBox; })
+          (lib.mkIf (cfg.kwin.tabBox.layoutName != null) { TabBox.LayoutName = cfg.kwin.tabBox.layoutName; })
+          (lib.mkIf (cfg.kwin.tabBox.sortOrder != null) { TabBox.SwitchingMode = cfg.kwin.tabBox.sortOrder; })
+          (lib.mkIf (cfg.kwin.tabBox.includeShowDesktop != null) {
+            TabBox.ShowDesktopMode = cfg.kwin.tabBox.includeShowDesktop;
+          })
+          (lib.mkIf (cfg.kwin.tabBox.oneWindowPerApp != null) {
+            TabBox.ApplicationsMode = cfg.kwin.tabBox.oneWindowPerApp;
+          })
+          (lib.mkIf (cfg.kwin.tabBox.minimisedFirst != null) {
+            TabBox.OrderMinimizedMode = cfg.kwin.tabBox.minimisedFirst;
           })
 
           (lib.mkIf (cfg.kwin.tiling.padding != null) {

--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -458,7 +458,7 @@ in
           ];
         in
         lib.mkOption {
-          type = with lib.types; nullor (enum enumVals);
+          type = with lib.types; nullOr (enum enumVals);
           default = null;
           example = "sidebar";
           description = "The visualisation type of Task Switcher.";
@@ -478,21 +478,21 @@ in
           apply = sortOrder: if (sortOrder == null) then null else switchingModeId.${sortOrder};
         };
       includeShowDesktop = lib.mkOption {
-        type = with lib.types; nullor bool;
+        type = with lib.types; nullOr bool;
         default = null;
         example = true;
         description = "Include 'Show Desktop' entry in Task Switcher.";
         apply = showDesktopMode: if showDesktopMode == true then 1 else null;
       };
       oneWindowPerApp = lib.mkOption {
-        type = with lib.types; nullor bool;
+        type = with lib.types; nullOr bool;
         default = null;
         example = true;
         description = "Show only one window per application in Task Switcher.";
         apply = applicationMode: if applicationMode == true then 1 else null;
       };
       minimisedFirst = lib.mkOption {
-        type = with lib.types; nullor bool;
+        type = with lib.types; nullOr bool;
         default = null;
         example = true;
         description = "Order minimised windows after non-minimised ones in Task Switcher.";


### PR DESCRIPTION
Hello, I've just started using this and noticed a few missing options for configuring how the Task Switcher behaves.

I had some uncertainty around naming the configuration options and ran into a couple of issues with handling options that use 0/1 values (to represent different modes) instead of simple true/false booleans.

Just to explain my thought process behind handling `includeShowDesktop` and `sortMode` differently, I think that it is more likely that a new Sorting order would be added than they add more ShowDesktopModes.

Looking forward to any feedback and suggestions on how to improve the clarity and usability of these configuration options.