### PR TITLE
fix(input): replace splitString with stringToCharacters, fix eval on Darwin

### DIFF
--- a/modules/input.nix
+++ b/modules/input.nix
@@ -367,25 +367,8 @@ in
   config.assertions = [
     (
       let
-        validChars = [
-          "0"
-          "1"
-          "2"
-          "3"
-          "4"
-          "5"
-          "6"
-          "7"
-          "8"
-          "9"
-          "a"
-          "b"
-          "c"
-          "d"
-          "e"
-          "f"
-        ];
-        hexChars = hexStr: builtins.tail (lib.reverseList (builtins.tail (lib.splitString "" hexStr)));
+        validChars = lib.stringToCharacters "0123456789abcdef";
+        hexChars = lib.stringToCharacters;
         hexCodeInvalid =
           hex:
           !(lib.all (c: builtins.elem (lib.toLower c) validChars) (hexChars hex))


### PR DESCRIPTION
## Problem
When running deployment or evaluation on macOS (Darwin), the configuration fails with:
`error: invalid regular expression ''`

This occurs in `modules/input.nix` where `lib.splitString ""` is used.

```
user@macOS ~> nix repl -f 'flake:nixpkgs'
Nix 2.31.2
Type :? for help.
Loading installable ''...
Added 25389 variables.
AAAAAASomeThingsFailToEvaluate, AMB-plugins, ArchiSteamFarm, AusweisApp2, CHOWTapeModel, ChowCentaur, ChowKick, ChowPhaser, CoinMP, CuboCore, DisnixWebService, EBTKS, EmptyEpsilon, FIL-plugins, Fabric, HentaiAtHome, LAStools, LASzip, LASzip2, LPCNet
... and 25369 more; view with :ll
nix-repl> hexChars = hexStr: builtins.tail (lib.reverseList (builtins.tail (lib.splitString "" hexStr)))
nix-repl> hexChars "1a2b"
error:
       … while calling the 'tail' builtin
         at «string»:1:10:
            1|  hexStr: builtins.tail (lib.reverseList (builtins.tail (lib.splitString "" hexStr)))
             |          ^

       … while calling the 'genList' builtin
         at /nix/store/llpp2pmwcm81h1j45bw4mz9ifxgfxmzj-source/lib/lists.nix:1107:5:
         1106|     in
         1107|     genList (n: elemAt xs (l - n - 1)) l;
             |     ^
         1108|

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: invalid regular expression ''

nix-repl> hexChars = lib.stringToCharacters 
nix-repl> hexChars "1a2b"                   
[
  "1"
  "a"
  "2"
  "b"
]
```

```
user@Linux ~> nix repl -f 'flake:nixpkgs'
Nix 2.31.2+2
Type :? for help.
Loading installable ''...
Added 25701 variables.
AAAAAASomeThingsFailToEvaluate, AMB-plugins, ArchiSteamFarm, AusweisApp2, CHOWTapeModel, ChowCentaur, ChowKick, ChowPhaser, CoinMP, CuboCore, DisnixWebService, EBTKS, EmptyEpsilon, FIL-plugins, Fabric, HentaiAtHome, LAStools, LASzip, LASzip2, LPCNet
... and 25681 more; view with :ll
nix-repl> hexChars = hexStr: builtins.tail (lib.reverseList (builtins.tail (lib.splitString "" hexStr)))
nix-repl> hexChars "1a2b"
[
  "b"
  "2"
  "a"
  "1"
]
nix-repl> hexChars = lib.stringToCharacters
nix-repl> hexChars "1a2b"
[
  "1"
  "a"
  "2"
  "b"
]
```

## Solution
I refactored the validation logic to use `lib.stringToCharacters` instead of `lib.splitString`. 

## Changes included
- Replaced the `hexChars` implementation with `lib.stringToCharacters`.
- Simplified `validChars` definition using the same function (removing the verbose list).