### PR TITLE
fix: use nixpkgs.legacyPackages instead of importing nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
       forAllSystems = inputs.nixpkgs.lib.genAttrs supportedSystems;
 
       # Attribute set of nixpkgs for each system:
-      nixpkgsFor = forAllSystems (system: import inputs.nixpkgs { inherit system; });
+      nixpkgsFor = inputs.nixpkgs.legacyPackages;
     in
     {
       homeManagerModules.plasma-manager =


### PR DESCRIPTION
Changes `import nixpkgs` to `nixpkgs.legacyPackages`

See here for more info: https://zimbatm.com/notes/1000-instances-of-nixpkgs

(The `legacyPackages` name is purely a Flakes thing, because the `packages` output is meant to be a flat attribute set, but Nixpkgs contains nested package sets, so it must be called `legacyPackages` instead)