### PR TITLE
fix: prevent wallpapers from being garbage collected

### DIFF
--- a/modules/kscreenlocker.nix
+++ b/modules/kscreenlocker.nix
@@ -203,6 +203,7 @@ in
         (lib.mkIf (cfg.kscreenlocker.appearance.wallpaper != null) {
           Greeter.WallpaperPlugin = "org.kde.image";
           "Greeter/Wallpaper/org.kde.image/General".Image = builtins.path {
+            name = "kscreenlocker-wallpaper";
             path = cfg.kscreenlocker.appearance.wallpaper;
           };
         })

--- a/modules/kscreenlocker.nix
+++ b/modules/kscreenlocker.nix
@@ -202,9 +202,9 @@ in
       lib.mkMerge [
         (lib.mkIf (cfg.kscreenlocker.appearance.wallpaper != null) {
           Greeter.WallpaperPlugin = "org.kde.image";
-          "Greeter/Wallpaper/org.kde.image/General".Image = (
-            builtins.toString cfg.kscreenlocker.appearance.wallpaper
-          );
+          "Greeter/Wallpaper/org.kde.image/General".Image = builtins.path {
+            path = cfg.kscreenlocker.appearance.wallpaper;
+          };
         })
         (lib.mkIf (cfg.kscreenlocker.appearance.wallpaperPictureOfTheDay != null) {
           Greeter.WallpaperPlugin = "org.kde.potd";

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -457,46 +457,55 @@ in
                     if (builtins.typeOf cfg.workspace.wallpaper) == "list" then
                       ''
                         let images = [
-                        ${
-                          builtins.concatStringsSep "\n," (map (
-                            wallpaper: ''"file://${builtins.path { path = wallpaper; }}"''
-                          ) cfg.workspace.wallpaper)
-                        }
+                        ${builtins.concatStringsSep "\n," (
+                          map (
+                            wallpaper:
+                            ''"file://${
+                              builtins.path {
+                                name = "plasma-wallpaper";
+                                path = wallpaper;
+                              }
+                            }"''
+                          ) cfg.workspace.wallpaper
+                        )}
                         ];
                         let image = images[desktop.screen];''
                     else
-                      ''let image = "file://${builtins.path { path = cfg.workspace.wallpaper; }}";''
+                      ''let image = "file://${
+                        builtins.path {
+                          name = "plasma-wallpaper";
+                          path = cfg.workspace.wallpaper;
+                        }
+                      }";''
                   }
                   if (image) {
                     desktop.writeConfig("Image", image);
                   }
-                  ${
-                    lib.optionalString (cfg.workspace.wallpaperFillMode != null)
-                      ''desktop.writeConfig("FillMode", "${
-                        toString wallpaperFillModeTypes.${cfg.workspace.wallpaperFillMode}
-                      }");''
+                  ${lib.optionalString (cfg.workspace.wallpaperFillMode != null)
+                    ''desktop.writeConfig("FillMode", "${
+                      toString wallpaperFillModeTypes.${cfg.workspace.wallpaperFillMode}
+                    }");''
                   }
-                  ${
-                    lib.optionalString (cfg.workspace.wallpaperBackground != null)
-                      ''desktop.writeConfig("${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
-                          "Blur"
-                        else if
-                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
-                        then
-                          "Color"
-                        else
-                          throw "plasma-manager: wallpaperBackground is not null and has no option set"
-                      }", "${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
-                          lib.boolToString cfg.workspace.wallpaperBackground.blur
-                        else if
-                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
-                        then
-                          cfg.workspace.wallpaperBackground.color
-                        else
-                          throw "plasma-manager: wallpaperBackground is not null and has no option set"
-                      }");''
+                  ${lib.optionalString (cfg.workspace.wallpaperBackground != null)
+                    ''desktop.writeConfig("${
+                      if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                        "Blur"
+                      else if
+                        cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
+                      then
+                        "Color"
+                      else
+                        throw "plasma-manager: wallpaperBackground is not null and has no option set"
+                    }", "${
+                      if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                        lib.boolToString cfg.workspace.wallpaperBackground.blur
+                      else if
+                        cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
+                      then
+                        cfg.workspace.wallpaperBackground.color
+                      else
+                        throw "plasma-manager: wallpaperBackground is not null and has no option set"
+                    }");''
                   }
               }
             '';
@@ -516,33 +525,31 @@ in
                   desktop.writeConfig("UpdateOverMeteredConnection", "${
                     if (cfg.workspace.wallpaperPictureOfTheDay.updateOverMeteredConnection) then "1" else "0"
                   }");
-                  ${
-                    lib.optionalString (cfg.workspace.wallpaperFillMode != null)
-                      ''desktop.writeConfig("FillMode", "${
-                        toString wallpaperFillModeTypes.${cfg.workspace.wallpaperFillMode}
-                      }");''
+                  ${lib.optionalString (cfg.workspace.wallpaperFillMode != null)
+                    ''desktop.writeConfig("FillMode", "${
+                      toString wallpaperFillModeTypes.${cfg.workspace.wallpaperFillMode}
+                    }");''
                   }
-                  ${
-                    lib.optionalString (cfg.workspace.wallpaperBackground != null)
-                      ''desktop.writeConfig("${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
-                          "Blur"
-                        else if
-                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
-                        then
-                          "Color"
-                        else
-                          throw "plasma-manager: wallpaperBackground is not null and has no option set"
-                      }", "${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
-                          lib.boolToString cfg.workspace.wallpaperBackground.blur
-                        else if
-                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
-                        then
-                          cfg.workspace.wallpaperBackground.color
-                        else
-                          throw "plasma-manager: wallpaperBackground is not null and has no option set"
-                      }");''
+                  ${lib.optionalString (cfg.workspace.wallpaperBackground != null)
+                    ''desktop.writeConfig("${
+                      if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                        "Blur"
+                      else if
+                        cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
+                      then
+                        "Color"
+                      else
+                        throw "plasma-manager: wallpaperBackground is not null and has no option set"
+                    }", "${
+                      if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                        lib.boolToString cfg.workspace.wallpaperBackground.blur
+                      else if
+                        cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
+                      then
+                        cfg.workspace.wallpaperBackground.color
+                      else
+                        throw "plasma-manager: wallpaperBackground is not null and has no option set"
+                    }");''
                   }
               }
             '';
@@ -583,33 +590,31 @@ in
                       "[" + (builtins.concatStringsSep "," (map (s: "\"" + s + "\"") path)) + "]"
                   });
                   desktop.writeConfig("SlideInterval", "${builtins.toString cfg.workspace.wallpaperSlideShow.interval}");
