### PR TITLE
Per-screen desktop widget support

### DIFF
--- a/modules/desktop.nix
+++ b/modules/desktop.nix
@@ -525,10 +525,7 @@ in
                 });
               });
 
-              for (let i = 0; i < allDesktops.length; i++) {
-                const desktop = allDesktops[i];
-                ${widgets.lib.addDesktopWidgetStmts "desktop" "desktopWidgets" cfg.desktop.widgets}
-              }
+              ${widgets.lib.addDesktopWidgetStmts "desktopWidgets" cfg.desktop.widgets}
             '';
             priority = 2;
           }

--- a/modules/widgets/app-menu.nix
+++ b/modules/widgets/app-menu.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 let
   inherit (import ./lib.nix { inherit lib; }) configValueType;
-  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType screenType;
 
   mkBoolOption =
     description:
@@ -30,6 +30,16 @@ in
           height = 50;
         };
         description = "The size of the widget. (Only for desktop widget)";
+      };
+      screen = lib.mkOption {
+        type = screenType;
+        default = null;
+        description = ''
+          The screen the widget should appear on. (Only for desktop widget)
+          Can be an `int`, or a `list of ints`, starting from `0`, representing
+          the ID of the screen the widget should appear on. Alternatively, it
+          can be set to `all` if the widget should appear on all the screens.
+        '';
       };
       compactView = mkBoolOption "Whether to show the app menu in a compact view";
       settings = lib.mkOption {

--- a/modules/widgets/application-title-bar.nix
+++ b/modules/widgets/application-title-bar.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 let
   inherit (import ./lib.nix { inherit lib; }) configValueType;
-  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType screenType; 
 
   elements = [
     "windowCloseButton"
@@ -185,6 +185,16 @@ in
           height = 50;
         };
         description = "The size of the widget. (Only for desktop widget)";
+      };
+      screen = lib.mkOption {
+        type = screenType;
+        default = null;
+        description = ''
+          The screen the widget should appear on. (Only for desktop widget)
+          Can be an `int`, or a `list of ints`, starting from `0`, representing
+          the ID of the screen the widget should appear on. Alternatively, it
+          can be set to `all` if the widget should appear on all the screens.
+        '';
       };
       layout = {
         widgetMargins = lib.mkOption {

--- a/modules/widgets/battery.nix
+++ b/modules/widgets/battery.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 let
   inherit (import ./lib.nix { inherit lib; }) configValueType;
-  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType screenType;
 in
 {
   battery = {
@@ -24,6 +24,16 @@ in
           height = 500;
         };
         description = "The size of the widget. (Only for desktop widget)";
+      };
+      screen = lib.mkOption {
+        type = screenType;
+        default = null;
+        description = ''
+          The screen the widget should appear on. (Only for desktop widget)
+          Can be an `int`, or a `list of ints`, starting from `0`, representing
+          the ID of the screen the widget should appear on. Alternatively, it
+          can be set to `all` if the widget should appear on all the screens.
+        '';
       };
       showPercentage = lib.mkOption {
         type = with lib.types; nullOr bool;

--- a/modules/widgets/default.nix
+++ b/modules/widgets/default.nix
@@ -54,6 +54,13 @@ let
     };
   };
 
+  screenType = with lib.types;
+    nullOr (oneOf [
+      ints.unsigned
+      (listOf ints.unsigned)
+      (enum [ "all" ])
+    ]);
+
   compositeWidgetType = lib.pipe sources [
     (builtins.mapAttrs (
       _: s:
@@ -129,6 +136,16 @@ let
         };
         description = "The size of the widget.";
       };
+      screen = lib.mkOption {
+        type = screenType;
+        default = null;
+        description = ''
+          The screen the widget should appear on. (Only for desktop widget)
+          Can be an `int`, or a `list of ints`, starting from `0`, representing
+          the ID of the screen the widget should appear on. Alternatively, it
+          can be set to `all` if the widget should appear on all the screens.
+        '';
+      };
       config = lib.mkOption {
         type = (import ./lib.nix (args // { widgets = self; })).configValueType;
         default = null;
@@ -164,7 +181,7 @@ let
   isKnownWidget = lib.flip builtins.hasAttr sources;
 
   self = {
-    inherit isKnownWidget positionType sizeType;
+    inherit isKnownWidget positionType sizeType screenType;
 
     type = lib.types.oneOf [
       lib.types.str
@@ -214,6 +231,7 @@ let
               widget.${type}.size
             else
               (throw "Desktop widget requires a size");
+          screen = widget.${type}.screen;
         }
       else
         widget; # not a known composite type

--- a/modules/widgets/digital-clock.nix
+++ b/modules/widgets/digital-clock.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib) mkOption types;
   inherit (import ./lib.nix { inherit lib; }) configValueType;
-  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType screenType;
 
   mkBoolOption =
     description:
@@ -70,6 +70,16 @@ in
           height = 500;
         };
         description = "The size of the widget. (Only for desktop widget)";
+      };
+      screen = lib.mkOption {
+        type = screenType;
+        default = null;
+        description = ''
+          The screen the widget should appear on. (Only for desktop widget)
+          Can be an `int`, or a `list of ints`, starting from `0`, representing
+          the ID of the screen the widget should appear on. Alternatively, it
+          can be set to `all` if the widget should appear on all the screens.
+        '';
       };
       date = {
         enable = mkBoolOption "Enable showing the current date.";

--- a/modules/widgets/icon-tasks.nix
+++ b/modules/widgets/icon-tasks.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib) mkOption types;
   inherit (import ./lib.nix { inherit lib; }) configValueType;
-  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType screenType;
 
   mkBoolOption =
     description:
@@ -67,6 +67,16 @@ in
           height = 500;
         };
         description = "The size of the widget. (Only for desktop widget)";
+      };
+      screen = lib.mkOption {
+        type = screenType;
+        default = null;
+        description = ''
+          The screen the widget should appear on. (Only for desktop widget)
+          Can be an `int`, or a `list of ints`, starting from `0`, representing
+          the ID of the screen the widget should appear on. Alternatively, it
+          can be set to `all` if the widget should appear on all the screens.
+        '';
       };
       launchers = mkOption {
         type = types.nullOr (types.listOf types.str);

--- a/modules/widgets/keyboard-layout.nix
+++ b/modules/widgets/keyboard-layout.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 let
   inherit (import ./lib.nix { inherit lib; }) configValueType;
-  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType screenType;
 
   getIndexFromEnum =
     enum: value:
@@ -32,6 +32,16 @@ in
           height = 500;
         };
         description = "The size of the widget. (Only for desktop widget)";
+      };
+      screen = lib.mkOption {
+        type = screenType;
+        default = null;
+        description = ''
+          The screen the widget should appear on. (Only for desktop widget)
+          Can be an `int`, or a `list of ints`, starting from `0`, representing
+          the ID of the screen the widget should appear on. Alternatively, it
+          can be set to `all` if the widget should appear on all the screens.
+        '';
       };
       displayStyle =
         let

