### PR TITLE
konsole: allow defining custom colorschemes with Nix values

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -2,6 +2,9 @@
 let
   dontCheckModules = {
     _module.check = false;
+    _module.args = {
+      inherit pkgs lib;
+    };
   };
   modules = [
     ../modules

--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   inherit
     (import ../../lib/types.nix {
@@ -8,15 +13,7 @@ let
     basicSettingsType
     ;
 
-  # used as shown in the example in the library docs:
-  # https://noogle.dev/f/lib/attrsets/mapAttrs'
-  createColorSchemes = lib.attrsets.mapAttrs' (
-    name: value:
-    lib.attrsets.nameValuePair "konsole/${name}.colorscheme" {
-      enable = true;
-      source = value;
-    }
-  );
+  iniFormat = pkgs.formats.ini { };
 
   cfg = config.programs.konsole;
   profilesSubmodule = {
@@ -103,7 +100,12 @@ in
     };
 
     customColorSchemes = lib.mkOption {
-      type = with lib.types; attrsOf path;
+      type =
+        with lib.types;
+        attrsOf (oneOf [
+          path
+          iniFormat.type
+        ]);
       default = { };
       description = ''
         Custom color schemes to be added to the installation. The attribute key maps to their name.
@@ -185,7 +187,13 @@ in
           ) cfg.profiles
         )
       ))
-      (createColorSchemes cfg.customColorSchemes)
+      (lib.attrsets.mapAttrs' (
+        name: value:
+        lib.attrsets.nameValuePair "konsole/${name}.colorscheme" {
+          source =
+            if builtins.isPath value then value else iniFormat.generate "konsole-${name}.colorscheme" value;
+        }
+      ) cfg.customColorSchemes)
     ];
   };
 }

--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -107,6 +107,54 @@ in
           iniFormat.type
         ]);
       default = { };
+      example = lib.literalExpression ''
+        {
+          CustomTheme = ./CustomTheme.colorscheme;
+          Breeze = {
+            General = {
+              Anchor = "0.5,0.5";
+              Blur = true;
+              ColorRandomization = false;
+              Description = "Breeze";
+              FillStyle = "Tile";
+              Opacity = 0.96;
+              Wallpaper = ./cool-wallpaper.png;
+              WallpaperFlipType = "NoFlip";
+              WallpaperOpacity = 1;
+            };
+            Foreground.Color = "252,252,252";
+            ForegroundFaint.Color = "239,240,241";
+            ForegroundIntense.Color = "61,174,233";
+            Background.Color = "35,38,39";
+            BackgroundFaint.Color = "49,54,59";
+            BackgroundIntense.Color = "0,0,0";
+            Color0.Color = "35,38,39";
+            Color0Faint.Color = "49,54,59";
+            Color0Intense.Color = "127,140,141";
+            Color1.Color = "127,140,141";
+            Color1Faint.Color = "120,50,40";
+            Color1Intense.Color = "192,57,43";
+            Color2.Color = "17,209,22";
+            Color2Faint.Color = "23,162,98";
+            Color2Intense.Color = "28,220,154";
+            Color3.Color = "246,116,0";
+            Color3Faint.Color = "182,86,25";
+            Color3Intense.Color = "253,188,75";
+            Color4.Color = "29,153,243";
+            Color4Faint.Color = "27,102,143";
+            Color4Intense.Color = "61,174,233";
+            Color5.Color = "155,89,182";
+            Color5Faint.Color = "97,74,115";
+            Color5Intense.Color = "142,68,173";
+            Color6.Color = "26,188,156";
+            Color6Faint.Color = "24,108,96";
+            Color6Intense.Color = "22,160,133";
+            Color7.Color = "252,252,252";
+            Color7Faint.Color = "99,104,109";
+            Color7Intense.Color = "255,255,255";
+          }
+        }
+      '';
       description = ''
         Custom color schemes to be added to the installation. The attribute key maps to their name.
         Choose them in any profile with `profiles.<profile>.colorScheme = <name>`;


### PR DESCRIPTION
This approach allows further override of useful values like `Blur` and `Achor`.