### PR TITLE
feat(input): added config for pointer-acceleration-profile to touchpad

### DIFF
--- a/modules/input.nix
+++ b/modules/input.nix
@@ -143,20 +143,11 @@ let
         '';
       };
       accelerationProfile = lib.mkOption {
-        type =
-          with lib.types;
-          nullOr (enum (builtins.attrNames accelerationProfiles));
+        type = with lib.types; nullOr (enum (builtins.attrNames accelerationProfiles));
         default = null;
         example = "none";
         description = "Set the touchpad acceleration profile.";
-        apply =
-          profile:
-          if profile == "none" then
-            1
-          else if profile == "default" then
-            2
-          else
-            null;
+        apply = profile: if (profile == null) then null else accelerationProfiles."${profile}";
       };
       naturalScroll = lib.mkOption {
         type = with lib.types; nullOr bool;
@@ -328,20 +319,11 @@ let
         '';
       };
       accelerationProfile = lib.mkOption {
-        type =
-          with lib.types;
-          nullOr (enum (builtins.attrNames accelerationProfiles));
+        type = with lib.types; nullOr (enum (builtins.attrNames accelerationProfiles));
         default = null;
         example = "none";
         description = "Set the mouse acceleration profile.";
-        apply =
-          profile:
-          if profile == "none" then
-            1
-          else if profile == "default" then
-            2
-          else
-            null;
+        apply = profile: if (profile == null) then null else accelerationProfiles."${profile}";
       };
       naturalScroll = lib.mkOption {
         type = with lib.types; nullOr bool;

--- a/modules/input.nix
+++ b/modules/input.nix
@@ -22,6 +22,10 @@ let
     bottomRight = 1;
     twoFingers = 2;
   };
+  accelerationProfiles = {
+    none = 1;
+    default = 2;
+  };
 
   capitalizeWord =
     word:
@@ -141,10 +145,7 @@ let
       accelerationProfile = lib.mkOption {
         type =
           with lib.types;
-          nullOr (enum [
-            "none"
-            "default"
-          ]);
+          nullOr (enum (builtins.attrNames accelerationProfiles));
         default = null;
         example = "none";
         description = "Set the touchpad acceleration profile.";
@@ -329,10 +330,7 @@ let
       accelerationProfile = lib.mkOption {
         type =
           with lib.types;
-          nullOr (enum [
-            "none"
-            "default"
-          ]);
+          nullOr (enum (builtins.attrNames accelerationProfiles));
         default = null;
         example = "none";
         description = "Set the mouse acceleration profile.";

--- a/modules/input.nix
+++ b/modules/input.nix
@@ -138,6 +138,25 @@ let
           How fast the pointer moves.
         '';
       };
+      accelerationProfile = lib.mkOption {
+        type =
+          with lib.types;
+          nullOr (enum [
+            "none"
+            "default"
+          ]);
+        default = null;
+        example = "none";
+        description = "Set the touchpad acceleration profile.";
+        apply =
+          profile:
+          if profile == "none" then
+            1
+          else if profile == "default" then
+            2
+          else
+            null;
+      };
       naturalScroll = lib.mkOption {
         type = with lib.types; nullOr bool;
         default = null;
@@ -227,6 +246,7 @@ let
         LeftHanded = touchpad.leftHanded;
         MiddleButtonEmulation = touchpad.middleButtonEmulation;
         PointerAcceleration = touchpad.pointerSpeed;
+        PointerAccelerationProfile = touchpad.accelerationProfile;
         NaturalScroll = touchpad.naturalScroll;
         TapToClick = touchpad.tapToClick;
         TapAndDrag = touchpad.tapAndDrag;


### PR DESCRIPTION
Whilst configuring my touchpad, I could only find the option for setting the acceleration profile in the mice settings and no corresponding setting for my touchpad. Copied config-option from mice to touchpads.