### PR TITLE
feat(panels): add opacity option

### DIFF
--- a/lib/panel.nix
+++ b/lib/panel.nix
@@ -34,6 +34,7 @@ let
         ${stringIfNotNull panel.maxLength "panel.maximumLength = ${toString panel.maxLength};"}
         ${stringIfNotNull panel.minLength "panel.minimumLength = ${toString panel.minLength};"}
         ${stringIfNotNull panel.offset "panel.offset = ${toString panel.offset};"}
+        ${stringIfNotNull panel.opacity ''panel.opacity = "${panel.opacity}";''}
         ${stringIfNotNull panel.screen ''panel.writeConfig("lastScreen[$i]", ${if ((panel.screen == "all") || (builtins.isList panel.screen)) then "screenID" else toString panel.screen});''}
 
         ${addWidgetStmts "panel" "panelWidgets" panel.widgets}

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -182,6 +182,20 @@ let
             appear on all the screens.
           '';
         };
+        opacity = lib.mkOption {
+          type =
+            with lib.types;
+            nullOr (enum [
+              "adaptive"
+              "opaque"
+              "translucent"
+            ]);
+          default = null;
+          example = "opaque";
+          description = ''
+            The opacity mode of the panel.
+          '';
+        };
         extraSettings = lib.mkOption {
           type = with lib.types; nullOr str;
           default = null;


### PR DESCRIPTION
Closes #352 

This resolves the inability to set panel opacity, as requested in issue #352. The implementation relies on the merged Plasma MR
that enables opacity configuration via the scripting API (available in Plasma 6.3+, which is now available in nixos-unstable).