### PR TITLE
Remove kwin.virtualDesktops.navigationWrapsAround in favor of kwin.effects.desktopSwitching.navigationWrapping

### DIFF
--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -320,14 +320,6 @@ in
           `names` list.
         '';
       };
-      navigationWrapsAround = lib.mkOption {
-        type = with lib.types; nullOr bool;
-        default = null;
-        example = true;
-        description = ''
-          Whether switching virtual desktops wraps around.
-        '';
-      };
     };
 
     borderlessMaximizedWindows = lib.mkOption {
@@ -750,11 +742,6 @@ in
               (virtualDesktopIdAttrs (builtins.length cfg.kwin.virtualDesktops.names))
               (virtualDesktopNameAttrs cfg.kwin.virtualDesktops.names)
             ];
-          })
-          (lib.mkIf (cfg.kwin.virtualDesktops.navigationWrapsAround != null) {
-            Windows = {
-               RollOverDesktops = cfg.kwin.virtualDesktops.navigationWrapsAround;
-            };
           })
 
           # Borderless maximized windows


### PR DESCRIPTION
After merging #493 we needed to revert eed6ee70669e4d84c4ba12b4a045b10341f02c81 since this was pretty much duplicate. My bad on not seeing this before.