### PR TITLE
feat(cursors): Cursor launch feedback

### DIFF
--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -36,19 +36,19 @@ let
           default = null;
           example = "Bouncing";
           description = ''
-	    The cursor feedback icon after launching an application. Valid options are Bouncing, Blinking, Static, and None.
+            	    The cursor feedback icon after launching an application. Valid options are Bouncing, Blinking, Static, and None.
           '';
         };
         taskManagerFeedback = lib.mkOption {
           type = nullOr bool;
           default = null;
-	  example = true;
+          example = true;
           description = "The feedback wheel on an application icon after launching an application from the task manager.";
         };
         animationTime = lib.mkOption {
           type = nullOr ints.positive;
           default = null;
-	  example = 5;
+          example = 5;
           description = "The duration that the cursorFeedback and taskManagerFeedback run for.";
         };
       };
@@ -156,9 +156,9 @@ in
       example = {
         theme = "Breeze_Snow";
         size = 24;
-	cursorFeedback = "Bouncing";
-	taskManagerFeedback = true;
-	animationTime = 5;
+        cursorFeedback = "Bouncing";
+        taskManagerFeedback = true;
+        animationTime = 5;
       };
       description = ''
         Submodule for configuring the cursor appearance. The theme, size, cursor feedback, task manager feedback, and animation time are configurable.
@@ -377,7 +377,7 @@ in
                 Mouse.cursorSize = cfg.workspace.cursor.size;
               }
             );
