### PR TITLE
Revert previous patch

### DIFF
--- a/modules/input.nix
+++ b/modules/input.nix
@@ -77,7 +77,7 @@ let
         '';
       };
       name = lib.mkOption {
-        type = with lib.types; nullOr str;
+        type = lib.types.str;
         default = null;
         example = "PNP0C50:00 0911:5288 Touchpad";
         description = ''
@@ -88,7 +88,7 @@ let
         '';
       };
       vendorId = lib.mkOption {
-        type = with lib.types; nullOr str;
+        type = lib.types.str;
         default = null;
         example = "0911";
         description = ''
@@ -99,7 +99,7 @@ let
         '';
       };
       productId = lib.mkOption {
-        type = with lib.types; nullOr str;
+        type = lib.types.str;
         default = null;
         example = "5288";
         description = ''

--- a/modules/input.nix
+++ b/modules/input.nix
@@ -77,7 +77,7 @@ let
         '';
       };
       name = lib.mkOption {
-        type = lib.types.str;
+        type = with lib.types; nullOr str;
         default = null;
         example = "PNP0C50:00 0911:5288 Touchpad";
         description = ''
@@ -99,7 +99,7 @@ let
         '';
       };
       productId = lib.mkOption {
-        type = lib.types.str;
+        type = with lib.types; nullOr str;
         default = null;
         example = "5288";
         description = ''


### PR DESCRIPTION
Sorry, I totally had it wrong!

`touchPadToConfig` uses `vendorId`, alongside `name` and `productId`, in order to merge into kcminputrc. I don't believe it's possible to set touchpad properties without specifying these values. Sorry!