### PR TITLE
feat(workspace): add widgetStyle option

### DIFF
--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -273,6 +273,15 @@ in
         '';
       };
     };
+
+    widgetStyle = lib.mkOption {
+      type = with lib.types; nullOr str;
+      default = null;
+      example = "breeze";
+      description = ''
+        The widget style to use with Plasma.
+      '';
+    };
   };
 
   config = (
@@ -343,6 +352,9 @@ in
             kdeglobals = {
               KDE.SingleClick = (
                 lib.mkIf (cfg.workspace.clickItemTo != null) (cfg.workspace.clickItemTo == "open")
+              );
+              KDE.widgetStyle = (
+                lib.mkIf (cfg.workspace.widgetStyle != null) (cfg.workspace.widgetStyle)
               );
               Sounds.Theme = (lib.mkIf (cfg.workspace.soundTheme != null) cfg.workspace.soundTheme);
             };


### PR DESCRIPTION
Adds `workspace.widgetStyle` to set the application/widget style as seen in system settings

Suggested in #543