### PR TITLE
fix(input): rename wrongful option name

### DIFF
--- a/modules/input.nix
+++ b/modules/input.nix
@@ -522,7 +522,7 @@ in
         productId = "21128";
         disableWhileTyping = true;
         leftHanded = true;
-        middleMouseEmulation = true;
+        middleButtonEmulation = true;
         pointerSpeed = 0;
         naturalScroll = true;
         tapToClick = true;


### PR DESCRIPTION
After reading through the [docs](https://nix-community.github.io/plasma-manager/options.xhtml), I found that the example configuration for [programs.plasma.input.touchpads](https://nix-community.github.io/plasma-manager/options.xhtml#opt-programs.plasma.input.touchpads) contained the wrongful name 'middleMouseEmulation' for the option 'middleButtonEmulation'.