### PR TITLE
fix(ci,example): set the file system type and disable polonium

### DIFF
--- a/examples/home.nix
+++ b/examples/home.nix
@@ -251,8 +251,6 @@
     kwin = {
       edgeBarrier = 0; # Disables the edge-barriers introduced in plasma 6.1
       cornerBarrier = false;
-
-      scripts.polonium.enable = true;
     };
 
     kscreenlocker = {

--- a/examples/systemFlake/flake.nix
+++ b/examples/systemFlake/flake.nix
@@ -40,7 +40,10 @@
           {
             system.stateVersion = "23.11";
             users.users."${username}".isNormalUser = true;
-            fileSystems."/".device = "/dev/sda";
+            fileSystems."/" = {
+              device = "/dev/sda";
+              fsType = "ext4";
+            };
             boot.loader.grub.devices = [ "/dev/sda" ];
           }
 


### PR DESCRIPTION
The CI pipeline fails since,
- as of NixOS 26.05, `fileSystems.*.fsType` has no default value, and
- polonium has been removed from nixpkgs since Plasma 5 reached EOL.

Hence, set the file system type to `ext4` and disable polonium.
