### PR TITLE
chore(nix): fix short path literals in `flake.nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
             (inputs.nixpkgs.lib.nixosSystem {
               inherit system;
               modules = [
-                (import test/demo.nix {
+                (import ./test/demo.nix {
                   home-manager-module = inputs.home-manager.nixosModules.home-manager;
                   plasma-module = self.homeManagerModules.plasma-manager;
                 })
@@ -65,7 +65,7 @@
           rc2nix = pkgs.writeShellApplication {
             name = "rc2nix";
             runtimeInputs = with pkgs; [ python3 ];
-            text = ''python3 ${script/rc2nix.py} "$@"'';
+            text = ''python3 ${./script/rc2nix.py} "$@"'';
           };
         }
       );


### PR DESCRIPTION
Nix 2.34 includes a new option, `lint-short-path-literals`, which can be configured to warn or fail when a relative path is evaluated without the long-form `./` or `../` suffixes. Consistently using the suffixes is considered a best practice for code readability.

For more information, see https://nix.dev/manual/nix/2.34/command-ref/conf-file#conf-lint-short-path-literals.