### PR TITLE
feat(system-tray): adapt plasma 6.4 changes (#500)

### DIFF
--- a/modules/widgets/system-tray.nix
+++ b/modules/widgets/system-tray.nix
@@ -216,11 +216,12 @@ in
             iconSpacing = icons.spacing;
           };
         };
-        extraConfig = ''
-          (widget) => {
-            ${widgets.lib.addWidgetStmts "widget" "trayWidgets" items.configs}
-          }
-        '';
+        # Uncomment this if plasma scripting API ever adds support for nested containments.
+        # extraConfig = ''
+        #   (widget) => {
+        #     ${widgets.lib.addWidgetStmts "widget" "trayWidgets" items.configs}
+        #   }
+        # '';
       };
   };
 }

--- a/modules/widgets/system-tray.nix
+++ b/modules/widgets/system-tray.nix
@@ -201,8 +201,10 @@ in
         settings,
         ...
       }:
-      let
-        sets = {
+      lib.recursiveUpdate settings {
+        name = "org.kde.plasma.systemtray";
+
+        config = {
           General = lib.filterAttrs (_: v: v != null) {
             inherit pin;
             extraItems = items.extra;
@@ -214,17 +216,9 @@ in
             iconSpacing = icons.spacing;
           };
         };
-        mergedSettings = lib.recursiveUpdate sets settings;
-      in
-      {
-        name = "org.kde.plasma.systemtray";
         extraConfig = ''
           (widget) => {
-            const tray = desktopById(widget.readConfig("SystrayContainmentId"));
-            if (!tray) return; // if somehow the containment doesn't exist
-
-            ${widgets.lib.setWidgetSettings "tray" mergedSettings}
-            ${widgets.lib.addWidgetStmts "tray" "trayWidgets" items.configs}
+            ${widgets.lib.addWidgetStmts "widget" "trayWidgets" items.configs}
           }
         '';
       };


### PR DESCRIPTION
Hi,

With these modifications, I was able to get the System Tray entities displayed correctly under KDE Plasma 6.4 (https://github.com/nix-community/plasma-manager/issues/500). However, I couldn't figure how to make shortcuts working, so please guide me how to do that or at least show the right direction.
I am terrible at Nix, so please be patient :D 

CC: @HeitorAugustoLN 