### PR TITLE
disable startup notify for hotkeys

### DIFF
--- a/modules/hotkeys.nix
+++ b/modules/hotkeys.nix
@@ -88,6 +88,7 @@ in
     xdg.desktopEntries."${group.name}" = {
       name = group.description;
       noDisplay = true;
+      startupNotify = false;
       type = "Application";
       actions = lib.mapAttrs (_: command: {
         name = command.name;


### PR DESCRIPTION
StartupNotify will show a bouncing terminal icon at the mouse position. It is disabled by default for commands created in the system settings, so it makes sense to disable it here.

.desktop file created by system settings
```ini
[Desktop Entry]
Exec=kitten quick-access-terminal
Name=
NoDisplay=true
StartupNotify=false
Type=Application
X-KDE-GlobalAccel-CommandShortcut=true
```