### PR TITLE
fix(workspace): make enableMiddleClickPaste option work

### DIFF
--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -365,14 +365,15 @@ in
                 Theme = cfg.workspace.splashScreen.theme;
               }
             );
-            kwinrc =
+            kwinrc = lib.mkMerge [
               (lib.mkIf (cfg.workspace.windowDecorations.theme != null) {
                 "org.kde.kdecoration2".library = cfg.workspace.windowDecorations.library;
                 "org.kde.kdecoration2".theme = cfg.workspace.windowDecorations.theme;
               })
-              // (lib.optionalAttrs (cfg.workspace.enableMiddleClickPaste != null) {
+              (lib.mkIf (cfg.workspace.enableMiddleClickPaste != null) {
                 Wayland.EnablePrimarySelection = cfg.workspace.enableMiddleClickPaste;
-              });
+              })
+            ];
           }
           # We add persistence to some keys in order to not reset the themes on
           # each generation when we use overrideConfig.


### PR DESCRIPTION
This pull request fixes the `programs.plasma.workspace.enableMiddleClickPaste` option, which currently does nothing.

---

For the curious, it does nothing because `mkIf` produces an attrset that looks like this:
```nix
{
  _type = "if";
  condition = foo;
  content = bar;
}
```
using the `//` update operator on this attrset does not have the intended effect:
```nix
{
  _type = "if";
  condition = foo;
  content = bar;
  MyNewAttribute = baz;
}
```
This results in `MyNewAttribute` (or, in the case of this pull request, `Wayland.EnablePrimarySelection`) getting completely ignored.