### PR TITLE
Added --compact arg to rc2nix.py for outputting nested Nix attr sets

### DIFF
--- a/script/rc2nix.py
+++ b/script/rc2nix.py
@@ -26,7 +26,8 @@ XDG_CONFIG_HOME: str = os.path.expanduser(os.getenv("XDG_CONFIG_HOME", "~/.confi
 XDG_DATA_HOME: str = os.path.expanduser(os.getenv("XDG_DATA_HOME", "~/.local/share"))
 indent_str = '  '
 
-nix_key_valid_chars = re.compile(r'^[a-z_][\w_-]*?$', flags=re.IGNORECASE)
+rx_nix_key_valid_chars = re.compile(r'^[a-z_][\w_-]*?$', flags=re.IGNORECASE)
+rx_shortcut_value_split = re.compile(r"(?<!\\),")
 
 
 class Rc2Nix:
@@ -284,8 +285,7 @@ class Rc2Nix:
 
                 for action in actions:
                     keys = (
-                        groups[group][action]
-                        .split(r"(?<!\\),")[0]
+                        rx_shortcut_value_split.split(groups[group][action])[0]
                         .replace(r"\?", ",")
                         .replace(r"\t", "\t")
                         .split("\t")
@@ -317,7 +317,7 @@ class Rc2Nix:
 
 
 def nix_key(key: str) -> str:
-    if nix_key_valid_chars.match(key):
+    if rx_nix_key_valid_chars.match(key):
         return key
     else:
         return f'"{key}"'

--- a/script/rc2nix.py
+++ b/script/rc2nix.py
@@ -36,6 +36,15 @@ def escape_key(key: str) -> str:
         return f'"{key}"'
 
 
+def to_nix_list(values: List[str], compact: bool, indent) -> str:
+    if compact and len(values) > 1:
+        join_str = f'\n{indent_str * (indent + 1)}'
+
+        return f"[{join_str}{join_str.join(values)}\n{indent_str * indent}]"
+    else:
+        return f"[{' '.join(values)}]"
+
+
 class Rc2Nix:
     # Files that we'll scan by default.
     KNOWN_CONFIG_FILES: List[str] = [
@@ -301,9 +310,7 @@ class Rc2Nix:
                     if not keys or keys[0] == "none":
                         keys_str = "[ ]"
                     elif len(keys) > 1:
-                        keys_str = (
-                            f"[{' '.join(nix_val(k.rstrip(',')) for k in keys)}]"
-                        )
+                        keys_str = to_nix_list([nix_val(k.rstrip(',')) for k in keys], self.compact, indent)
                     else:
                         ks = keys[0].split(",")
                         k = ks[0] if len(ks) == 3 and ks[0] == ks[1] else keys[0]

--- a/script/rc2nix.py
+++ b/script/rc2nix.py
@@ -29,22 +29,6 @@ indent_str = '  '
 nix_key_valid_chars = re.compile(r'^[a-z_][\w_-]*?$', flags=re.IGNORECASE)
 
 
-def escape_key(key: str) -> str:
-    if nix_key_valid_chars.match(key):
-        return key
-    else:
-        return f'"{key}"'
-
-
-def to_nix_list(values: List[str], compact: bool, indent) -> str:
-    if compact and len(values) > 1:
-        join_str = f'\n{indent_str * (indent + 1)}'
-
-        return f"[{join_str}{join_str.join(values)}\n{indent_str * indent}]"
-    else:
-        return f"[{' '.join(values)}]"
-
-
 class Rc2Nix:
     # Files that we'll scan by default.
     KNOWN_CONFIG_FILES: List[str] = [
@@ -198,10 +182,10 @@ class Rc2Nix:
             self.data_settings: Dict[str, Dict[str, Dict[str, str]]] = {}
 
             parser = argparse.ArgumentParser()
-            parser.add_argument('-c', '--compact', action='store_true', help='Use nested attribute sets in Nix conversion')
+            parser.add_argument('-n', '--nested-format', action='store_true', help='Use nested attribute sets in Nix conversion')
             _args = parser.parse_args()
 
-            self.compact = _args.compact
+            self.nested = _args.nested_format
 
         def run(self):
 
@@ -246,38 +230,38 @@ class Rc2Nix:
         def pp_settings(self, settings: Dict[str, Dict[str, Dict[str, str]]], indent: int) -> str:
             result: List[str] = []
 
-            ek = escape_key
+            ek = nix_key
 
             for file in sorted(settings.keys()):
                 if file != "kglobalshortcutsrc":
                     groups = sorted(settings[file].keys())
-                    groups_compact = self.compact and len(groups) > 1
+                    groups_nested = self.nested and len(groups) > 1
 
-                    if groups_compact:
+                    if groups_nested:
                         result.append(f"{indent_str * indent}{ek(file)} = {{")
                         indent += 1
 
                     for group in groups:
                         keys = sorted([a for a in settings[file][group].keys() if a != '_k_friendly_name'])
-                        keys_compact = self.compact and len(keys) > 1
+                        keys_nested = self.nested and len(keys) > 1
 
-                        if keys_compact:
+                        if keys_nested:
                             result.append(f"{indent_str * indent}{ek(group)} = {{")
                             indent += 1
 
                         for key in keys:
-                            if keys_compact:
+                            if keys_nested:
                                 result.append(f"{indent_str * indent}{ek(key)} = {nix_val(settings[file][group][key])};")
                             else:
                                 result.append(
                                     f"{indent_str * indent}{ek(file)}.{ek(group)}.{ek(key)} = {nix_val(settings[file][group][key])};"
                                 )
 
-                        if keys_compact:
+                        if keys_nested:
                             indent -= 1
                             result.append(f'{indent_str * indent}}};')
 
-                    if groups_compact:
+                    if groups_nested:
                         indent -= 1
                         result.append(f'{indent_str * indent}}};')
 
@@ -287,14 +271,14 @@ class Rc2Nix:
             if not groups:
                 return ""
 
-            ek = escape_key
+            ek = nix_key
 
             result: List[str] = []
             for group in sorted(groups.keys()):
                 actions = sorted([a for a in groups[group].keys() if a != '_k_friendly_name'])
-                compact = self.compact and len(actions) > 1
+                nested = self.nested and len(actions) > 1
 
-                if compact:
+                if nested:
                     result.append(f"{indent_str * indent}{ek(group)} = {{")
                     indent += 1
 
@@ -310,7 +294,7 @@ class Rc2Nix:
                     if not keys or keys[0] == "none":
                         keys_str = "[ ]"
                     elif len(keys) > 1:
-                        keys_str = to_nix_list([nix_val(k.rstrip(',')) for k in keys], self.compact, indent)
+                        keys_str = nix_list([nix_val(k.rstrip(',')) for k in keys], self.nested, indent)
                     else:
                         ks = keys[0].split(",")
                         k = ks[0] if len(ks) == 3 and ks[0] == ks[1] else keys[0]
@@ -320,16 +304,32 @@ class Rc2Nix:
                             else nix_val(k.rstrip(","))
                         )
 
-                    if compact:
+                    if nested:
                         result.append(f"{indent_str * indent}{ek(action)} = {keys_str};")
                     else:
                         result.append(f"{indent_str * indent}{ek(group)}.{ek(action)} = {keys_str};")
 
-                if compact:
+                if nested:
                     indent -= 1
                     result.append(f'{indent_str * indent}}};')
 
             return "\n".join(result)
+
+
+def nix_key(key: str) -> str:
+    if nix_key_valid_chars.match(key):
+        return key
+    else:
+        return f'"{key}"'
+
+
+def nix_list(values: List[str], nested: bool, indent: int) -> str:
+    if nested and len(values) > 1:
+        join_str = f'\n{indent_str * (indent + 1)}'
+
+        return f"[{join_str}{join_str.join(values)}\n{indent_str * indent}]"
+    else:
+        return f"[{' '.join(values)}]"
 
 
 def nix_val(s: Optional[str]) -> str:

--- a/script/rc2nix.py
+++ b/script/rc2nix.py
@@ -18,11 +18,22 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple, Union, TypeAlias
+import argparse
 
 # The root directory where configuration files are stored.
 XDG_CONFIG_HOME: str = os.path.expanduser(os.getenv("XDG_CONFIG_HOME", "~/.config"))
 XDG_DATA_HOME: str = os.path.expanduser(os.getenv("XDG_DATA_HOME", "~/.local/share"))
+indent_str = '  '
+
+nix_key_valid_chars = re.compile(r'^[a-z_][\w_-]*?$', flags=re.IGNORECASE)
+
+
+def escape_key(key: str) -> str:
+    if nix_key_valid_chars.match(key):
+        return key
+    else:
+        return f'"{key}"'
 
 
 class Rc2Nix:
@@ -163,11 +174,7 @@ class Rc2Nix:
                     f"{self.file_name}: setting outside of group: {key}={val}"
                 )
 
-            if (
-                should_skip_group(self.last_group)
-                or should_skip_key(key)
-                or should_skip_by_lambda(self.last_group, key)
-            ):
+            if should_skip_group(self.last_group) or should_skip_key(key) or should_skip_by_lambda(self.last_group, key):
                 return
 
             if self.last_group not in self.settings:
@@ -181,7 +188,14 @@ class Rc2Nix:
             self.config_settings: Dict[str, Dict[str, Dict[str, str]]] = {}
             self.data_settings: Dict[str, Dict[str, Dict[str, str]]] = {}
 
+            parser = argparse.ArgumentParser()
+            parser.add_argument('-c', '--compact', action='store_true', help='Use nested attribute sets in Nix conversion')
+            _args = parser.parse_args()
+
+            self.compact = _args.compact
+
         def run(self):
+
             for file in self.config_files:
                 if not os.path.exists(file):
                     continue
@@ -209,67 +223,105 @@ class Rc2Nix:
             print("  programs.plasma = {")
             print("    enable = true;")
             print("    shortcuts = {")
-            print(
-                self.pp_shortcuts(self.config_settings.get("kglobalshortcutsrc", {}), 6)
-            )
+            print(self.pp_shortcuts(self.config_settings.get("kglobalshortcutsrc", {}), 3))
             print("    };")
             print("    configFile = {")
-            print(self.pp_settings(self.config_settings, 6))
+            print(self.pp_settings(self.config_settings, 3))
             print("    };")
             print("    dataFile = {")
-            print(self.pp_settings(self.data_settings, 6))
+            print(self.pp_settings(self.data_settings, 3))
             print("    };")
             print("  };")
             print("}")
 
-        def pp_settings(
-            self, settings: Dict[str, Dict[str, Dict[str, str]]], indent: int
-        ) -> str:
+        def pp_settings(self, settings: Dict[str, Dict[str, Dict[str, str]]], indent: int) -> str:
             result: List[str] = []
+
+            ek = escape_key
+
             for file in sorted(settings.keys()):
                 if file != "kglobalshortcutsrc":
-                    for group in sorted(settings[file].keys()):
-                        for key in sorted(settings[file][group].keys()):
-                            if key != "_k_friendly_name":
+                    groups = sorted(settings[file].keys())
+                    groups_compact = self.compact and len(groups) > 1
+
+                    if groups_compact:
+                        result.append(f"{indent_str * indent}{ek(file)} = {{")
+                        indent += 1
+
+                    for group in groups:
+                        keys = sorted([a for a in settings[file][group].keys() if a != '_k_friendly_name'])
+                        keys_compact = self.compact and len(keys) > 1
+
+                        if keys_compact:
+                            result.append(f"{indent_str * indent}{ek(group)} = {{")
+                            indent += 1
+
+                        for key in keys:
+                            if keys_compact:
+                                result.append(f"{indent_str * indent}{ek(key)} = {nix_val(settings[file][group][key])};")
+                            else:
                                 result.append(
-                                    f"{' ' * indent}\"{file}\".\"{group}\".\"{key}\" = {nix_val(settings[file][group][key])};"
+                                    f"{indent_str * indent}{ek(file)}.{ek(group)}.{ek(key)} = {nix_val(settings[file][group][key])};"
                                 )
+
+                        if keys_compact:
+                            indent -= 1
+                            result.append(f'{indent_str * indent}}};')
+
+                    if groups_compact:
+                        indent -= 1
+                        result.append(f'{indent_str * indent}}};')
+
             return "\n".join(result)
 
         def pp_shortcuts(self, groups: Dict[str, Dict[str, str]], indent: int) -> str:
             if not groups:
                 return ""
 
+            ek = escape_key
+
             result: List[str] = []
             for group in sorted(groups.keys()):
-                for action in sorted(groups[group].keys()):
-                    if action != "_k_friendly_name":
-                        keys = (
-                            groups[group][action]
-                            .split(r"(?<!\\),")[0]
-                            .replace(r"\?", ",")
-                            .replace(r"\t", "\t")
-                            .split("\t")
+                actions = sorted([a for a in groups[group].keys() if a != '_k_friendly_name'])
+                compact = self.compact and len(actions) > 1
+
+                if compact:
+                    result.append(f"{indent_str * indent}{ek(group)} = {{")
+                    indent += 1
+
+                for action in actions:
+                    keys = (
+                        groups[group][action]
+                        .split(r"(?<!\\),")[0]
+                        .replace(r"\?", ",")
+                        .replace(r"\t", "\t")
+                        .split("\t")
+                    )
+
+                    if not keys or keys[0] == "none":
+                        keys_str = "[ ]"
+                    elif len(keys) > 1:
+                        keys_str = (
+                            f"[{' '.join(nix_val(k.rstrip(',')) for k in keys)}]"
+                        )
+                    else:
+                        ks = keys[0].split(",")
+                        k = ks[0] if len(ks) == 3 and ks[0] == ks[1] else keys[0]
+                        keys_str = (
+                            "[ ]"
+                            if k == "" or k == "none"
+                            else nix_val(k.rstrip(","))
                         )
 
-                        if not keys or keys[0] == "none":
-                            keys_str = "[ ]"
-                        elif len(keys) > 1:
-                            keys_str = (
-                                f"[{' '.join(nix_val(k.rstrip(',')) for k in keys)}]"
-                            )
-                        else:
-                            ks = keys[0].split(",")
-                            k = ks[0] if len(ks) == 3 and ks[0] == ks[1] else keys[0]
-                            keys_str = (
-                                "[ ]"
-                                if k == "" or k == "none"
-                                else nix_val(k.rstrip(","))
-                            )
+                    if compact:
+                        result.append(f"{indent_str * indent}{ek(action)} = {keys_str};")
+                    else:
+                        result.append(f"{indent_str * indent}{ek(group)}.{ek(action)} = {keys_str};")
 
-                        result.append(
-                            f"{' ' * indent}\"{group}\".\"{action}\" = {keys_str};"
-                        )
+                if compact:
+                    indent -= 1
+                    result.append(f'{indent_str * indent}}};')
+
             return "\n".join(result)
 
 


### PR DESCRIPTION
For me the way rc2nix.py outputs it's Nix conversion is unreadable. Not a criticism, just an accommodation I need, so I made it an option

When executing rc2nix.py with no arguments the output remains unchanged

```nix
{
  programs.plasma = {
    enable = true;
    shortcuts = {
      ActivityManager.switch-to-activity-1595ee1f-09c7-4e54-9969-1f629be88458 = [ ];
      "KDE Keyboard Layout Switcher"."Switch to Last-Used Keyboard Layout" = "Meta+Alt+L";
      "KDE Keyboard Layout Switcher"."Switch to Next Keyboard Layout" = "Meta+Alt+K";
      ksmserver."Lock Session" = [ "Meta+L" "Screensaver,Meta+L" "Screensaver,Lock Session" ];
      ...
    };
    ...
}
```

But with the -n|--nested-format argument it will nest the output, attr sets and lists with a single child remain in-line
```nix
{
  programs.plasma = {
    enable = true;
    shortcuts = {
      ActivityManager.switch-to-activity-1595ee1f-09c7-4e54-9969-1f629be88458 = [ ];
      "KDE Keyboard Layout Switcher" = {
        "Switch to Last-Used Keyboard Layout" = "Meta+Alt+L";
        "Switch to Next Keyboard Layout" = "Meta+Alt+K";
      };
      ksmserver."Lock Session" = [
        "Meta+L"
        "Screensaver,Meta+L"
        "Screensaver,Lock Session"
      ];
      ...
    };
    ...
}
```

I also introduced a minor change that will only quote keys when necessary using this regular expression

```^[a-z_][\w_-]*?$```

If the key begins with a letter or underscore, and the rest of the characters are all alphanumeric, underscore, or dash, it will not unnecessarily quote the key. I'm actually not 100% sure those are all the valid characters, but by making it inclusive it is fail-safe

Additional bugfixes:
- When splitting shortcut values, a regular expression pattern was being used but called in a way it was treating it as a literal string. Using the split function from re now. See [this comment](https://github.com/nix-community/plasma-manager/pull/534#issuecomment-3367374746) for an example