### PR TITLE
feat(kwin): add kwin virtual desktop navigation wraps around option

### DIFF
--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -313,6 +313,14 @@ in
           `names` list.
         '';
       };
+      navigationWrapsAround = lib.mkOption {
+        type = with lib.types; nullOr bool;
+        default = null;
+        example = true;
+        description = ''
+          Whether switching virtual desktops wraps around.
+        '';
+      };
     };
 
     borderlessMaximizedWindows = lib.mkOption {
@@ -732,6 +740,11 @@ in
               (virtualDesktopIdAttrs (builtins.length cfg.kwin.virtualDesktops.names))
               (virtualDesktopNameAttrs cfg.kwin.virtualDesktops.names)
             ];
+          })
+          (lib.mkIf (cfg.kwin.virtualDesktops.navigationWrapsAround != null) {
+            Windows = {
+               RollOverDesktops = cfg.kwin.virtualDesktops.navigationWrapsAround;
+            };
           })
 
           # Borderless maximized windows


### PR DESCRIPTION
KWin has an option for wrapping around when navigating virtual desktops.
Using the GUI, this option set using the `Window Management > Virtual Desktops > Navigation wraps around` toggle.
In `~/.config/kwinrc`, it is set using
```
[Windows]
RollOverDesktops=true
```
.
This pull request allows setting the option using:
```
programs.plasma.kwin = {
  virtualDesktops = {
    number = 8;
    rows = 4;
    navigationWrapsAround = true;
  };
};
```

Note: I am pretty new to Nix, so please double-check that I didn't make an obvious mistake or messed up a naming convention.