-	    klaunchrc = lib.mkMerge [
+            klaunchrc = lib.mkMerge [
               (lib.mkIf (cfg.workspace.cursor != null && cfg.workspace.cursor.cursorFeedback != null) (
                 {
                   "None" = {
@@ -400,7 +400,8 @@ in
                     BusyCursorSettings.Bouncing = "true";
                     FeedbackStyle.BusyCursor = "true";
                   };
-                }.${cfg.workspace.cursor.cursorFeedback}
+                }
+                .${cfg.workspace.cursor.cursorFeedback}
               ))
 
               (lib.mkIf (cfg.workspace.cursor != null && cfg.workspace.cursor.taskManagerFeedback != null) {

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -384,23 +384,31 @@ in
               (lib.mkIf (cfg.workspace.cursor != null && cfg.workspace.cursor.cursorFeedback != null) (
                 {
                   "None" = {
-                    BusyCursorSettings.Blinking = false;
-                    BusyCursorSettings.Bouncing = false;
+                    BusyCursorSettings = {
+                      Blinking = false;
+                      Bouncing = false;
+                    };
                     FeedbackStyle.BusyCursor = false;
                   };
                   "Static" = {
-                    BusyCursorSettings.Blinking = false;
-                    BusyCursorSettings.Bouncing = false;
+                    BusyCursorSettings = {
+                      Blinking = false;
+                      Bouncing = false;
+                    };
                     FeedbackStyle.BusyCursor = true;
                   };
                   "Blinking" = {
-                    BusyCursorSettings.Blinking = true;
-                    BusyCursorSettings.Bouncing = false;
+                    BusyCursorSettings = {
+                      Blinking = true;
+                      Bouncing = false;
+                    };
                     FeedbackStyle.BusyCursor = true;
                   };
                   "Bouncing" = {
-                    BusyCursorSettings.Blinking = false;
-                    BusyCursorSettings.Bouncing = true;
+                    BusyCursorSettings = {
+                      Blinking = false;
+                      Bouncing = true;
+                    };
                     FeedbackStyle.BusyCursor = true;
                   };
                 }

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -31,6 +31,14 @@ let
           example = 24;
           description = "The size of the cursor. See the System Settings app for allowed sizes for each cursor theme.";
         };
+        cursorFeedback = lib.mkOption {
+          type = nullOr str;
+          default = null;
+          example = "Bouncing";
+          description = ''
+	    The cursor feedback icon after launching an application. Valid options are Bouncing, Blinking, Static, and None.
+          '';
+        };
       };
     };
 
@@ -99,7 +107,7 @@ in
       default = null;
       example = false;
       description = ''
-        Whether clicking the middle mouse button pastes the clipboard content.";
+        Whether clicking the middle mouse button pastes the clipboard content.
       '';
     };
 
@@ -136,9 +144,10 @@ in
       example = {
         theme = "Breeze_Snow";
         size = 24;
+	cursorFeedback = "Bouncing";
       };
       description = ''
-        Submodule for configuring the cursor appearance. Both the theme and size are configurable.
+        Submodule for configuring the cursor appearance. Both the theme, size, and cursor feedback are configurable.
       '';
     };
 

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -378,30 +378,39 @@ in
               }
             );
             klaunchrc = (
-              lib.mkIf (cfg.workspace.cursor != null && cfg.workspace.cursor.cursorFeedback != null) (
-	        lib.mkMerge [
-	          (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "None") {
-                    BusyCursorSettings.Blinking = "false";
-                    BusyCursorSettings.Bouncing = "false";
-	            FeedbackStyle.BusyCursor = "false";
-	          })
-	          (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "Static") {
-                    BusyCursorSettings.Blinking = "false";
-                    BusyCursorSettings.Bouncing = "false";
-	            FeedbackStyle.BusyCursor = "true";
-		  })
-	          (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "Blinking") {
-                    BusyCursorSettings.Blinking = "true";
-                    BusyCursorSettings.Bouncing = "false";
-	            FeedbackStyle.BusyCursor = "true";
-		  })	
-	          (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "Bouncing") {
-                    BusyCursorSettings.Blinking = "false";
-                    BusyCursorSettings.Bouncing = "true";
-	            FeedbackStyle.BusyCursor = "true";
-		  })	
-		]
-              )
+	      lib.mkMerge [
+                (lib.mkIf (cfg.workspace.cursor != null && cfg.workspace.cursor.cursorFeedback != null) (
+	          lib.mkMerge [
+	            (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "None") {
+                      BusyCursorSettings.Blinking = "false";
+                      BusyCursorSettings.Bouncing = "false";
+	              FeedbackStyle.BusyCursor = "false";
+	            })
+	            (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "Static") {
+                      BusyCursorSettings.Blinking = "false";
+                      BusyCursorSettings.Bouncing = "false";
+	              FeedbackStyle.BusyCursor = "true";
+		    })
+	            (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "Blinking") {
+                      BusyCursorSettings.Blinking = "true";
+                      BusyCursorSettings.Bouncing = "false";
+	              FeedbackStyle.BusyCursor = "true";
+		    })	
+	            (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "Bouncing") {
+                      BusyCursorSettings.Blinking = "false";
+                      BusyCursorSettings.Bouncing = "true";
+	              FeedbackStyle.BusyCursor = "true";
+		    })	
+		  ]
+                ))
+		(lib.mkIf (cfg.workspace.cursor != null && cfg.workspace.cursor.taskManagerFeedback != null) {
+		  FeedbackStyle.TaskbarButton = cfg.workspace.cursor.taskManagerFeedback;
+		})
+		(lib.mkIf (cfg.workspace.cursor != null && cfg.workspace.cursor.animationTime != null) {
+		  BusyCursorSettings.Timeout = cfg.workspace.cursor.animationTime; 
+		  TaskbarButtonSettings.Timeout = cfg.workspace.cursor.animationTime; 
+		})
+	      ]
             );
             ksplashrc.KSplash = (
               lib.mkIf (cfg.workspace.splashScreen.theme != null) {

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -363,6 +363,32 @@ in
                 Mouse.cursorSize = cfg.workspace.cursor.size;
               }
             );