--- a/modules/widgets/kicker.nix
+++ b/modules/widgets/kicker.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib) mkOption types;
   inherit (import ./lib.nix { inherit lib; }) configValueType;
-  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType screenType;
 
   mkBoolOption =
     description:
@@ -55,6 +55,16 @@ in
           height = 500;
         };
         description = "The size of the widget. (Only for desktop widget)";
+      };
+      screen = lib.mkOption {
+        type = screenType;
+        default = null;
+        description = ''
+          The screen the widget should appear on. (Only for desktop widget)
+          Can be an `int`, or a `list of ints`, starting from `0`, representing
+          the ID of the screen the widget should appear on. Alternatively, it
+          can be set to `all` if the widget should appear on all the screens.
+        '';
       };
       icon = mkOption {
         type = types.nullOr types.str;

--- a/modules/widgets/kickerdash.nix
+++ b/modules/widgets/kickerdash.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib) mkOption types;
   inherit (import ./lib.nix { inherit lib; }) configValueType;
-  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType screenType;
 
   mkBoolOption =
     description:
@@ -51,6 +51,16 @@ in
           height = 500;
         };
         description = "The size of the widget. (Only for desktop widget)";
+      };
+      screen = lib.mkOption {
+        type = screenType;
+        default = null;
+        description = ''
+          The screen the widget should appear on. (Only for desktop widget)
+          Can be an `int`, or a `list of ints`, starting from `0`, representing
+          the ID of the screen the widget should appear on. Alternatively, it
+          can be set to `all` if the widget should appear on all the screens.
+        '';
       };
       icon = mkOption {
         type = types.nullOr types.str;

--- a/modules/widgets/kickoff.nix
+++ b/modules/widgets/kickoff.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 let
   inherit (import ./lib.nix { inherit lib; }) configValueType;
-  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType screenType;
 
   mkBoolOption =
     description:
@@ -54,6 +54,16 @@ in
           height = 500;
         };
         description = "The size of the widget. (Only for desktop widget)";
