### PR TITLE
escape string values passed to writeConfig for widgets

### DIFF
--- a/modules/widgets/lib.nix
+++ b/modules/widgets/lib.nix
@@ -30,7 +30,7 @@ let
   valToJS =
     v:
     if (builtins.isString v) then
-      ''"${v}"''
+      ''${builtins.toJSON v}''
     else if (builtins.isBool v) then
       (lib.boolToString v)
     else


### PR DESCRIPTION
allows setting values that include things like double quotes

uses `toJSON` to take care of the escaping