### PR TITLE
Kwin: add Blur Saturation option from Kwin 6.5.1

### DIFF
--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -265,12 +265,12 @@ in
           default = null;
           example = 8;
           description = "Adds noise to the blur effect.";
+        };
         saturation = lib.mkOption {
           type = with lib.types; nullOr (ints.between 0 10);
           default = null;
           example = 1;
           description = "Adds saturation to the blur effect.";
-        };
         };
       };
       snapHelper.enable = lib.mkOption {

--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -267,7 +267,7 @@ in
           description = "Adds noise to the blur effect.";
         };
         saturation = lib.mkOption {
-          type = with lib.types; nullOr (ints.between 0 10);
+          type = with lib.types; nullOr (ints.between 0 100);
           default = null;
           example = 1;
           description = "Adds saturation to the blur effect.";

--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -265,6 +265,12 @@ in
           default = null;
           example = 8;
           description = "Adds noise to the blur effect.";
+        saturation = lib.mkOption {
+          type = with lib.types; nullOr (ints.between 0 10);
+          default = null;
+          example = 1;
+          description = "Adds saturation to the blur effect.";
+        };
         };
       };
       snapHelper.enable = lib.mkOption {

--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -720,6 +720,7 @@ in
             Effect-blur = {
               BlurStrength = cfg.kwin.effects.blur.strength;
               NoiseStrength = cfg.kwin.effects.blur.noiseStrength;
+              Saturation = cfg.kwin.effects.blur.saturation;
             };
           })
           (lib.mkIf (cfg.kwin.effects.dimInactive.enable != null) {


### PR DESCRIPTION
Kwin 6.5.1 has changed the blur effect.

We can now use
```
[Effect-blur]
Saturation=3
```
to change the blur saturation.

This pull request simply adds this as an option.