### PR TITLE
fix(spectacle): correct config group for spectacle options

### DIFF
--- a/modules/spectacle.nix
+++ b/modules/spectacle.nix
@@ -147,7 +147,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    programs.plasma.shortcuts."org.kde.spectacle.desktop" = lib.mkMerge [
+    programs.plasma.shortcuts."services/org.kde.spectacle.desktop" = lib.mkMerge [
       (lib.mkIf (cfg.spectacle.shortcuts.captureActiveWindow != null) {
         ActiveWindowScreenShot = cfg.spectacle.shortcuts.captureActiveWindow;
       })


### PR DESCRIPTION
Came across issue whilst configuring [spectacle shortcuts](https://nix-community.github.io/plasma-manager/options.xhtml#opt-programs.plasma.spectacle.shortcuts.captureCurrentMonitor). Configuration is being written to group `org.kde.spectacle.desktop` in `~/.config/kglobalshortcutsrc`. However, when making native (in app) changes to spectacle settings, they are being written to subgroup `services`, resulting in the following group in the config file: `[services][org.kde.spectacle.desktop]`

Correct, natively generated configuration:
![native-configuration](https://github.com/user-attachments/assets/885e272e-c3b3-4f9a-ac42-e393ed7c09e2)

Incorrect, plasma-manager generated configuration:
![plasma-manager-configuration](https://github.com/user-attachments/assets/109498a9-78f1-47e4-b07f-913484d77db7)
