### PR TITLE
docs: update from SDDM to Plasma Login

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ limitations don't hesitate to open an issue or submit a pr.
 ## What will not be supported
 There are some things which are out of bounds for this project due to technical
 reasons. For example
-- SDDM configuration (requires root-privileges and thus not suited for a `home-manager` module)
+- Plasma Login configuration (requires root-privileges and thus not suited for a `home-manager` module)
 
 ## Getting started
 We provide some examples to help you get started. These are located in the

--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756542300,
-        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
+        "lastModified": 1774709303,
+        "narHash": "sha256-D3Q07BbIA2KnTcSXIqqu9P586uWxN74zNoCH3h2ESHg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
         "type": "github"
       },
       "original": {

--- a/test/demo.nix
+++ b/test/demo.nix
@@ -39,7 +39,7 @@
       autoLogin.user = "fake";
       autoLogin.enable = true;
       defaultSession = "plasma";
-      sddm.enable = true;
+      plasma-login-manager.enable = true;
     };
     services.desktopManager.plasma6.enable = true;
 


### PR DESCRIPTION
Since Plasma 6.6, SDDM has been replaced by Plasma Login as the only officially supported (and maintained by KDE) login manager

### Important Notice

Plasma 6.6 is only available in nixpkgs unstable (26.05), not in the current stable (25.11) yet