### PR TITLE
shortcuts: do not escape commas in service shortcuts

### DIFF
--- a/modules/shortcuts.nix
+++ b/modules/shortcuts.nix
@@ -93,7 +93,6 @@
       mkGlobalShortcutFor =
         group: _action: skey:
         let
-          # Keys are expected to be a list:
           keys =
             if !builtins.isList skey then
               [ skey ]
@@ -101,18 +100,15 @@
               [ "none" ]
             else
               skey;
-
-          # Don't allow un-escaped commas:
-          escape = lib.escape [ "," ];
-          keysStr = builtins.concatStringsSep "\t" (map escape keys);
+          mkKeysString = lib.concatStringsSep "\t";
         in
 
-        # If the shortcut is not in the "services" group, we have to sanitize it.
+        # If the shortcut is not in the "services" group, we have to sanitise it.
         if lib.hasPrefix "services/" group then
-          keysStr
+          mkKeysString keys
         else
           lib.concatStringsSep "," [
-            keysStr
+            (mkKeysString (map (lib.escape [ "," ]) keys))
             "" # List of default keys, not needed.
             "" # Display string, not needed.
           ];


### PR DESCRIPTION
### Description

Currently, commas in the keys of shortcuts are escaped:
```
[kwin]
Show Desktop=Alt+\,

[services][foo.desktop]
_launch=Meta+\,
```
However, Plasma does not pick up the `foo.desktop` launch shortcut since it is malformed. By setting the shortcut through the UI, I found out that commas do not have to be escaped for shortcuts that are grouped under the `[services]` section, i.e. the corrected example would be
```
[kwin]
Show Desktop=Alt+\,

[services][foo.desktop]
_launch=Meta+,
```

This PR fixes this bug.

### Tests

I successfully tested this change on my own system.