+      };
+      screen = lib.mkOption {
+        type = screenType;
+        default = null;
+        description = ''
+          The screen the widget should appear on. (Only for desktop widget)
+          Can be an `int`, or a `list of ints`, starting from `0`, representing
+          the ID of the screen the widget should appear on. Alternatively, it
+          can be set to `all` if the widget should appear on all the screens.
+        '';
       };
       icon = lib.mkOption {
         type = with lib.types; nullOr str;

--- a/modules/widgets/lib.nix
+++ b/modules/widgets/lib.nix
@@ -94,7 +94,7 @@ let
     '';
 
   addDesktopWidgetStmts =
-    containment: var: ws:
+    var: ws:
     let
       widgetConfigsToStmts =
         { name, config, ... }:
@@ -103,20 +103,35 @@ let
           ${setWidgetSettings "w" config}
         '';
 
+      screenFilterFor =
+        screen:
+        if builtins.isList screen then
+          ''d => [${concatMapStringsSep ", " (map valToJS screen)}].indexOf(d.screen) !== -1''
+        else if builtins.isInt screen then
+          ''d => d.screen === ${toString screen}''
+        else
+          "d => true";
+
       addStmt =
         {
           name,
           position,
           size,
+          screen,
           config,
           extraConfig,
         }@widget:
+        let
+          screenFilter = screenFilterFor screen;
+        in
         ''
-          ${var}["${name}"] = ${containment}.addWidget("${name}", ${toString position.horizontal}, ${toString position.vertical}, ${toString size.width}, ${toString size.height});
-          ${stringIfNotNull config (widgetConfigsToStmts widget)}
-          ${lib.optionalString (extraConfig != "") ''
-            (${extraConfig})(${var}["${name}"]);
-          ''}
+          for (const desktop of allDesktops.filter(${screenFilter})) {
+            ${var}["${name}"] = desktop.addWidget("${name}", ${toString position.horizontal}, ${toString position.vertical}, ${toString size.width}, ${toString size.height});
+            ${stringIfNotNull config (widgetConfigsToStmts widget)}
+            ${lib.optionalString (extraConfig != "") ''
+              (${extraConfig})(${var}["${name}"]);
+            ''}
+          }
         '';
     in
     ''

--- a/modules/widgets/pager.nix
+++ b/modules/widgets/pager.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 let
   inherit (import ./lib.nix { inherit lib; }) configValueType;
-  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType screenType;
 
   mkBoolOption =
     description:
@@ -40,6 +40,16 @@ in
           height = 500;
         };
         description = "The size of the widget. (Only for desktop widget)";
+      };
+      screen = lib.mkOption {
+        type = screenType;
+        default = null;
+        description = ''
+          The screen the widget should appear on. (Only for desktop widget)
+          Can be an `int`, or a `list of ints`, starting from `0`, representing
+          the ID of the screen the widget should appear on. Alternatively, it
+          can be set to `all` if the widget should appear on all the screens.
+        '';
       };
       general = {
         showWindowOutlines = mkBoolOption "Whether to show window outlines";

--- a/modules/widgets/panel-spacer.nix
+++ b/modules/widgets/panel-spacer.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 let
   inherit (import ./lib.nix { inherit lib; }) configValueType;
-  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType screenType;
 
   mkBoolOption =
     description:
@@ -30,6 +30,16 @@ in
           height = 50;
         };
         description = "The size of the widget. (Only for desktop widget)";
