### PR TITLE
doc(input): add some examples to keyboard layout variant

### DIFF
--- a/modules/input.nix
+++ b/modules/input.nix
@@ -46,7 +46,7 @@ let
         example = "eng";
         description = ''
           Keyboard layout variant.
-          examples: "mac" "dvorak" "workman-intl" "colemak_dh_wide_iso"
+          Examples: "mac", "dvorak", "workman-intl", and "colemak_dh_wide_iso"
         '';
         apply = builtins.toString;
       };

--- a/modules/input.nix
+++ b/modules/input.nix
@@ -43,16 +43,10 @@ let
       variant = lib.mkOption {
         type = with lib.types; nullOr str;
         default = null;
-        example = [
-          "eng"
-          "mac"
-          "dvorak"
-          # these two examples below exists to tell that the spacer is not consistent (- or _).
-          "workman-intl"
-          "colemak_dh_wide_iso"
-        ];
+        example = "eng";
         description = ''
           Keyboard layout variant.
+          examples: "mac" "dvorak" "workman-intl" "colemak_dh_wide_iso"
         '';
         apply = builtins.toString;
       };

--- a/modules/input.nix
+++ b/modules/input.nix
@@ -43,7 +43,14 @@ let
       variant = lib.mkOption {
         type = with lib.types; nullOr str;
         default = null;
-        example = "eng";
+        example = [
+          "eng"
+          "mac"
+          "dvorak"
+          # these two examples below exists to tell that the spacer is not consistent (- or _).
+          "workman-intl"
+          "colemak_dh_wide_iso"
+        ];
         description = ''
           Keyboard layout variant.
         '';


### PR DESCRIPTION
It should include examples of layout (such as Dvorak, Colemak, etc).
"mac" isn't necessary, but it's better than not having mac in there.