### PR TITLE
Fix CI and evaluation errors

### DIFF
--- a/docs/plasma-manager-options.nix
+++ b/docs/plasma-manager-options.nix
@@ -43,8 +43,7 @@ stdenv.mkDerivation {
       --style style.css \
       --script highlightjs/highlight.pack.js \
       --script highlightjs/loader.js \
-      --toc-depth 1 \
-      --section-toc-depth 1 \
+      --sidebar-depth 1 \
       manual.md \
       out/index.xhtml
   '';

--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,7 @@
       devShells = forAllSystems (system: {
         default = nixpkgsFor.${system}.mkShell {
           buildInputs = with nixpkgsFor.${system}; [
-            nixfmt-rfc-style
+            nixfmt
             ruby
             ruby.devdoc
             (python3.withPackages (pyPkgs: [

--- a/modules/apps/okular.nix
+++ b/modules/apps/okular.nix
@@ -5,16 +5,6 @@
   ...
 }:
 
-let
-  getIndexFromEnum =
-    enum: value:
-    if value == null then
-      null
-    else
-      lib.lists.findFirstIndex (x: x == value)
-        (throw "getIndexFromEnum (okular): Value ${value} isn't present in the enum. This is a bug.")
-        enum;
-in
 {
   options.programs.okular = {
     enable = lib.mkEnableOption ''
@@ -78,12 +68,17 @@ in
 
       zoomMode =
         let
-          enumVals = [
+          values = [
             "100%"
             "fitWidth"
             "fitPage"
             "autoFit"
           ];
+          getIndexInEnum =
+            enum: value:
+            lib.lists.findFirstIndex (x: x == value)
+              (throw "getIndexInEnum: ${value} is not present in the enum '${toString enum}'. This is a bug.")
+              enum;
         in
         lib.mkOption {
           description = ''
@@ -91,8 +86,8 @@ in
             For those files which were opened before the previous zoom mode is applied.
           '';
           default = null;
-          type = with lib.types; nullOr (enum enumVals);
-          apply = getIndexFromEnum enumVals;
+          type = with lib.types; nullOr (enum values);
+          apply = x: if x == null then null else getIndexInEnum values x;
         };
 
       obeyDrm = lib.mkOption {

--- a/modules/apps/okular.nix
+++ b/modules/apps/okular.nix
@@ -15,7 +15,6 @@ let
         (throw "getIndexFromEnum (okular): Value ${value} isn't present in the enum. This is a bug.")
         enum;
 in
-with lib.types;
 {
   options.programs.okular = {
     enable = lib.mkEnableOption ''
@@ -43,36 +42,38 @@ with lib.types;
       smoothScrolling = lib.mkOption {
         description = "Whether to use smooth scrolling.";
         default = null;
-        type = nullOr bool;
+        type = with lib.types; nullOr bool;
       };
 
       showScrollbars = lib.mkOption {
         description = "Whether to show scrollbars in the document viewer.";
         default = null;
-        type = nullOr bool;
+        type = with lib.types; nullOr bool;
       };
 
       openFileInTabs = lib.mkOption {
         description = "Whether to open files in tabs.";
         default = null;
-        type = nullOr bool;
+        type = with lib.types; nullOr bool;
       };
 
       viewContinuous = lib.mkOption {
         description = "Whether to open in continous mode by default.";
         default = null;
-        type = nullOr bool;
+        type = with lib.types; nullOr bool;
       };
 
       viewMode = lib.mkOption {
         description = "The view mode for the pages.";
         default = null;
-        type = nullOr (enum [
-          "Single"
-          "Facing"
-          "FacingFirstCentered"
-          "Summary"
-        ]);
+        type =
+          with lib.types;
+          nullOr (enum [
+            "Single"
+            "Facing"
+            "FacingFirstCentered"
+            "Summary"
+          ]);
       };
 
       zoomMode =
@@ -90,7 +91,7 @@ with lib.types;
             For those files which were opened before the previous zoom mode is applied.
           '';
           default = null;
-          type = nullOr (enum enumVals);
+          type = with lib.types; nullOr (enum enumVals);
           apply = getIndexFromEnum enumVals;
         };
 
@@ -101,7 +102,7 @@ with lib.types;
           Note that in some configurations of Okular, this option is not available.
         '';
         default = null;
-        type = nullOr bool;
+        type = with lib.types; nullOr bool;
       };
 
       mouseMode = lib.mkOption {
@@ -117,52 +118,54 @@ with lib.types;
           - `Magnifier`: Activates the magnifier with left mouse button.
         '';
         default = null;
-        type = nullOr (enum [
-          "Browse"
-          "Zoom"
-          "RectSelect"
-          "TextSelect"
-          "TableSelect"
-          "Magnifier"
-          "TrimSelect"
-        ]);
+        type =
+          with lib.types;
+          nullOr (enum [
+            "Browse"
+            "Zoom"
+            "RectSelect"
+            "TextSelect"
+            "TableSelect"
+            "Magnifier"
+            "TrimSelect"
+          ]);
       };
 
       showMenuBar = lib.mkOption {
         description = "Whether to show the menu bar.";
         default = null;
-        type = nullOr bool;
+        type = with lib.types; nullOr bool;
       };
       showSidebar = lib.mkOption {
         description = "Whether to show the sidebar.";
         default = null;
-        type = nullOr bool;
+        type = with lib.types; nullOr bool;
       };
       lockSidebar = lib.mkOption {
         description = "Whether to lock the sidebar from being toggled.";
         default = null;
-        type = nullOr bool;
+        type = with lib.types; nullOr bool;
       };
       fullScreen = lib.mkOption {
         description = "Whether to open in fullscreen by default.";
         default = null;
-        type = nullOr bool;
+        type = with lib.types; nullOr bool;
       };
       useCustomBackgroundColor = lib.mkOption {
         description = "Whether to set a custom background color (the color around the displayed page). By default, the Qt™ toolkit color is used when this option is unchecked. ";
         default = null;
-        type = nullOr bool;
+        type = with lib.types; nullOr bool;
       };
       backgroundColor = lib.mkOption {
         description = "The RGB color that will fill the part of the screen not covered by the page when on presentation mode.";
         default = null;
         example = "255,255,255";
-        type = nullOr str;
+        type = with lib.types; nullOr str;
       };
       colorScheme = lib.mkOption {
         description = "The color scheme used for the user interface. This does not affect the colors of the documents.";
         default = null;
-        type = nullOr str;
+        type = with lib.types; nullOr str;
       };
     };
 
@@ -172,7 +175,7 @@ with lib.types;
       highlightLinks = lib.mkOption {
         description = "Whether to draw borders around links.";
         default = null;
-        type = nullOr bool;
+        type = with lib.types; nullOr bool;
       };
 
       changeColors = {
@@ -182,50 +185,52 @@ with lib.types;
         mode = lib.mkOption {
           description = "Mode used to change the colors.";
           default = null;
-          type = nullOr (enum [
-            # Inverts colors, including hue
-            "Inverted"
-            # Change background color (see option below)
-            "Paper"
-            # Change light and dark colors (see options below)
-            "Recolor"
-            # Change to black & white colors (see options below)
-            "BlackWhite"
-            # Invert lightness but leave hue and saturation
-            "InvertLightness"
-            # Like InvertLightness, but slightly more contrast
-            "InvertLumaSymmetric"
-            # Like InvertLightness, but much more contrast
-            "InvertLuma"
-            # Shift hue of all colors by 120 degrees
-            "HueShiftPositive"
-            # Shift hue of all colors by 240 degrees
-            "HueShiftNegative"
-          ]);
+          type =
+            with lib.types;
+            nullOr (enum [
+              # Inverts colors, including hue
+              "Inverted"
+              # Change background color (see option below)
+              "Paper"
+              # Change light and dark colors (see options below)
+              "Recolor"
+              # Change to black & white colors (see options below)
+              "BlackWhite"
+              # Invert lightness but leave hue and saturation
+              "InvertLightness"
+              # Like InvertLightness, but slightly more contrast
+              "InvertLumaSymmetric"
+              # Like InvertLightness, but much more contrast
+              "InvertLuma"
+              # Shift hue of all colors by 120 degrees
+              "HueShiftPositive"
+              # Shift hue of all colors by 240 degrees
+              "HueShiftNegative"
+            ]);
         };
         paperColor = lib.mkOption {
           description = "Paper color in RGB. Used for the `Paper` mode.";
           default = null;
           example = "255,255,255";
-          type = nullOr str;
+          type = with lib.types; nullOr str;
         };
         recolorBackground = lib.mkOption {
           description = "New background color in RGB. Used for the `Recolor` mode.";
           default = null;
           example = "0,0,0";
-          type = nullOr str;
+          type = with lib.types; nullOr str;
         };
         recolorForeground = lib.mkOption {
           description = "New foreground color in RGB. Used for the `Recolor` mode.";
           default = null;
           example = "255,255,255";
-          type = nullOr str;
+          type = with lib.types; nullOr str;
         };
         blackWhiteContrast = lib.mkOption {
           description = "New contrast strength. Used for the `BlackWhite` mode.";
           default = null;
           example = 4;
-          type = nullOr (ints.between 2 6);
+          type = with lib.types; nullOr (ints.between 2 6);
         };
         blackWhiteThreshold = lib.mkOption {
           description = ''
@@ -235,7 +240,7 @@ with lib.types;
           '';
           default = null;
           example = 127;
-          type = nullOr (numbers.between 2 253);
+          type = with lib.types; nullOr (numbers.between 2 253);
         };
       };
     };
@@ -246,18 +251,20 @@ with lib.types;
       enableTransparencyEffects = lib.mkOption {
         description = "Whether to enable transparancy effects. This may increase CPU usage.";
         default = null;
-        type = nullOr bool;
+        type = with lib.types; nullOr bool;
       };
 
       memoryUsage = lib.mkOption {
         description = "Memory usage profile for Okular. This may impact the speed performance of Okular, as it determines how many computation results are kept in memory.";
         default = null;
-        type = nullOr (enum [
-          "Low"
-          "Normal"
-          "Aggressive"
-          "Greedy"
-        ]);
+        type =
+          with lib.types;
+          nullOr (enum [
+            "Low"
+            "Normal"
+            "Aggressive"
+            "Greedy"
+          ]);
       };
     };
   };

--- a/modules/apps/okular.nix
+++ b/modules/apps/okular.nix
@@ -325,7 +325,14 @@
           "ShowSidebar" = applyIfSet gen.showSidebar;
         };
         "MainWindow" = {
-          "MenuBar" = applyIfSet (if gen.showMenuBar then "Enabled" else "Disabled");
+          "MenuBar" = applyIfSet (
+            if gen.showMenuBar == null then
+              null
+            else if gen.showMenuBar then
+              "Enabled"
+            else
+              "Disabled"
+          );
         };
         "UiSettings" = {
           "ColorScheme" = applyIfSet gen.colorScheme;

--- a/modules/apps/okular.nix
+++ b/modules/apps/okular.nix
@@ -6,7 +6,6 @@
 }:
 
 let
-  cfg = config.programs.okular;
   getIndexFromEnum =
     enum: value:
     if value == null then
@@ -263,87 +262,73 @@ with lib.types;
     };
   };
 
-  config = {
-    home.packages = lib.mkIf (cfg.enable && cfg.package != null) [ cfg.package ];
-  };
-
-  # ==================================
-  #     WRITING THE OKULARPARTRC
-  config.programs.plasma.configFile."okularpartrc" = lib.mkIf cfg.enable (
+  config =
     let
+      cfg = config.programs.okular;
       gen = cfg.general;
       acc = cfg.accessibility;
       perf = cfg.performance;
+
       applyIfSet = opt: lib.mkIf (opt != null) opt;
     in
-    {
-      "PageView" = {
-        "SmoothScrolling" = applyIfSet gen.smoothScrolling;
-        "ShowScrollBars" = applyIfSet gen.showScrollbars;
-        "ViewContinuous" = applyIfSet gen.viewContinuous;
-        "ViewMode" = applyIfSet gen.viewMode;
-        "MouseMode" = applyIfSet gen.mouseMode;
-        "UseCustomBackgroundColor" = applyIfSet gen.useCustomBackgroundColor;
-        "BackgroundColor" = applyIfSet gen.backgroundColor;
+    lib.mkIf cfg.enable {
+
+      home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+      programs.plasma.configFile."okularpartrc" = {
+        "PageView" = {
+          "SmoothScrolling" = applyIfSet gen.smoothScrolling;
+          "ShowScrollBars" = applyIfSet gen.showScrollbars;
+          "ViewContinuous" = applyIfSet gen.viewContinuous;
+          "ViewMode" = applyIfSet gen.viewMode;
+          "MouseMode" = applyIfSet gen.mouseMode;
+          "UseCustomBackgroundColor" = applyIfSet gen.useCustomBackgroundColor;
+          "BackgroundColor" = applyIfSet gen.backgroundColor;
+        };
+        "Zoom" = {
+          "ZoomMode" = applyIfSet gen.zoomMode;
+        };
+        "Core General" = {
+          "ObeyDRM" = applyIfSet gen.obeyDrm;
+        };
+        "General" = {
+          "ShellOpenFileInTabs" = applyIfSet gen.openFileInTabs;
+        };
+        "Document" = {
+          "ChangeColors" = applyIfSet acc.changeColors.enable;
+          "RenderMode" = applyIfSet acc.changeColors.mode;
+          "PaperColor" = applyIfSet acc.changeColors.paperColor;
+        };
+        "Dlg Accessibility" = {
+          "HighlightLinks" = applyIfSet acc.highlightLinks;
+          "RecolorBackground" = applyIfSet acc.changeColors.recolorBackground;
+          "RecolorForeground" = applyIfSet acc.changeColors.recolorForeground;
+          "BWContrast" = applyIfSet acc.changeColors.blackWhiteContrast;
+          "BWThreshold" = applyIfSet acc.changeColors.blackWhiteThreshold;
+        };
+        "Core Performance" = {
+          "MemoryLevel" = applyIfSet perf.memoryUsage;
+        };
+        "Dlg Performance" = {
+          "EnableCompositing" = applyIfSet perf.enableTransparencyEffects;
+        };
       };
 
-      "Zoom" = {
-        "ZoomMode" = applyIfSet gen.zoomMode;
-      };
-      "Core General" = {
-        "ObeyDRM" = applyIfSet gen.obeyDrm;
-      };
-
-      "General" = {
-        "ShellOpenFileInTabs" = applyIfSet gen.openFileInTabs;
-      };
-
-      "Document" = {
-        "ChangeColors" = applyIfSet acc.changeColors.enable;
-        "RenderMode" = applyIfSet acc.changeColors.mode;
-        "PaperColor" = applyIfSet acc.changeColors.paperColor;
-      };
-
-      "Dlg Accessibility" = {
-        "HighlightLinks" = applyIfSet acc.highlightLinks;
-        "RecolorBackground" = applyIfSet acc.changeColors.recolorBackground;
-        "RecolorForeground" = applyIfSet acc.changeColors.recolorForeground;
-        "BWContrast" = applyIfSet acc.changeColors.blackWhiteContrast;
-        "BWThreshold" = applyIfSet acc.changeColors.blackWhiteThreshold;
+      programs.plasma.configFile."okularrc" = {
+        "Desktop Entry" = {
+          "FullScreen" = applyIfSet gen.fullScreen;
+        };
+        "General" = {
+          "LockSidebar" = applyIfSet gen.lockSidebar;
+          "ShowSidebar" = applyIfSet gen.showSidebar;
+        };
+        "MainWindow" = {
+          "MenuBar" = applyIfSet (if gen.showMenuBar then "Enabled" else "Disabled");
+        };
+        "UiSettings" = {
+          "ColorScheme" = applyIfSet gen.colorScheme;
+        };
       };
 
-      "Core Performance" = {
-        "MemoryLevel" = applyIfSet perf.memoryUsage;
-      };
-
-      "Dlg Performance" = {
-        "EnableCompositing" = applyIfSet perf.enableTransparencyEffects;
-      };
-    }
-  );
-
-  config.programs.plasma.configFile."okularrc" = lib.mkIf cfg.enable (
-    let
-      gen = cfg.general;
-      applyIfSet = opt: lib.mkIf (opt != null) opt;
-    in
-    {
-      "Desktop Entry" = {
-        "FullScreen" = applyIfSet gen.fullScreen;
-      };
-
-      "General" = {
-        "LockSidebar" = applyIfSet gen.lockSidebar;
-        "ShowSidebar" = applyIfSet gen.showSidebar;
-      };
-
-      "MainWindow" = {
-        "MenuBar" = applyIfSet (if gen.showMenuBar then "Enabled" else "Disabled");
-      };
-
-      "UiSettings" = {
-        "ColorScheme" = applyIfSet gen.colorScheme;
-      };
-    }
-  );
+    };
 }

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,4 +1,4 @@
-[formatter.nixfmt-rfc-style]
+[formatter.nixfmt]
 command = "nixfmt"
 includes = ["*.nix"]
 


### PR DESCRIPTION
CI and config evaluation throw various errors which this PR fixes:

- chore(nix-render-docs): `--toc-depth` and `--section-toc-depth` have been renamed to `--sidebar-depth`.
- chore(ci): replace `pkgs.nixfmt-rfc-style` by `pkgs.nixfmt` since the RFC style was finalized and adopted.
- refactor(okular):
  - combine `config` attributes to enable local, shared let-bindings and to require a single `lib.mkIf cfg.enable` guard only.
  - use `with lib.types;` locally since usage of `with <attrs>;` in a big scope is discouraged.
  - float `getIndexFromEnum` to its use site
- fix(okular): handle `general.showMenuBar == null`; otherwise evaluation of the Okular module fails.