+      };
+      screen = lib.mkOption {
+        type = screenType;
+        default = null;
+        description = ''
+          The screen the widget should appear on. (Only for desktop widget)
+          Can be an `int`, or a `list of ints`, starting from `0`, representing
+          the ID of the screen the widget should appear on. Alternatively, it
+          can be set to `all` if the widget should appear on all the screens.
+        '';
       };
       expanding = mkBoolOption "Whether the spacer should expand to fill the available space.";
       length = lib.mkOption {

--- a/modules/widgets/plasma-panel-colorizer.nix
+++ b/modules/widgets/plasma-panel-colorizer.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib) mkOption types;
   inherit (import ./lib.nix { inherit lib; }) configValueType;
-  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType screenType;
 
   mkBoolOption =
     description:
@@ -114,6 +114,16 @@ in
           height = 500;
         };
         description = "The size of the widget. (Only for desktop widget)";
+      };
+      screen = lib.mkOption {
+        type = screenType;
+        default = null;
+        description = ''
+          The screen the widget should appear on. (Only for desktop widget)
+          Can be an `int`, or a `list of ints`, starting from `0`, representing
+          the ID of the screen the widget should appear on. Alternatively, it
+          can be set to `all` if the widget should appear on all the screens.
+        '';
       };
       general = {
         enable = mkBoolOption "Whether to enable the widget";

--- a/modules/widgets/plasmusic-toolbar.nix
+++ b/modules/widgets/plasmusic-toolbar.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 let
   inherit (import ./lib.nix { inherit lib; }) configValueType;
-  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType screenType;
 
   qfont = import ../../lib/qfont.nix { inherit lib; };
 
@@ -234,6 +234,16 @@ in
           height = 100;
         };
         description = "The size of the widget. (Only for desktop widget)";
+      };
+      screen = lib.mkOption {
+        type = screenType;
+        default = null;
+        description = ''
+          The screen the widget should appear on. (Only for desktop widget)
+          Can be an `int`, or a `list of ints`, starting from `0`, representing
+          the ID of the screen the widget should appear on. Alternatively, it
+          can be set to `all` if the widget should appear on all the screens.
+        '';
       };
       panelIcon = {
         icon = lib.mkOption {

--- a/modules/widgets/system-monitor.nix
+++ b/modules/widgets/system-monitor.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib) mkOption types;
   inherit (import ./lib.nix { inherit lib; }) configValueType;
-  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType screenType;
 
   # KDE expects a key/value pair like this:
   # ```ini
@@ -63,6 +63,16 @@ in
           height = 500;
         };
         description = "The size of the widget. (Only for desktop widget)";
+      };
+      screen = lib.mkOption {
+        type = screenType;
+        default = null;
+        description = ''
+          The screen the widget should appear on. (Only for desktop widget)
+          Can be an `int`, or a `list of ints`, starting from `0`, representing
+          the ID of the screen the widget should appear on. Alternatively, it
+          can be set to `all` if the widget should appear on all the screens.
+        '';
       };
       title = mkOption {
         type = with types; nullOr str;

--- a/modules/widgets/system-tray.nix
+++ b/modules/widgets/system-tray.nix
@@ -2,7 +2,7 @@
 let
   inherit (lib) mkOption types;
   inherit (import ./lib.nix { inherit lib; }) configValueType;
-  inherit (import ./default.nix { inherit lib; }) positionType sizeType;
+  inherit (import ./default.nix { inherit lib; }) positionType sizeType screenType;
 
   mkBoolOption =
     description:
@@ -36,6 +36,16 @@ in
             height = 500;
           };
           description = "The size of the widget. (Only for desktop widget)";
+        };
+        screen = lib.mkOption {
+          type = screenType;
+          default = null;
+          description = ''
+            The screen the widget should appear on. (Only for desktop widget)
+            Can be an `int`, or a `list of ints`, starting from `0`, representing
+            the ID of the screen the widget should appear on. Alternatively, it
+            can be set to `all` if the widget should appear on all the screens.
+          '';
         };
         pin = mkBoolOption "Whether the popup should remain open when another window is activated.";
 


### PR DESCRIPTION
This adds a per-widget option to control which screen it renders on (requested previously as part of https://github.com/nix-community/plasma-manager/issues/515#issue-3308268191)

I am not very familiar with the codebase or the Nix language, so I'm not perfectly confident in the approach. Please let me know if there are improvements to be made.