### PR TITLE
feat(workspace): add `wallpaperBackground` support for `wallpaper`

### DIFF
--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -453,7 +453,7 @@ in
               for (const desktop of allDesktops) {
                   desktop.wallpaperPlugin = "org.kde.image";
                   desktop.currentConfigGroup = ["Wallpaper", "org.kde.image", "General"];
-                  desktop.writeConfig("Image", "file://${cfg.workspace.wallpaper}");
+                  desktop.writeConfig("Image", "file://${toString cfg.workspace.wallpaper}");
                   ${
                     lib.optionalString (cfg.workspace.wallpaperFillMode != null)
                       ''desktop.writeConfig("FillMode", "${

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -466,7 +466,7 @@ in
                         if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           "Blur"
                         else if
-                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.blur != null
+                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
                         then
                           "Color"
                         else
@@ -512,7 +512,7 @@ in
                         if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           "Blur"
                         else if
-                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.blur != null
+                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
                         then
                           "Color"
                         else
@@ -579,7 +579,7 @@ in
                         if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           "Blur"
                         else if
-                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.blur != null
+                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
                         then
                           "Color"
                         else

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -464,12 +464,9 @@ in
                     lib.optionalString
                       (cfg.workspace.wallpaperBackground != null || cfg.workspace.wallpaperBackground != { })
                       ''desktop.writeConfig("${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
-                          "Blur"
-                        else
-                          "Color"
+                        if cfg.workspace.wallpaperBackground.blur != null then "Blur" else "Color"
                       }", "${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground.blur != null then
                           lib.boolToString cfg.workspace.wallpaperBackground.blur
                         else
                           cfg.workspace.wallpaperBackground.color
@@ -503,12 +500,9 @@ in
                     lib.optionalString
                       (cfg.workspace.wallpaperBackground != null || cfg.workspace.wallpaperBackground != { })
                       ''desktop.writeConfig("${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
-                          "Blur"
-                        else
-                          "Color"
+                        if cfg.workspace.wallpaperBackground.blur != null then "Blur" else "Color"
                       }", "${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground.blur != null then
                           lib.boolToString cfg.workspace.wallpaperBackground.blur
                         else
                           cfg.workspace.wallpaperBackground.color
@@ -563,12 +557,9 @@ in
                     lib.optionalString
                       (cfg.workspace.wallpaperBackground != null || cfg.workspace.wallpaperBackground != { })
                       ''desktop.writeConfig("${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
-                          "Blur"
-                        else
-                          "Color"
+                        if cfg.workspace.wallpaperBackground.blur != null then "Blur" else "Color"
                       }", "${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground.blur != null then
                           lib.boolToString cfg.workspace.wallpaperBackground.blur
                         else
                           cfg.workspace.wallpaperBackground.color

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -463,16 +463,20 @@ in
                   ${
                     lib.optionalString (cfg.workspace.wallpaperBackground != null)
                       ''desktop.writeConfig("${
-                        if cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           "Blur"
-                        else if cfg.workspace.wallpaperBackground.blur != null then
+                        else if
+                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.blur != null
+                        then
                           "Color"
                         else
                           throw "plasma-manager: wallpaperBackground is not null and has no option set"
                       }", "${
-                        if cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           lib.boolToString cfg.workspace.wallpaperBackground.blur
-                        else if cfg.workspace.wallpaperBackground.color != null then
+                        else if
+                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
+                        then
                           cfg.workspace.wallpaperBackground.color
                         else
                           throw "plasma-manager: wallpaperBackground is not null and has no option set"
@@ -505,16 +509,20 @@ in
                   ${
                     lib.optionalString (cfg.workspace.wallpaperBackground != null)
                       ''desktop.writeConfig("${
-                        if cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           "Blur"
-                        else if cfg.workspace.wallpaperBackground.blur != null then
+                        else if
+                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.blur != null
+                        then
                           "Color"
                         else
                           throw "plasma-manager: wallpaperBackground is not null and has no option set"
                       }", "${
-                        if cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           lib.boolToString cfg.workspace.wallpaperBackground.blur
-                        else if cfg.workspace.wallpaperBackground.color != null then
+                        else if
+                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
+                        then
                           cfg.workspace.wallpaperBackground.color
                         else
                           throw "plasma-manager: wallpaperBackground is not null and has no option set"
@@ -568,16 +576,20 @@ in
                   ${
                     lib.optionalString (cfg.workspace.wallpaperBackground != null)
                       ''desktop.writeConfig("${
-                        if cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           "Blur"
-                        else if cfg.workspace.wallpaperBackground.blur != null then
+                        else if
+                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.blur != null
+                        then
                           "Color"
                         else
                           throw "plasma-manager: wallpaperBackground is not null and has no option set"
                       }", "${
-                        if cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           lib.boolToString cfg.workspace.wallpaperBackground.blur
-                        else if cfg.workspace.wallpaperBackground.color != null then
+                        else if
+                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
+                        then
                           cfg.workspace.wallpaperBackground.color
                         else
                           throw "plasma-manager: wallpaperBackground is not null and has no option set"

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -448,17 +448,33 @@ in
 
         desktopScript."wallpaper_picture" = (
           lib.mkIf (cfg.workspace.wallpaper != null) {
-            # We just put this here as we need this script to be a desktop-script in
-            # order to link it together with the other desktop-script (namely
-            # panels). Adding a comment with the wallpaper makes it so that when the
-            # wallpaper changes, the sha256sum also changes for the js file, which
-            # gives us the correct behavior with last_run files.
-            text = "// Wallpaper to set later: ${cfg.workspace.wallpaper}";
-            postCommands = ''
-              plasma-apply-wallpaperimage ${cfg.workspace.wallpaper} ${
-                lib.optionalString (
-                  cfg.workspace.wallpaperFillMode != null
-                ) "--fill-mode ${cfg.workspace.wallpaperFillMode}"
+            text = ''
+              let allDesktops = desktops();
+              for (const desktop of allDesktops) {
+                  desktop.wallpaperPlugin = "org.kde.image";
+                  desktop.currentConfigGroup = ["Wallpaper", "org.kde.image", "General"];
+                  desktop.writeConfig("Image", "file://${cfg.workspace.wallpaper}");
+                  ${
+                    lib.optionalString (cfg.workspace.wallpaperFillMode != null)
+                      ''desktop.writeConfig("FillMode", "${
+                        toString wallpaperFillModeTypes.${cfg.workspace.wallpaperFillMode}
+                      }");''
+                  }
+                  ${
+                    lib.optionalString
+                      (cfg.workspace.wallpaperBackground != null || cfg.workspace.wallpaperBackground != { })
+                      ''desktop.writeConfig("${
+                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                          "Blur"
+                        else
+                          "Color"
+                      }", "${
+                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                          lib.boolToString cfg.workspace.wallpaperBackground.blur
+                        else
+                          cfg.workspace.wallpaperBackground.color
+                      }");''
+                  }
               }
             '';
             priority = 3;

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -461,18 +461,25 @@ in
                       }");''
                   }
                   ${
-                    lib.optionalString
-                      (cfg.workspace.wallpaperBackground != null || cfg.workspace.wallpaperBackground != { })
+                    lib.optionalString (cfg.workspace.wallpaperBackground != null)
                       ''desktop.writeConfig("${
                         if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           "Blur"
-                        else
+                        else if
+                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.blur != null
+                        then
                           "Color"
+                        else
+                          throw "plasma-manager: wallpaperBackground is not null and has no option set"
                       }", "${
                         if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           lib.boolToString cfg.workspace.wallpaperBackground.blur
-                        else
+                        else if
+                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
+                        then
                           cfg.workspace.wallpaperBackground.color
+                        else
+                          throw "plasma-manager: wallpaperBackground is not null and has no option set"
                       }");''
                   }
               }
@@ -500,18 +507,25 @@ in
                       }");''
                   }
                   ${
-                    lib.optionalString
-                      (cfg.workspace.wallpaperBackground != null || cfg.workspace.wallpaperBackground != { })
+                    lib.optionalString (cfg.workspace.wallpaperBackground != null)
                       ''desktop.writeConfig("${
                         if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           "Blur"
-                        else
+                        else if
+                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.blur != null
+                        then
                           "Color"
+                        else
+                          throw "plasma-manager: wallpaperBackground is not null and has no option set"
                       }", "${
                         if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           lib.boolToString cfg.workspace.wallpaperBackground.blur
-                        else
+                        else if
+                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
+                        then
                           cfg.workspace.wallpaperBackground.color
+                        else
+                          throw "plasma-manager: wallpaperBackground is not null and has no option set"
                       }");''
                   }
               }
@@ -560,18 +574,25 @@ in
                       }");''
                   }
                   ${
-                    lib.optionalString
-                      (cfg.workspace.wallpaperBackground != null || cfg.workspace.wallpaperBackground != { })
+                    lib.optionalString (cfg.workspace.wallpaperBackground != null)
                       ''desktop.writeConfig("${
                         if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           "Blur"
-                        else
+                        else if
+                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.blur != null
+                        then
                           "Color"
+                        else
+                          throw "plasma-manager: wallpaperBackground is not null and has no option set"
                       }", "${
                         if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           lib.boolToString cfg.workspace.wallpaperBackground.blur
-                        else
+                        else if
+                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
+                        then
                           cfg.workspace.wallpaperBackground.color
+                        else
+                          throw "plasma-manager: wallpaperBackground is not null and has no option set"
                       }");''
                   }
               }

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -464,9 +464,12 @@ in
                     lib.optionalString
                       (cfg.workspace.wallpaperBackground != null || cfg.workspace.wallpaperBackground != { })
                       ''desktop.writeConfig("${
-                        if cfg.workspace.wallpaperBackground.blur != null then "Blur" else "Color"
+                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                          "Blur"
+                        else
+                          "Color"
                       }", "${
-                        if cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           lib.boolToString cfg.workspace.wallpaperBackground.blur
                         else
                           cfg.workspace.wallpaperBackground.color
@@ -500,9 +503,12 @@ in
                     lib.optionalString
                       (cfg.workspace.wallpaperBackground != null || cfg.workspace.wallpaperBackground != { })
                       ''desktop.writeConfig("${
-                        if cfg.workspace.wallpaperBackground.blur != null then "Blur" else "Color"
+                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                          "Blur"
+                        else
+                          "Color"
                       }", "${
-                        if cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           lib.boolToString cfg.workspace.wallpaperBackground.blur
                         else
                           cfg.workspace.wallpaperBackground.color
@@ -557,9 +563,12 @@ in
                     lib.optionalString
                       (cfg.workspace.wallpaperBackground != null || cfg.workspace.wallpaperBackground != { })
                       ''desktop.writeConfig("${
-                        if cfg.workspace.wallpaperBackground.blur != null then "Blur" else "Color"
+                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                          "Blur"
+                        else
+                          "Color"
                       }", "${
-                        if cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
                           lib.boolToString cfg.workspace.wallpaperBackground.blur
                         else
                           cfg.workspace.wallpaperBackground.color

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -463,20 +463,16 @@ in
                   ${
                     lib.optionalString (cfg.workspace.wallpaperBackground != null)
                       ''desktop.writeConfig("${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground.blur != null then
                           "Blur"
-                        else if
-                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.blur != null
-                        then
+                        else if cfg.workspace.wallpaperBackground.blur != null then
                           "Color"
                         else
                           throw "plasma-manager: wallpaperBackground is not null and has no option set"
                       }", "${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground.blur != null then
                           lib.boolToString cfg.workspace.wallpaperBackground.blur
-                        else if
-                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
-                        then
+                        else if cfg.workspace.wallpaperBackground.color != null then
                           cfg.workspace.wallpaperBackground.color
                         else
                           throw "plasma-manager: wallpaperBackground is not null and has no option set"
@@ -509,20 +505,16 @@ in
                   ${
                     lib.optionalString (cfg.workspace.wallpaperBackground != null)
                       ''desktop.writeConfig("${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground.blur != null then
                           "Blur"
-                        else if
-                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.blur != null
-                        then
+                        else if cfg.workspace.wallpaperBackground.blur != null then
                           "Color"
                         else
                           throw "plasma-manager: wallpaperBackground is not null and has no option set"
                       }", "${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground.blur != null then
                           lib.boolToString cfg.workspace.wallpaperBackground.blur
-                        else if
-                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
-                        then
+                        else if cfg.workspace.wallpaperBackground.color != null then
                           cfg.workspace.wallpaperBackground.color
                         else
                           throw "plasma-manager: wallpaperBackground is not null and has no option set"
@@ -576,20 +568,16 @@ in
                   ${
                     lib.optionalString (cfg.workspace.wallpaperBackground != null)
                       ''desktop.writeConfig("${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground.blur != null then
                           "Blur"
-                        else if
-                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.blur != null
-                        then
+                        else if cfg.workspace.wallpaperBackground.blur != null then
                           "Color"
                         else
                           throw "plasma-manager: wallpaperBackground is not null and has no option set"
                       }", "${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                        if cfg.workspace.wallpaperBackground.blur != null then
                           lib.boolToString cfg.workspace.wallpaperBackground.blur
-                        else if
-                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
-                        then
+                        else if cfg.workspace.wallpaperBackground.color != null then
                           cfg.workspace.wallpaperBackground.color
                         else
                           throw "plasma-manager: wallpaperBackground is not null and has no option set"


### PR DESCRIPTION
Removed `plasma-apply-wallpaperimage` due to limitations