### PR TITLE
fix: update deprecated substituteInPlace syntax

### DIFF
--- a/docs/plasma-manager-options.nix
+++ b/docs/plasma-manager-options.nix
@@ -28,12 +28,12 @@ stdenv.mkDerivation {
     cp ${./static/style.css} out/style.css
 
     substituteInPlace options.md \
-      --replace \
+      --replace-fail \
       '@OPTIONS_JSON@' \
       ${plasma-manager-options}/share/doc/nixos/options.json
 
     substituteInPlace manual.md \
-      --replace \
+      --replace-fail \
       '@VERSION@' \
       ${revision}
 


### PR DESCRIPTION
- Change `--replace` to `--replace-fail` in plasma-manager-options.nix
- Update both `options.md` and `manual.md` substitutions
- Maintain same substitution behavior but use supported syntax

This removes usage of deprecated `substituteInPlace --replace` flag.