### PR TITLE
feat(kwin/navigation-wrapping): add option for navigation-wrapping

### DIFF
--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -209,17 +209,24 @@ in
         default = null;
         description = "Arrange desktops in a virtual cube.";
       };
-      desktopSwitching.animation = lib.mkOption {
-        type =
-          with lib.types;
-          nullOr (enum [
-            "fade"
-            "slide"
-            "off"
-          ]);
-        default = null;
-        example = "fade";
-        description = "The animation used when switching through virtual desktops.";
+      desktopSwitching = {
+        animation = lib.mkOption {
+          type =
+            with lib.types;
+            nullOr (enum [
+              "fade"
+              "slide"
+              "off"
+            ]);
+          default = null;
+          example = "fade";
+          description = "The animation used when switching through virtual desktops.";
+        };
+        navigationWrapping = lib.mkOption {
+          type = with lib.types; nullOr bool;
+          default = null;
+          description = "Whether to wrap around when switching through virtual desktops.";
+        };
       };
       windowOpenClose = {
         animation = lib.mkOption {
@@ -692,6 +699,9 @@ in
           (lib.mkIf (cfg.kwin.effects.desktopSwitching.animation != null) {
             Plugins.slideEnabled = cfg.kwin.effects.desktopSwitching.animation == "slide";
             Plugins.fadedesktopEnabled = cfg.kwin.effects.desktopSwitching.animation == "fade";
+          })
+          (lib.mkIf (cfg.kwin.effects.desktopSwitching.navigationWrapping != null) {
+            Windows.RollOverDesktops = cfg.kwin.effects.desktopSwitching.navigationWrapping;
           })
           (lib.mkIf (cfg.kwin.effects.fallApart.enable != null) {
             Plugins.fallapartEnabled = cfg.kwin.effects.fallApart.enable;


### PR DESCRIPTION
Extend [programs.plasma.kwin.effects.desktopSwitching](https://nix-community.github.io/plasma-manager/options.xhtml#opt-programs.plasma.kwin.effects.desktopSwitching.animation) by adding option for wrapping around virtual desktops when switching through.

![native virtual desktops option - system settings](https://github.com/user-attachments/assets/39e0afce-c925-4ac4-a045-1382d782fcdd)
