### PR TITLE
Fix possible values for vendorId

### DIFF
--- a/modules/input.nix
+++ b/modules/input.nix
@@ -88,7 +88,7 @@ let
         '';
       };
       vendorId = lib.mkOption {
-        type = lib.types.str;
+        type = with lib.types; nullOr str;
         default = null;
         example = "0911";
         description = ''


### PR DESCRIPTION
The default value for `programs.plasma.input.touchpads.*.vendorId` is null, but the allowed type is only str. This fixes the allowed type, which allows vendorId to be left undeclared when modifying other aspects of `programs.plasma.input.touchpads.*`.