### PR TITLE
feat: declaratively install KDE cursor theme options

### DIFF
--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -168,6 +168,27 @@ in
       '';
     };
 
+    installedCursorThemes = lib.mkOption {
+      type = with lib.types; attrsOf package;
+      default = {};
+      example = {
+        "oreo_red_cursors" = pkgs.fetchzip {
+          name = "oreo_red_cursors";
+          url = "https://files06.pling.com/api/files/download/j/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MTY2MTA1Mzk2NiwibyI6IjEiLCJzIjoiZTQ4MzE1MmU2MzQwYTEzODA1YjY1ZjY2NjZiMjdmM2JiYTdkNzZkM2QyZDE2NTI5OWQ1MWY5YTYwYzU4YTAyNjBiZDI2ODFhMWI0MjE3N2NkZTk4ZGJlMmJhYTY1M2FkZTE0ZmU1YWYzZjY2MWUzMzZmZGQ1NTcxYzZlZWU3MmYiLCJ0IjoxNzY2MTg5Njg3LCJzdGZwIjpudWxsLCJzdGlwIjoiOTIuMjA2LjUuMjIxIn0.6r_mq5Ftfprj8xtrkJuv-6RFVCxE2eN53fdjlXb9irM/oreo-red-cursors.tar.gz";
+          hash = "sha256-Zr6Yvij/VGh0OjdrZHM4GN0G/ZjZkf4qLAyS3edSMzU=";
+        };
+      };
+      description = ''
+        Installs KDE cursor themes. You can supply them as [cursor files](https://develop.kde.org/docs/features/cursor/), or use a fetcher to download them.
+
+        Instructions on how to find the download link to content from the KDE store:
+        1) Browse api.kde-look.org/ocs/v1/content/categories in order to find the numerical ID of the `cursor` category.
+        2) Use the API search api.kde-look.org/ocs/v1/content/data?categories=<numeric id of category>&search=<searchterm> . The entries here contain real (== without timeouts or challanges) download links. Note that the supplied MD5 sums seem not to work with `fetchzip` for some reason.
+
+        I heavily recommend finding the exact name of what you search for in the regular (visual, non-API) KDE store first, as browsing is a lot easier there.
+      '';
+    };
+
     lookAndFeel = lib.mkOption {
       type = with lib.types; nullOr str;
       default = null;
@@ -353,24 +374,28 @@ in
           message = "programs.plasma.wallpaperBackground can only have a color or be blurred.";
         }
       ];
-      warnings = (
-        if
-          (
-            (cfg.workspace.lookAndFeel != null)
-            && (cfg.workspace.splashScreen.theme != null || cfg.workspace.windowDecorations.theme != null)
-          )
-        then
-          [
-            ''
-              Setting lookAndFeel together with splashScreen or windowDecorations in
-              plasma-manager is not recommended since lookAndFeel themes often
-              override these settings. Consider setting each part in the lookAndFeel
-              theme manually.
-            ''
-          ]
-        else
-          [ ]
-      );
+      warnings =
+        (lib.lists.optionals
+          ((cfg.workspace.lookAndFeel != null)
+          && (cfg.workspace.splashScreen.theme != null || cfg.workspace.windowDecorations.theme != null))
+        [
+          ''
+            Setting lookAndFeel together with splashScreen or windowDecorations in
+            plasma-manager is not recommended since lookAndFeel themes often
+            override these settings. Consider setting each part in the lookAndFeel
+            theme manually.
+          ''
+        ])
+        ++ (lib.lists.optionals ( cfg.workspace.cursor.theme != null && ! builtins.hasAttr cfg.workspace.cursor.theme cfg.workspace.installedCursorThemes)
+        [
+          ''
+            The cursor theme chosen in `config.home.plasma.workspace.cursor.theme` is not installed declaratively using `config.home.plasma.workspace.installedCursorThemes`.
+
+            If you use one of the default themes provided by KDE, you can safely ignore this warning.
+
+            If you manually installed the cursor theme in use consider declarative installation.
+          ''
+        ]);
 
       programs.plasma.configFile = (
         lib.mkMerge [
@@ -700,6 +725,8 @@ in
           }
         );
       };