+            klaunchrc = (
+              lib.mkIf (cfg.workspace.cursor != null && cfg.workspace.cursor.cursorFeedback != null) (
+	        lib.mkMerge [
+	          (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "None") {
+                    BusyCursorSettings.Blinking = "false";
+                    BusyCursorSettings.Bouncing = "false";
+	            FeedbackStyle.BusyCursor = "false";
+	          })
+	          (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "Static") {
+                    BusyCursorSettings.Blinking = "false";
+                    BusyCursorSettings.Bouncing = "false";
+	            FeedbackStyle.BusyCursor = "true";
+		  })
+	          (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "Blinking") {
+                    BusyCursorSettings.Blinking = "true";
+                    BusyCursorSettings.Bouncing = "false";
+	            FeedbackStyle.BusyCursor = "true";
+		  })	
+	          (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "Bouncing") {
+                    BusyCursorSettings.Blinking = "false";
+                    BusyCursorSettings.Bouncing = "true";
+	            FeedbackStyle.BusyCursor = "true";
+		  })	
+		]
+              )
+            );
             ksplashrc.KSplash = (
               lib.mkIf (cfg.workspace.splashScreen.theme != null) {
                 Engine = (

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -39,6 +39,18 @@ let
 	    The cursor feedback icon after launching an application. Valid options are Bouncing, Blinking, Static, and None.
           '';
         };
+        taskManagerFeedback = lib.mkOption {
+          type = nullOr bool;
+          default = null;
+	  example = true;
+          description = "The feedback wheel on an application icon after launching an application from the task manager.";
+        };
+        animationTime = lib.mkOption {
+          type = nullOr ints.positive;
+          default = null;
+	  example = 5;
+          description = "The duration that the cursorFeedback and taskManagerFeedback run for.";
+        };
       };
     };
 
@@ -145,9 +157,11 @@ in
         theme = "Breeze_Snow";
         size = 24;
 	cursorFeedback = "Bouncing";
+	taskManagerFeedback = true;
+	animationTime = 5;
       };
       description = ''
