### PR TITLE
feat(shortcuts): add per-app shortcut schemes

### DIFF
--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -50,14 +50,6 @@ let
       font = {
         name = lib.mkOption {
           type = lib.types.str;
-          /*
-            TODO: Set default to null after adding an assertion
-            Konsole needs to have a font set to be able to change font size
-            Since I couldn't get that to work I'll just set a default font
-            Not ideal since IMO we should only write things that are set explicitly
-            by the user but ehh it is what it is
-          */
-          default = "Hack";
           example = "Hack";
           description = ''
             Name of the font the profile should use.

--- a/modules/shortcuts.nix
+++ b/modules/shortcuts.nix
@@ -1,11 +1,18 @@
-# Global keyboard shortcuts:
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 let
+  attrsWith' =
+    placeholder: elemType:
+    lib.types.attrsWith {
+      inherit elemType placeholder;
+    };
+
+  keys = with lib.types; either str (listOf str);
+
   cfg = config.programs.plasma;
 
   # Convert one shortcut into a settings attribute set.
-  shortcutToConfigValue =
+  mkGlobalShortcutFor =
     group: _action: skey:
     let
       # Keys are expected to be a list:
@@ -32,49 +39,107 @@ let
         "" # Display string, not needed.
       ];
 
-  shortcutsToSettings = lib.mapAttrs (group: lib.mapAttrs (shortcutToConfigValue group));
-in
-{
-  options.programs.plasma.shortcuts = lib.mkOption {
-    description = ''
-      Global shortcuts; written to {file}`$XDG_CONFIG_HOME/kglobalshortcutsrc`.
+  mkGlobalShortcuts = lib.mapAttrs (group: lib.mapAttrs (mkGlobalShortcutFor group));
 
-      The outer key denotes the shortcuts group, the inner key denotes the
-      action to perform, and the value is the list of keys that trigger the
-      action.
-    '';
-    example = {
-      kmix = {
-        "decrease_volume" = [
-          "Volume Down"
-          "Meta+Down"
-        ];
-        "increase_volume" = [
-          "Volume Up"
-          "Meta+Up"
-        ];
+  xml = pkgs.formats.xml { };
+
+  mkShortcutSchemeFor =
+    let
+      mkAction = name: keys: {
+        "@name" = name;
+        "@shortcut" = lib.concatStringsSep "; " keys;
       };
-      kwin = {
-        "Switch One Desktop Down" = "Meta+J";
-        "Switch One Desktop Up" = "Meta+K";
-        "Switch One Desktop to the Left" = "Meta+H";
-        "Switch One Desktop to the Right" = "Meta+L";
+    in
+    app: scheme: {
+      gui = {
+        "@name" = app;
+        "@version" = "1";
+        ActionProperties.Action = lib.mapAttrsToList mkAction scheme;
       };
     };
-    default = { };
-    type =
-      let
-        attrsWith' =
-          placeholder: elemType:
-          lib.types.attrsWith {
-            inherit elemType placeholder;
+in
+{
+  options.programs.plasma = {
+
+    shortcuts = lib.mkOption {
+      description = ''
+        Global shortcuts; written to {file}`$XDG_CONFIG_HOME/kglobalshortcutsrc`.
+
+        The outer key denotes the shortcuts group, the inner key denotes the
+        action to perform, and the value is the list of keys that trigger the
+        action.
+      '';
+      example = {
+        kmix = {
+          "decrease_volume" = [
+            "Volume Down"
+            "Meta+Down"
+          ];
+          "increase_volume" = [
+            "Volume Up"
+            "Meta+Up"
+          ];
+        };
+        kwin = {
+          "Switch One Desktop Down" = "Meta+J";
+          "Switch One Desktop Up" = "Meta+K";
+          "Switch One Desktop to the Left" = "Meta+H";
+          "Switch One Desktop to the Right" = "Meta+L";
+        };
+      };
+      default = { };
+      type = attrsWith' "group" (attrsWith' "action" keys);
+    };
+
+    shortcutSchemes = lib.mkOption {
+      description = ''
+        Per-app shortcut schemes; written to {file}`$XDG_DATA_HOME/<app>/shortcuts/<scheme-name>`.
+
+        The outer key denotes the app, the middle key denotes the name of the
+        scheme, the inner key denotes the action to perform, and the value is
+        the list of keys that trigger the action.
+      '';
+      example = {
+        konsole.Custom = {
+          close-session = "Ctrl+Shift+W";
+          close-window = "Ctrl+Shift+Q";
+          new-window = "Ctrl+Shift+N";
+          new-tab = "Ctrl+Shift+T";
+        };
+        okular = {
+          Regular = {
+            go_goto_page = [
+              "G"
+              "Shift+G"
+              "Ctrl+G"
+            ];
+            first_page = "Home";
+            last_page = "End";
           };
-        keys = with lib.types; either str (listOf str);
-      in
-      attrsWith' "group" (attrsWith' "action" keys);
+          Vim = {
+            first_page = "G";
+            last_page = "Shift+G";
+          };
+        };
+      };
+      default = { };
+      type = attrsWith' "app" (attrsWith' "scheme-name" (attrsWith' "action" keys));
+      apply = lib.mapAttrsRecursive (_: v: if lib.isString v then [ v ] else v);
+    };
+
   };
 
   config = lib.mkIf cfg.enable {
-    programs.plasma.configFile."kglobalshortcutsrc" = shortcutsToSettings cfg.shortcuts;
+    programs.plasma.configFile."kglobalshortcutsrc" = mkGlobalShortcuts cfg.shortcuts;
+
+    xdg.dataFile = lib.concatMapAttrs (
+      app:
+      lib.mapAttrs' (
+        name: scheme: {
+          name = "${app}/shortcuts/${name}";
+          value.source = xml.generate "shortcuts-${app}-${name}" (mkShortcutSchemeFor app scheme);
+        }
+      )
+    ) cfg.shortcutSchemes;
   };
 }

--- a/modules/shortcuts.nix
+++ b/modules/shortcuts.nix
@@ -36,19 +36,42 @@ let
 in
 {
   options.programs.plasma.shortcuts = lib.mkOption {
-    type =
-      with lib.types;
-      attrsOf (
-        attrsOf (oneOf [
-          (listOf str)
-          str
-        ])
-      );
-    default = { };
     description = ''
-      An attribute set where the keys are application groups and the
-      values are shortcuts.
+      Global shortcuts; written to {file}`$XDG_CONFIG_HOME/kglobalshortcutsrc`.
+
+      The outer key denotes the shortcuts group, the inner key denotes the
+      action to perform, and the value is the list of keys that trigger the
+      action.
     '';
+    example = {
+      kmix = {
+        "decrease_volume" = [
+          "Volume Down"
+          "Meta+Down"
+        ];
+        "increase_volume" = [
+          "Volume Up"
+          "Meta+Up"
+        ];
+      };
+      kwin = {
+        "Switch One Desktop Down" = "Meta+J";
+        "Switch One Desktop Up" = "Meta+K";
+        "Switch One Desktop to the Left" = "Meta+H";
+        "Switch One Desktop to the Right" = "Meta+L";
+      };
+    };
+    default = { };
+    type =
+      let
+        attrsWith' =
+          placeholder: elemType:
+          lib.types.attrsWith {
+            inherit elemType placeholder;
+          };
+        keys = with lib.types; either str (listOf str);
+      in
+      attrsWith' "group" (attrsWith' "action" keys);
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/shortcuts.nix
+++ b/modules/shortcuts.nix
@@ -4,48 +4,35 @@
 let
   cfg = config.programs.plasma;
 
-  # Checks if the shortcut is in the "service" group, in which case we need to
-  # write the values a little differently.
-  isService =
-    group:
-    let
-      startString = "services/";
-    in
-    (builtins.substring 0 (builtins.stringLength startString) group) == startString;
-
   # Convert one shortcut into a settings attribute set.
   shortcutToConfigValue =
     group: _action: skey:
     let
       # Keys are expected to be a list:
       keys =
-        if builtins.isList skey then
-          (if ((builtins.length skey) == 0) then [ "none" ] else skey)
+        if !builtins.isList skey then
+          [ skey ]
+        else if skey == [ ] then
+          [ "none" ]
         else
-          [ skey ];
+          skey;
 
       # Don't allow un-escaped commas:
       escape = lib.escape [ "," ];
-      keysStr = (
-        if ((builtins.length keys) == 1) then
-          (escape (builtins.head keys))
-        else
-          builtins.concatStringsSep "\t" (map escape keys)
-      );
+      keysStr = builtins.concatStringsSep "\t" (map escape keys);
     in
-    (
-      if (isService group) then
-        keysStr
-      else
-        (lib.concatStringsSep "," [
-          keysStr
-          "" # List of default keys, not needed.
-          "" # Display string, not needed.
-        ])
-    );
 
-  shortcutsToSettings =
-    groups: lib.mapAttrs (group: attrs: (lib.mapAttrs (shortcutToConfigValue group) attrs)) groups;
+    # If the shortcut is not in the "services" group, we have to sanitize it.
+    if lib.hasPrefix "services/" group then
+      keysStr
+    else
+      lib.concatStringsSep "," [
+        keysStr
+        "" # List of default keys, not needed.
+        "" # Display string, not needed.
+      ];
+
+  shortcutsToSettings = lib.mapAttrs (group: lib.mapAttrs (shortcutToConfigValue group));
 in
 {
   options.programs.plasma.shortcuts = lib.mkOption {

--- a/modules/shortcuts.nix
+++ b/modules/shortcuts.nix
@@ -1,145 +1,152 @@
-{ config, lib, pkgs, ... }:
-
-let
-  attrsWith' =
-    placeholder: elemType:
-    lib.types.attrsWith {
-      inherit elemType placeholder;
-    };
-
-  keys = with lib.types; either str (listOf str);
-
-  cfg = config.programs.plasma;
-
-  # Convert one shortcut into a settings attribute set.
-  mkGlobalShortcutFor =
-    group: _action: skey:
-    let
-      # Keys are expected to be a list:
-      keys =
-        if !builtins.isList skey then
-          [ skey ]
-        else if skey == [ ] then
-          [ "none" ]
-        else
-          skey;
-
-      # Don't allow un-escaped commas:
-      escape = lib.escape [ "," ];
-      keysStr = builtins.concatStringsSep "\t" (map escape keys);
-    in
-
-    # If the shortcut is not in the "services" group, we have to sanitize it.
-    if lib.hasPrefix "services/" group then
-      keysStr
-    else
-      lib.concatStringsSep "," [
-        keysStr
-        "" # List of default keys, not needed.
-        "" # Display string, not needed.
-      ];
-
-  mkGlobalShortcuts = lib.mapAttrs (group: lib.mapAttrs (mkGlobalShortcutFor group));
-
-  xml = pkgs.formats.xml { };
-
-  mkShortcutSchemeFor =
-    let
-      mkAction = name: keys: {
-        "@name" = name;
-        "@shortcut" = lib.concatStringsSep "; " keys;
-      };
-    in
-    app: scheme: {
-      gui = {
-        "@name" = app;
-        "@version" = "1";
-        ActionProperties.Action = lib.mapAttrsToList mkAction scheme;
-      };
-    };
-in
 {
-  options.programs.plasma = {
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
-    shortcuts = lib.mkOption {
-      description = ''
-        Global shortcuts; written to {file}`$XDG_CONFIG_HOME/kglobalshortcutsrc`.
-
-        The outer key denotes the shortcuts group, the inner key denotes the
-        action to perform, and the value is the list of keys that trigger the
-        action.
-      '';
-      example = {
-        kmix = {
-          "decrease_volume" = [
-            "Volume Down"
-            "Meta+Down"
-          ];
-          "increase_volume" = [
-            "Volume Up"
-            "Meta+Up"
-          ];
+{
+  options.programs.plasma =
+    let
+      attrsWith' =
+        placeholder: elemType:
+        lib.types.attrsWith {
+          inherit elemType placeholder;
         };
-        kwin = {
-          "Switch One Desktop Down" = "Meta+J";
-          "Switch One Desktop Up" = "Meta+K";
-          "Switch One Desktop to the Left" = "Meta+H";
-          "Switch One Desktop to the Right" = "Meta+L";
-        };
-      };
-      default = { };
-      type = attrsWith' "group" (attrsWith' "action" keys);
-    };
+      keys = with lib.types; either str (listOf str);
+    in
+    {
 
-    shortcutSchemes = lib.mkOption {
-      description = ''
-        Per-app shortcut schemes; written to {file}`$XDG_DATA_HOME/<app>/shortcuts/<scheme-name>`.
+      shortcuts = lib.mkOption {
+        description = ''
+          Global shortcuts; written to {file}`$XDG_CONFIG_HOME/kglobalshortcutsrc`.
 
-        The outer key denotes the app, the middle key denotes the name of the
-        scheme, the inner key denotes the action to perform, and the value is
-        the list of keys that trigger the action.
-      '';
-      example = {
-        konsole.Custom = {
-          close-session = "Ctrl+Shift+W";
-          close-window = "Ctrl+Shift+Q";
-          new-window = "Ctrl+Shift+N";
-          new-tab = "Ctrl+Shift+T";
-        };
-        okular = {
-          Regular = {
-            go_goto_page = [
-              "G"
-              "Shift+G"
-              "Ctrl+G"
+          The outer key denotes the shortcuts group, the inner key denotes the
+          action to perform, and the value is the list of keys that trigger the
+          action.
+        '';
+        example = {
+          kmix = {
+            "decrease_volume" = [
+              "Volume Down"
+              "Meta+Down"
             ];
-            first_page = "Home";
-            last_page = "End";
+            "increase_volume" = [
+              "Volume Up"
+              "Meta+Up"
+            ];
           };
-          Vim = {
-            first_page = "G";
-            last_page = "Shift+G";
+          kwin = {
+            "Switch One Desktop Down" = "Meta+J";
+            "Switch One Desktop Up" = "Meta+K";
+            "Switch One Desktop to the Left" = "Meta+H";
+            "Switch One Desktop to the Right" = "Meta+L";
           };
         };
+        default = { };
+        type = attrsWith' "group" (attrsWith' "action" keys);
       };
-      default = { };
-      type = attrsWith' "app" (attrsWith' "scheme-name" (attrsWith' "action" keys));
-      apply = lib.mapAttrsRecursive (_: v: if lib.isString v then [ v ] else v);
+
+      shortcutSchemes = lib.mkOption {
+        description = ''
+          Per-app shortcut schemes; written to {file}`$XDG_DATA_HOME/<app>/shortcuts/<scheme-name>`.
+
+          The outer key denotes the app, the middle key denotes the name of the
+          scheme, the inner key denotes the action to perform, and the value is
+          the list of keys that trigger the action.
+        '';
+        example = {
+          konsole.Custom = {
+            close-session = "Ctrl+Shift+W";
+            close-window = "Ctrl+Shift+Q";
+            new-window = "Ctrl+Shift+N";
+            new-tab = "Ctrl+Shift+T";
+          };
+          okular = {
+            Regular = {
+              go_goto_page = [
+                "G"
+                "Shift+G"
+                "Ctrl+G"
+              ];
+              first_page = "Home";
+              last_page = "End";
+            };
+            Vim = {
+              first_page = "G";
+              last_page = "Shift+G";
+            };
+          };
+        };
+        default = { };
+        type = attrsWith' "app" (attrsWith' "scheme-name" (attrsWith' "action" keys));
+        apply = lib.mapAttrsRecursive (_: v: if lib.isString v then [ v ] else v);
+      };
+
     };
 
-  };
+  config =
+    let
+      cfg = config.programs.plasma;
 
-  config = lib.mkIf cfg.enable {
-    programs.plasma.configFile."kglobalshortcutsrc" = mkGlobalShortcuts cfg.shortcuts;
+      # Convert one shortcut into a settings attribute set.
+      mkGlobalShortcutFor =
+        group: _action: skey:
+        let
+          # Keys are expected to be a list:
+          keys =
+            if !builtins.isList skey then
+              [ skey ]
+            else if skey == [ ] then
+              [ "none" ]
+            else
+              skey;
 
-    xdg.dataFile = lib.concatMapAttrs (
-      app:
-      lib.mapAttrs' (
-        name: scheme: {
-          name = "${app}/shortcuts/${name}";
-          value.source = xml.generate "shortcuts-${app}-${name}" (mkShortcutSchemeFor app scheme);
-        }
-      )
-    ) cfg.shortcutSchemes;
-  };
+          # Don't allow un-escaped commas:
+          escape = lib.escape [ "," ];
+          keysStr = builtins.concatStringsSep "\t" (map escape keys);
+        in
+
+        # If the shortcut is not in the "services" group, we have to sanitize it.
+        if lib.hasPrefix "services/" group then
+          keysStr
+        else
+          lib.concatStringsSep "," [
+            keysStr
+            "" # List of default keys, not needed.
+            "" # Display string, not needed.
+          ];
+
+      mkGlobalShortcuts = lib.mapAttrs (group: lib.mapAttrs (mkGlobalShortcutFor group));
+
+      xml = pkgs.formats.xml { };
+
+      mkShortcutSchemeFor =
+        let
+          mkAction = name: keys: {
+            "@name" = name;
+            "@shortcut" = lib.concatStringsSep "; " keys;
+          };
+        in
+        app: scheme: {
+          gui = {
+            "@name" = app;
+            "@version" = "1";
+            ActionProperties.Action = lib.mapAttrsToList mkAction scheme;
+          };
+        };
+    in
+    lib.mkIf cfg.enable {
+      programs.plasma.configFile."kglobalshortcutsrc" = mkGlobalShortcuts cfg.shortcuts;
+
+      xdg.dataFile = lib.concatMapAttrs (
+        app:
+        lib.mapAttrs' (
+          name: scheme: {
+            name = "${app}/shortcuts/${name}";
+            value.source = xml.generate "shortcuts-${app}-${name}" (mkShortcutSchemeFor app scheme);
+          }
+        )
+      ) cfg.shortcutSchemes;
+    };
 }


### PR DESCRIPTION
This PR mainly adds support per-app shortcut schemes. I have successfully been using the per-app shortcut schemes for almost a year on my systems and want to upstream it know.

While implementing per-app shortcut schemes, I also

- simplified the shortcuts module,
- extended the documentation for `programs.plasma.shortcuts`, and
- resolved a todo in the Konsole module that mentioned to explicitly require the user setting a font in their profile definition.
