### PR TITLE
docs: fix `mkEnableOption` wording

### DIFF
--- a/modules/apps/ghostwriter.nix
+++ b/modules/apps/ghostwriter.nix
@@ -230,7 +230,7 @@ in
 {
   options.programs.ghostwriter = {
     enable = lib.mkEnableOption ''
-      Enable configuration management for Ghostwriter.
+      configuration management for Ghostwriter.
     '';
 
     font = lib.mkOption {

--- a/modules/apps/kate/default.nix
+++ b/modules/apps/kate/default.nix
@@ -450,23 +450,31 @@ in
       example = "<>(){}[]'\"\`*_~";
       description = "This options determines which characters kate will treat as brackets.";
     };
-    automaticallyAddClosing = lib.mkEnableOption ''
-      When enabled, a closing bracket is automatically inserted upon typing the opening.
-    '';
-    highlightRangeBetween = lib.mkEnableOption ''
-      This option enables automatch highlighting of the lines between an opening and a
-      closing bracket when the cursor is adjacent to either.
-    '';
-    highlightMatching = lib.mkEnableOption ''
-      When enabled, and the cursor is adjacent to a closing bracket, and the corresponding
-      closing bracket is outside of the currently visible area, then the line of the opening
-      bracket and the line directly after will be shown in a small, floating window
-      at the top of the text area.
-    '';
-    flashMatching = lib.mkEnableOption ''
-      When this option is enabled, then a bracket will quickly flash whenever the cursor
-      moves adjacent to the corresponding bracket.
-    '';
+    automaticallyAddClosing = lib.mkEnableOption "" // {
+      description = ''
+        When enabled, a closing bracket is automatically inserted upon typing the opening.
+      '';
+    };
+    highlightRangeBetween = lib.mkEnableOption "" // {
+      description = ''
+        This option enables automatch highlighting of the lines between an opening and a
+        closing bracket when the cursor is adjacent to either.
+      '';
+    };
+    highlightMatching = lib.mkEnableOption "" // {
+      description = ''
+        When enabled, and the cursor is adjacent to a closing bracket, and the corresponding
+        closing bracket is outside of the currently visible area, then the line of the opening
+        bracket and the line directly after will be shown in a small, floating window
+        at the top of the text area.
+      '';
+    };
+    flashMatching = lib.mkEnableOption "" // {
+      description = ''
+        When this option is enabled, then a bracket will quickly flash whenever the cursor
+        moves adjacent to the corresponding bracket.
+      '';
+    };
   };
 
   # ==================================

--- a/modules/apps/kate/default.nix
+++ b/modules/apps/kate/default.nix
@@ -237,7 +237,7 @@ in
 {
   options.programs.kate = {
     enable = lib.mkEnableOption ''
-      Enable configuration management for Kate, the KDE Advanced Text Editor.
+      configuration management for Kate, the KDE Advanced Text Editor.
     '';
 
     package =

--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -89,7 +89,7 @@ in
 {
   options.programs.konsole = {
     enable = lib.mkEnableOption ''
-      Enable configuration management for Konsole, the KDE Terminal.
+      configuration management for Konsole, the KDE Terminal.
     '';
 
     defaultProfile = lib.mkOption {

--- a/modules/apps/okular.nix
+++ b/modules/apps/okular.nix
@@ -140,7 +140,9 @@ with lib.types;
       };
 
       changeColors = {
-        enable = lib.mkEnableOption "Whether to change the colors of the documents.";
+        enable = lib.mkEnableOption "" // {
+          description = "Whether to change the colors of the documents.";
+        };
         mode = lib.mkOption {
           description = "Mode used to change the colors.";
           default = null;

--- a/modules/apps/okular.nix
+++ b/modules/apps/okular.nix
@@ -20,7 +20,7 @@ with lib.types;
 {
   options.programs.okular = {
     enable = lib.mkEnableOption ''
-      Enable configuration management for okular.
+      configuration management for okular.
     '';
 
     package =

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -23,6 +23,6 @@
   ];
 
   options.programs.plasma.enable = lib.mkEnableOption ''
-    Whether to enable declarative configuration options for the KDE Plasma Desktop.
+    declarative configuration options for the KDE Plasma Desktop.
   '';
 }

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -143,7 +143,9 @@ in
         Configuration files which explicitly should not be deleted on each generation, if `overrideConfig` is enabled.
       '';
     };
-    immutableByDefault = lib.mkEnableOption "Make keys written by plasma-manager immutable by default.";
+    immutableByDefault = lib.mkEnableOption "" // {
+      description = "Whether to make keys written by plasma-manager immutable by default.";
+    };
   };
 
   imports = [

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -139,7 +139,7 @@ let
             Plasma 6-only.
           '';
         };
-        floating = lib.mkEnableOption "Enable or disable floating style.";
+        floating = lib.mkEnableOption "floating style.";
         widgets = lib.mkOption {
           type = lib.types.listOf widgets.type;
           default = [


### PR DESCRIPTION
this function prepends "Whether to enable " to `description`, which was likely forgotten in some places, causing weird descriptions in https://nix-community.github.io/plasma-manager/options.xhtml