### PR TITLE
Fixed example for twoFingerTap

### DIFF
--- a/modules/input.nix
+++ b/modules/input.nix
@@ -216,7 +216,7 @@ let
             "middleClick"
           ]);
         default = null;
-        example = "twoFingers";
+        example = "rightClick";
         description = ''
           Configure what a two-finger tap maps to on the touchpad.
         '';


### PR DESCRIPTION
The example for programs.plasma.inputs.touchpads.*.twoFingerTap was incorrectly set as "twoFinger". This is wrong, since the type only allows "rightClick" or "middleClick".