-                  ${
-                    lib.optionalString (cfg.workspace.wallpaperFillMode != null)
-                      ''desktop.writeConfig("FillMode", "${
-                        toString wallpaperFillModeTypes.${cfg.workspace.wallpaperFillMode}
-                      }");''
+                  ${lib.optionalString (cfg.workspace.wallpaperFillMode != null)
+                    ''desktop.writeConfig("FillMode", "${
+                      toString wallpaperFillModeTypes.${cfg.workspace.wallpaperFillMode}
+                    }");''
                   }
-                  ${
-                    lib.optionalString (cfg.workspace.wallpaperBackground != null)
-                      ''desktop.writeConfig("${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
-                          "Blur"
-                        else if
-                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
-                        then
-                          "Color"
-                        else
-                          throw "plasma-manager: wallpaperBackground is not null and has no option set"
-                      }", "${
-                        if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
-                          lib.boolToString cfg.workspace.wallpaperBackground.blur
-                        else if
-                          cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
-                        then
-                          cfg.workspace.wallpaperBackground.color
-                        else
-                          throw "plasma-manager: wallpaperBackground is not null and has no option set"
-                      }");''
+                  ${lib.optionalString (cfg.workspace.wallpaperBackground != null)
+                    ''desktop.writeConfig("${
+                      if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                        "Blur"
+                      else if
+                        cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
+                      then
+                        "Color"
+                      else
+                        throw "plasma-manager: wallpaperBackground is not null and has no option set"
+                    }", "${
+                      if cfg.workspace.wallpaperBackground ? blur && cfg.workspace.wallpaperBackground.blur != null then
+                        lib.boolToString cfg.workspace.wallpaperBackground.blur
+                      else if
+                        cfg.workspace.wallpaperBackground ? color && cfg.workspace.wallpaperBackground.color != null
+                      then
+                        cfg.workspace.wallpaperBackground.color
+                      else
+                        throw "plasma-manager: wallpaperBackground is not null and has no option set"
+                    }");''
                   }
               }
             '';

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -459,13 +459,13 @@ in
                         let images = [
                         ${
                           builtins.concatStringsSep "\n," (map (
-                            wallpaper: ''"file://${toString wallpaper}"''
+                            wallpaper: ''"file://${builtins.path { path = wallpaper; }}"''
                           ) cfg.workspace.wallpaper)
                         }
                         ];
                         let image = images[desktop.screen];''
                     else
-                      ''let image = "file://${toString cfg.workspace.wallpaper}";''
+                      ''let image = "file://${builtins.path { path = cfg.workspace.wallpaper; }}";''
                   }
                   if (image) {
                     desktop.writeConfig("Image", image);


### PR DESCRIPTION
Whilst configuring wallpapers ([kscreenlocker](https://nix-community.github.io/plasma-manager/options.xhtml#opt-programs.plasma.kscreenlocker.appearance.wallpaper) and [workspace](https://nix-community.github.io/plasma-manager/options.xhtml#opt-programs.plasma.workspace.wallpaper)) on my system, I noticed that everything appeared to work after a rebuild, but the wallpapers disappeared after garbage collecting and rebooting.

Previously, wallpapers were copied into the nix store and their paths written directly to the KDE configuration files, resulting in them lying around unreferenced in the nix store and eventually being removed by the garbage collector.

This change wraps wallpapers with `builtins.path { path = ...; }`, which imports them into the nix store as declared dependencies. This ensures that the wallpapers are part of the system closure and thus retained by the garbage collector as long as it is referenced by the system configuration.

I'm not sure whether this is the most idiomatic nix solution, but I've found it to work for me. I'm open to feedback and happy to adjust if there’s a better approach to this problem.