### PR TITLE
fix(icon-tasks): add new horizontal position sort to enum

### DIFF
--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -167,6 +167,7 @@ in
               "alphabetically"
               "byDesktop"
               "byActivity"
+              "byHorizontalPosition"
             ];
           in
           mkOption {


### PR DESCRIPTION
Checked by setting it manually that `sortingStrategy=6`. (Added in 6.4)
