### PR TITLE
fix: rename homeManagerModules to homeModules

### DIFF
--- a/examples/homeManagerFlake/flake.nix
+++ b/examples/homeManagerFlake/flake.nix
@@ -34,7 +34,7 @@
         pkgs = import nixpkgs { inherit system; };
 
         modules = [
-          inputs.plasma-manager.homeManagerModules.plasma-manager
+          inputs.plasma-manager.homeModules.plasma-manager
 
           # Specify the path to your home configuration here:
           ../home.nix

--- a/examples/systemFlake/flake.nix
+++ b/examples/systemFlake/flake.nix
@@ -48,7 +48,7 @@
           {
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
-            home-manager.sharedModules = [ plasma-manager.homeManagerModules.plasma-manager ];
+            home-manager.sharedModules = [ plasma-manager.homeModules.plasma-manager ];
 
             # This should point to your home.nix path of course. For an example
             # of this see ./home.nix in this directory.

--- a/flake.nix
+++ b/flake.nix
@@ -25,11 +25,15 @@
       nixpkgsFor = forAllSystems (system: import inputs.nixpkgs { inherit system; });
     in
     {
-      homeManagerModules.plasma-manager =
+      homeModules.plasma-manager =
         { ... }:
         {
           imports = [ ./modules ];
         };
+
+      homeManagerModules = inputs.nixpkgs.lib.warn ''
+        plasma-manager: homeManagerModules has been renamed to homeModules
+      '' self.homeModules;
 
       packages = forAllSystems (
         system:


### PR DESCRIPTION
The proper output name for Home Manager modules is `homeModules`, not `homeManagerModules`. See [here][1] and [here][2] and the discussion [here][3].

Also, I changed `import inputs.nixpkgs { ... }` to `nixpkgs.legacyPackages`, to avoid creating another instance of nixpkgs (small performance optimization).

[1]: https://github.com/nix-community/home-manager/blob/99a69bdf8a3c6bf038c4121e9c4b6e99706a187a/flake-module.nix#L28-L43
[2]: https://github.com/DeterminateSystems/flake-schemas/blob/d0e74ee9a30eda4cc153b7f1e347043680834180/flake.nix#L293-L306
[3]: https://github.com/nix-community/home-manager/pull/6392#issuecomment-2633445057