-        Submodule for configuring the cursor appearance. Both the theme, size, and cursor feedback are configurable.
+        Submodule for configuring the cursor appearance. The theme, size, cursor feedback, task manager feedback, and animation time are configurable.
       '';
     };
 

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -32,12 +32,15 @@ let
           description = "The size of the cursor. See the System Settings app for allowed sizes for each cursor theme.";
         };
         cursorFeedback = lib.mkOption {
-          type = nullOr str;
+          type = nullOr (enum [
+            "Bouncing"
+            "Blinking"
+            "Static"
+            "None"
+          ]);
           default = null;
           example = "Bouncing";
-          description = ''
-            	    The cursor feedback icon after launching an application. Valid options are Bouncing, Blinking, Static, and None.
-          '';
+          description = "The cursor feedback icon after launching an application.";
         };
         taskManagerFeedback = lib.mkOption {
           type = nullOr bool;

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -384,24 +384,24 @@ in
               (lib.mkIf (cfg.workspace.cursor != null && cfg.workspace.cursor.cursorFeedback != null) (
                 {
                   "None" = {
-                    BusyCursorSettings.Blinking = "false";
-                    BusyCursorSettings.Bouncing = "false";
-                    FeedbackStyle.BusyCursor = "false";
+                    BusyCursorSettings.Blinking = false;
+                    BusyCursorSettings.Bouncing = false;
+                    FeedbackStyle.BusyCursor = false;
                   };
                   "Static" = {
-                    BusyCursorSettings.Blinking = "false";
-                    BusyCursorSettings.Bouncing = "false";
-                    FeedbackStyle.BusyCursor = "true";
+                    BusyCursorSettings.Blinking = false;
+                    BusyCursorSettings.Bouncing = false;
+                    FeedbackStyle.BusyCursor = true;
                   };
                   "Blinking" = {
-                    BusyCursorSettings.Blinking = "true";
-                    BusyCursorSettings.Bouncing = "false";
-                    FeedbackStyle.BusyCursor = "true";
+                    BusyCursorSettings.Blinking = true;
+                    BusyCursorSettings.Bouncing = false;
+                    FeedbackStyle.BusyCursor = true;
                   };
                   "Bouncing" = {
-                    BusyCursorSettings.Blinking = "false";
-                    BusyCursorSettings.Bouncing = "true";
-                    FeedbackStyle.BusyCursor = "true";
+                    BusyCursorSettings.Blinking = false;
+                    BusyCursorSettings.Bouncing = true;
+                    FeedbackStyle.BusyCursor = true;
                   };
                 }
                 .${cfg.workspace.cursor.cursorFeedback}

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -377,41 +377,41 @@ in
                 Mouse.cursorSize = cfg.workspace.cursor.size;
               }
             );
-            klaunchrc = (
-	      lib.mkMerge [
-                (lib.mkIf (cfg.workspace.cursor != null && cfg.workspace.cursor.cursorFeedback != null) (
-	          lib.mkMerge [
-	            (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "None") {
-                      BusyCursorSettings.Blinking = "false";
-                      BusyCursorSettings.Bouncing = "false";
-	              FeedbackStyle.BusyCursor = "false";
-	            })
-	            (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "Static") {
-                      BusyCursorSettings.Blinking = "false";
-                      BusyCursorSettings.Bouncing = "false";
-	              FeedbackStyle.BusyCursor = "true";
-		    })
-	            (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "Blinking") {
-                      BusyCursorSettings.Blinking = "true";
-                      BusyCursorSettings.Bouncing = "false";
-	              FeedbackStyle.BusyCursor = "true";
-		    })	
-	            (lib.mkIf (cfg.workspace.cursor.cursorFeedback == "Bouncing") {
-                      BusyCursorSettings.Blinking = "false";
-                      BusyCursorSettings.Bouncing = "true";
-	              FeedbackStyle.BusyCursor = "true";
-		    })	
-		  ]
-                ))
-		(lib.mkIf (cfg.workspace.cursor != null && cfg.workspace.cursor.taskManagerFeedback != null) {
-		  FeedbackStyle.TaskbarButton = cfg.workspace.cursor.taskManagerFeedback;
-		})
-		(lib.mkIf (cfg.workspace.cursor != null && cfg.workspace.cursor.animationTime != null) {
-		  BusyCursorSettings.Timeout = cfg.workspace.cursor.animationTime; 
-		  TaskbarButtonSettings.Timeout = cfg.workspace.cursor.animationTime; 
-		})
-	      ]
-            );
+	    klaunchrc = lib.mkMerge [
+              (lib.mkIf (cfg.workspace.cursor != null && cfg.workspace.cursor.cursorFeedback != null) (
+                {
+                  "None" = {
+                    BusyCursorSettings.Blinking = "false";
+                    BusyCursorSettings.Bouncing = "false";
+                    FeedbackStyle.BusyCursor = "false";
+                  };
+                  "Static" = {
+                    BusyCursorSettings.Blinking = "false";
+                    BusyCursorSettings.Bouncing = "false";
+                    FeedbackStyle.BusyCursor = "true";
+                  };
+                  "Blinking" = {
+                    BusyCursorSettings.Blinking = "true";
+                    BusyCursorSettings.Bouncing = "false";
+                    FeedbackStyle.BusyCursor = "true";
+                  };
+                  "Bouncing" = {
+                    BusyCursorSettings.Blinking = "false";
+                    BusyCursorSettings.Bouncing = "true";
+                    FeedbackStyle.BusyCursor = "true";
+                  };
+                }.${cfg.workspace.cursor.cursorFeedback}
+              ))
+
+              (lib.mkIf (cfg.workspace.cursor != null && cfg.workspace.cursor.taskManagerFeedback != null) {
+                FeedbackStyle.TaskbarButton = cfg.workspace.cursor.taskManagerFeedback;
+              })
+
+              (lib.mkIf (cfg.workspace.cursor != null && cfg.workspace.cursor.animationTime != null) {
+                BusyCursorSettings.Timeout = cfg.workspace.cursor.animationTime;
+                TaskbarButtonSettings.Timeout = cfg.workspace.cursor.animationTime;
+              })
+            ];
             ksplashrc.KSplash = (
               lib.mkIf (cfg.workspace.splashScreen.theme != null) {
                 Engine = (


### PR DESCRIPTION
While I was configuring my kde setup I noticed that the settings for cursor launch feedback seemed to be missing.
![image](https://github.com/user-attachments/assets/5c92d395-6b46-4b2a-9822-bab46af1c800)

I had a go at adding these settings to the cursorType since they are listed under cursors in kde settings, and added configuration to klaunchrc which I believe is the only place these settings have an effect. 

I'm quite new to nix so please let me know if it needs any changes or if you need me to refactor this.