+
+      xdg.dataFile = lib.attrsets.mapAttrs' (name : value: lib.attrsets.nameValuePair ( "icons/${name}") { source = value; } ) cfg.workspace.installedCursorThemes;
     }
   );
 }

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -197,7 +197,7 @@ in
     installedCursorThemes = lib.mkOption {
       type = with lib.types; attrsOf package;
       default = {};
-      example = lib.literalExpression ''"${./cursor}"'';
+      example = lib.literalExpression ''"''${./cursor}"'';
       description = "Download links of the KDE API do change all the time, therefore it is recommended to download your preferred theme and put it into your nix config.";
     };
 

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -169,27 +169,10 @@ in
     };
 
     installedCursorThemes = lib.mkOption {
-      type = with lib.types; attrsOf package;
+      type = with lib.types; attrsOf path;
       default = {};
-      example = {
-        "oreo_red_cursors" = lib.literalExpression
-          ''
-            pkgs.fetchzip {
-              name = "oreo_red_cursors";
-              url = "https://files06.pling.com/api/files/download/j/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MTY2MTA1Mzk2NiwibyI6IjEiLCJzIjoiZTQ4MzE1MmU2MzQwYTEzODA1YjY1ZjY2NjZiMjdmM2JiYTdkNzZkM2QyZDE2NTI5OWQ1MWY5YTYwYzU4YTAyNjBiZDI2ODFhMWI0MjE3N2NkZTk4ZGJlMmJhYTY1M2FkZTE0ZmU1YWYzZjY2MWUzMzZmZGQ1NTcxYzZlZWU3MmYiLCJ0IjoxNzY2MTg5Njg3LCJzdGZwIjpudWxsLCJzdGlwIjoiOTIuMjA2LjUuMjIxIn0.6r_mq5Ftfprj8xtrkJuv-6RFVCxE2eN53fdjlXb9irM/oreo-red-cursors.tar.gz";
-              hash = "sha256-Zr6Yvij/VGh0OjdrZHM4GN0G/ZjZkf4qLAyS3edSMzU=";
-            };
-          '';
-        };
-      description = ''
-        Installs KDE cursor themes. You can supply them as [cursor files](https://develop.kde.org/docs/features/cursor/), or use a fetcher to download them.
-
-        Instructions on how to find the download link to content from the KDE store:
-        1) Browse api.kde-look.org/ocs/v1/content/categories in order to find the numerical ID of the `cursor` category.
-        2) Use the API search api.kde-look.org/ocs/v1/content/data?categories=<numeric id of category>&search=<searchterm> . The entries here contain real (== without timeouts or challanges) download links. Note that the supplied MD5 sums seem not to work with `fetchzip` for some reason.
-
-        I heavily recommend finding the exact name of what you search for in the regular (visual, non-API) KDE store first, as browsing is a lot easier there.
-      '';
+      example = lib.literalExpression ''./cursor'';
+      description = "Download links of the KDE API do change all the time, therefore it is recommended to download your preferred theme and put it into your nix config.";
     };
 
     lookAndFeel = lib.mkOption {

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -721,6 +721,7 @@ in
         );
       };
 
