### PR TITLE
fix(panels): set alignment manually to avoid resolution-specific assignment

### DIFF
--- a/lib/panel.nix
+++ b/lib/panel.nix
@@ -13,6 +13,12 @@ let
           ${cmd}
         }
       '';
+
+      plasmaPanelAlignment = {
+        left = "1";    # Qt::AlignLeft
+        center = "132";  # Qt::AlignCenter
+        right = "2";   # Qt::AlignRight
+      };
     in
     ''
       ${
@@ -27,7 +33,16 @@ let
         const panel = new Panel();
         panel.height = ${toString panel.height};
         panel.floating = ${boolToString panel.floating};
-        ${stringIfNotNull panel.alignment ''panel.alignment = "${panel.alignment}";''}
+
+        // Set the panel alignment directly using the config file
+        // Otherwise, it will be set specifically for the primary screen
+        if (panel.alignment) {
+          const shellConfig = ConfigFile("plasmashellrc");
+          shellConfig.group = "PlasmaViews";
+          const panelConfig = ConfigFile(shellConfig, "Panel " + panel.id);
+          panelConfig.writeEntry("alignment", ${plasmaPanelAlignment.${panel.alignment}});
+        }
+
         ${stringIfNotNull panel.hiding ''panel.hiding = "${panel.hiding}";''}
         ${stringIfNotNull panel.location ''panel.location = "${panel.location}";''}
         ${stringIfNotNull panel.lengthMode (plasma6OnlyCmd ''panel.lengthMode = "${panel.lengthMode}";'')}


### PR DESCRIPTION
To fix #550 I changed the panel creation script to set the alignment using the `ConfigFile` API instead of directly setting the alignment property on the created `Panel` object.

When set normally, the Plasma scripting API makes [alignment resolution-dependent](https://invent.kde.org/plasma/plasma-workspace/-/blob/master/shell/scripting/panel.cpp?ref_type=heads#L134-170), preventing it from applying when moved to a different screen. This is problematic when the panel is configured to show on the non-primary display.

This fix isn't ideal, but I couldn't come up with a better way to apply the property for all screens.