+      # todo load data from path
       xdg.dataFile = lib.attrsets.mapAttrs' (name : value: lib.attrsets.nameValuePair ( "icons/${name}") { source = value; } ) cfg.workspace.installedCursorThemes;
     }
   );

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -169,9 +169,9 @@ in
     };
 
     installedCursorThemes = lib.mkOption {
-      type = with lib.types; attrsOf path;
+      type = with lib.types; attrsOf package;
       default = {};
-      example = lib.literalExpression ''./cursor'';
+      example = lib.literalExpression ''"${./cursor}"'';
       description = "Download links of the KDE API do change all the time, therefore it is recommended to download your preferred theme and put it into your nix config.";
     };
 

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -376,26 +376,35 @@ in
       ];
       warnings =
         (lib.lists.optionals
-          ((cfg.workspace.lookAndFeel != null)
-          && (cfg.workspace.splashScreen.theme != null || cfg.workspace.windowDecorations.theme != null))
-        [
-          ''
-            Setting lookAndFeel together with splashScreen or windowDecorations in
-            plasma-manager is not recommended since lookAndFeel themes often
-            override these settings. Consider setting each part in the lookAndFeel
-            theme manually.
-          ''
-        ])
-        ++ (lib.lists.optionals ( cfg.workspace.cursor.theme != null && ! builtins.hasAttr cfg.workspace.cursor.theme cfg.workspace.installedCursorThemes)
-        [
-          ''
-            The cursor theme chosen in `config.home.plasma.workspace.cursor.theme` is not installed declaratively using `config.home.plasma.workspace.installedCursorThemes`.
+          (
+            (cfg.workspace.lookAndFeel != null)
+            && (cfg.workspace.splashScreen.theme != null || cfg.workspace.windowDecorations.theme != null)
+          )
+          [
+            ''
+              Setting lookAndFeel together with splashScreen or windowDecorations in
+              plasma-manager is not recommended since lookAndFeel themes often
+              override these settings. Consider setting each part in the lookAndFeel
+              theme manually.
+            ''
+          ]
+        )
+        ++ (lib.lists.optionals
+          (
+            (cfg.workspace.cursor != null)
+            && (cfg.workspace.cursor.theme != null)
+            && !(builtins.hasAttr cfg.workspace.cursor.theme cfg.workspace.installedCursorThemes)
+          )
+          [
+            ''
+              The cursor theme chosen in `plasma.workspace.cursor.theme` is not installed declaratively using `plasma.workspace.installedCursorThemes`.
 
-            If you use one of the default themes provided by KDE, you can safely ignore this warning.
+              If you use one of the default themes provided by KDE, you can safely ignore this warning.
 
-            If you manually installed the cursor theme in use consider declarative installation.
-          ''
-        ]);
+              If you manually installed the cursor theme in use consider declarative installation.
+            ''
+          ]
+        );
 
       programs.plasma.configFile = (
         lib.mkMerge [

--- a/modules/workspace.nix
+++ b/modules/workspace.nix
@@ -172,12 +172,15 @@ in
       type = with lib.types; attrsOf package;
       default = {};
       example = {
-        "oreo_red_cursors" = pkgs.fetchzip {
-          name = "oreo_red_cursors";
-          url = "https://files06.pling.com/api/files/download/j/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MTY2MTA1Mzk2NiwibyI6IjEiLCJzIjoiZTQ4MzE1MmU2MzQwYTEzODA1YjY1ZjY2NjZiMjdmM2JiYTdkNzZkM2QyZDE2NTI5OWQ1MWY5YTYwYzU4YTAyNjBiZDI2ODFhMWI0MjE3N2NkZTk4ZGJlMmJhYTY1M2FkZTE0ZmU1YWYzZjY2MWUzMzZmZGQ1NTcxYzZlZWU3MmYiLCJ0IjoxNzY2MTg5Njg3LCJzdGZwIjpudWxsLCJzdGlwIjoiOTIuMjA2LjUuMjIxIn0.6r_mq5Ftfprj8xtrkJuv-6RFVCxE2eN53fdjlXb9irM/oreo-red-cursors.tar.gz";
-          hash = "sha256-Zr6Yvij/VGh0OjdrZHM4GN0G/ZjZkf4qLAyS3edSMzU=";
+        "oreo_red_cursors" = lib.literalExpression
+          ''
+            pkgs.fetchzip {
+              name = "oreo_red_cursors";
+              url = "https://files06.pling.com/api/files/download/j/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MTY2MTA1Mzk2NiwibyI6IjEiLCJzIjoiZTQ4MzE1MmU2MzQwYTEzODA1YjY1ZjY2NjZiMjdmM2JiYTdkNzZkM2QyZDE2NTI5OWQ1MWY5YTYwYzU4YTAyNjBiZDI2ODFhMWI0MjE3N2NkZTk4ZGJlMmJhYTY1M2FkZTE0ZmU1YWYzZjY2MWUzMzZmZGQ1NTcxYzZlZWU3MmYiLCJ0IjoxNzY2MTg5Njg3LCJzdGZwIjpudWxsLCJzdGlwIjoiOTIuMjA2LjUuMjIxIn0.6r_mq5Ftfprj8xtrkJuv-6RFVCxE2eN53fdjlXb9irM/oreo-red-cursors.tar.gz";
+              hash = "sha256-Zr6Yvij/VGh0OjdrZHM4GN0G/ZjZkf4qLAyS3edSMzU=";
+            };
+          '';
         };
-      };
       description = ''
         Installs KDE cursor themes. You can supply them as [cursor files](https://develop.kde.org/docs/features/cursor/), or use a fetcher to download them.
 


### PR DESCRIPTION
This PR adds the option to declaratively install KDE cursor themes.

(I believe that issue has come up in the past; but I can't seem to find that again now.)

If this is accepted I can add a similar feature for all the other places where KDE downloads themes from the store.

----

Further, I figured out how to download stuff from the KDE store, the following instructions should go to the wiki or something:

```
        Instructions on how to find the download link to content from the KDE store:
        1) Browse api.kde-look.org/ocs/v1/content/categories in order to find the numerical ID of the `cursor` category.
        2) Use the API search api.kde-look.org/ocs/v1/content/data?categories=<numeric id of category>&search=<searchterm> . The entries here contain real (== without timeouts or challanges) download links. Note that the supplied MD5 sums seem not to work with `fetchzip` for some reason.

        I heavily recommend finding the exact name of what you search for in the regular (visual, non-API) KDE store first, as browsing is a lot easier there.
```