### PR TITLE
refactor(konsole): streamline the module

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -45,8 +45,7 @@ let
       options = builtins.removeAttrs opts [ "_module" ];
     in
     pkgs.buildPackages.nixosOptionsDoc {
-      inherit options;
-      inherit transformOptions;
+      inherit options transformOptions;
       warningsAreErrors = false;
     }
   );

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -66,4 +66,10 @@ in
     advancedSettingsType
     coercedSettingsType
     ;
+
+  attrsWith' =
+    placeholder: elemType:
+    lib.types.attrsWith {
+      inherit elemType placeholder;
+    };
 }

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -61,7 +61,9 @@ let
     coercedTo basicSettingsType (value: { inherit value; }) advancedSettingsType;
 in
 {
-  inherit basicSettingsType;
-  inherit advancedSettingsType;
-  inherit coercedSettingsType;
+  inherit
+    basicSettingsType
+    advancedSettingsType
+    coercedSettingsType
+    ;
 }

--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -13,63 +13,97 @@ let
   iniFormat = pkgs.formats.ini { };
 
   cfg = config.programs.konsole;
-  profilesSubmodule = {
-    options = {
-      name = lib.mkOption {
-        type = with lib.types; nullOr str;
-        default = null;
-        description = ''
-          Name of the profile. Defaults to the attribute name.
-        '';
-      };
-      colorScheme = lib.mkOption {
-        type = with lib.types; nullOr str;
-        default = null;
-        example = "Catppuccin-Mocha";
-        description = ''
-          Color scheme the profile will use. You can check the files you can
-          use in `$HOME/.local/share/konsole` or `/run/current-system/sw/share/konsole`.
-          You might also add a custom color scheme using
-          `programs.konsole.customColorSchemes`.
-        '';
-      };
-      command = lib.mkOption {
-        type = with lib.types; nullOr str;
-        default = null;
-        example = lib.literalExpression ''"''${pkgs.zsh}/bin/zsh"'';
-        description = ''
-          The command to run on new sessions.
-        '';
-      };
-      font = {
+
+  mkColorScheme =
+    name: value:
+    lib.attrsets.nameValuePair "konsole/${name}.colorscheme" {
+      source =
+        if builtins.isPath value then value else iniFormat.generate "konsole-${name}.colorscheme" value;
+    };
+
+  profileType =
+    { config, name, ... }:
+    {
+      imports = [
+        (lib.mkRenamedOptionModule [ "extraConfig" ] [ "settings" ])
+      ];
+
+      options = {
         name = lib.mkOption {
           type = lib.types.str;
-          example = "Hack";
+          default = name;
+          defaultText = "<name>";
           description = ''
-            Name of the font the profile should use.
+            Name of the profile. Defaults to the attribute name.
           '';
         };
-        size = lib.mkOption {
-          # The konsole ui gives you a limited range
-          type = (lib.types.numbers.between 4 128);
-          default = 10;
-          example = 12;
+        colorScheme = lib.mkOption {
+          type = with lib.types; nullOr str;
+          default = null;
+          example = "Catppuccin-Mocha";
           description = ''
-            Size of the font.
-            Due to Konsole limitations, only a limited range of sizes is possible.
+            Color scheme the profile will use. You can check the files you can
+            use in `$HOME/.local/share/konsole` or `/run/current-system/sw/share/konsole`.
+            You might also add a custom color scheme using
+            `programs.konsole.customColorSchemes`.
+          '';
+        };
+        command = lib.mkOption {
+          type = with lib.types; nullOr str;
+          default = null;
+          example = lib.literalExpression ''"''${pkgs.zsh}/bin/zsh"'';
+          description = ''
+            The command to run on new sessions.
+          '';
+        };
+        font = {
+          name = lib.mkOption {
+            type = lib.types.str;
+            example = "Hack";
+            description = ''
+              Name of the font the profile should use.
+            '';
+          };
+          size = lib.mkOption {
+            # The konsole ui gives you a limited range
+            type = (lib.types.numbers.between 4 128);
+            default = 10;
+            example = 12;
+            description = ''
+              Size of the font.
+              Due to Konsole limitations, only a limited range of sizes is possible.
+            '';
+          };
+        };
+        settings = lib.mkOption {
+          type = attrsWith' "section" (attrsWith' "setting" basicSettingsType);
+          default = { };
+          example.Scrolling.ScrollBarPosition = 2;
+          description = ''
+            Settings that will be written to
+            `''${config.xdg.dataHome}/konsole/''${profile.name}.profile`.
           '';
         };
       };
-      extraConfig = lib.mkOption {
-        type = attrsWith' "section" (attrsWith' "setting" basicSettingsType);
-        default = { };
-        example = { };
-        description = ''
-          Extra keys to manually add to the profile.
-        '';
+
+      config.settings = {
+        General = {
+          Name = config.name;
+          Parent = "FALLBACK/"; # Konsole generated profiles seem to always have this
+        }
+        // lib.optionalAttrs (config.command != null) { Command = config.command; };
+        Appearance = {
+          Font = "${config.font.name},${toString config.font.size}";
+        }
+        // lib.optionalAttrs (config.colorScheme != null) { ColorScheme = config.colorScheme; };
       };
     };
-  };
+
+  mkProfile =
+    _: profile:
+    lib.nameValuePair "konsole/${profile.name}.profile" {
+      text = lib.generators.toINI { } profile.settings;
+    };
 in
 
 {
@@ -89,7 +123,7 @@ in
     };
 
     profiles = lib.mkOption {
-      type = with lib.types; nullOr (attrsOf (submodule profilesSubmodule));
+      type = with lib.types; nullOr (attrsOf (submodule profileType));
       default = { };
       description = ''
         Plasma profiles to generate.
@@ -97,12 +131,7 @@ in
     };
 
     customColorSchemes = lib.mkOption {
-      type =
-        with lib.types;
-        attrsOf (oneOf [
-          path
-          iniFormat.type
-        ]);
+      type = with lib.types; attrsOf (either path iniFormat.type);
       default = { };
       example = lib.literalExpression ''
         {
@@ -196,49 +225,8 @@ in
     ];
 
     xdg.dataFile = lib.mkMerge [
-      (lib.mkIf (cfg.profiles != { }) (
-        lib.mkMerge (
-          lib.mapAttrsToList (
-            attrName: profile:
-            let
-              # Use the name from the name option if it's set
-              profileName = if builtins.isString profile.name then profile.name else attrName;
-              fontString = lib.mkIf (
-                profile.font.name != null
-              ) "${profile.font.name},${builtins.toString profile.font.size}";
-            in
-            {
-              "konsole/${profileName}.profile".text = lib.generators.toINI { } (
-                lib.recursiveUpdate {
-                  "General" = (
-                    {
-                      "Name" = profileName;
-                      # Konsole generated profiles seem to always have this
-                      "Parent" = "FALLBACK/";
-                    }
-                    // (lib.optionalAttrs (profile.command != null) { "Command" = profile.command; })
-                  );
-                  "Appearance" = (
-                    {
-                      # If the font size is not set we leave a comma at the end after the name
-                      # We should fix this probs but konsole doesn't seem to care ¯\_(ツ)_/¯
-                      "Font" = fontString.content;
-                    }
-                    // (lib.optionalAttrs (profile.colorScheme != null) { "ColorScheme" = profile.colorScheme; })
-                  );
-                } profile.extraConfig
-              );
-            }
-          ) cfg.profiles
-        )
-      ))
-      (lib.attrsets.mapAttrs' (
-        name: value:
-        lib.attrsets.nameValuePair "konsole/${name}.colorscheme" {
-          source =
-            if builtins.isPath value then value else iniFormat.generate "konsole-${name}.colorscheme" value;
-        }
-      ) cfg.customColorSchemes)
+      (lib.mapAttrs' mkColorScheme cfg.customColorSchemes)
+      (lib.mapAttrs' mkProfile cfg.profiles)
     ];
   };
 }

--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -5,7 +5,10 @@
   ...
 }:
 let
-  inherit (import ../../lib/types.nix { inherit config lib; }) basicSettingsType;
+  inherit (import ../../lib/types.nix { inherit config lib; })
+    attrsWith'
+    basicSettingsType
+    ;
 
   iniFormat = pkgs.formats.ini { };
 
@@ -58,7 +61,7 @@ let
         };
       };
       extraConfig = lib.mkOption {
-        type = with lib.types; attrsOf (attrsOf basicSettingsType);
+        type = attrsWith' "section" (attrsWith' "setting" basicSettingsType);
         default = { };
         example = { };
         description = ''
@@ -166,7 +169,7 @@ in
     };
 
     extraConfig = lib.mkOption {
-      type = with lib.types; attrsOf (attrsOf basicSettingsType);
+      type = attrsWith' "section" (attrsWith' "setting" basicSettingsType);
       default = { };
       description = ''
         Extra config to add to the `konsolerc`.

--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -5,13 +5,7 @@
   ...
 }:
 let
-  inherit
-    (import ../../lib/types.nix {
-      inherit lib;
-      inherit config;
-    })
-    basicSettingsType
-    ;
+  inherit (import ../../lib/types.nix { inherit config lib; }) basicSettingsType;
 
   iniFormat = pkgs.formats.ini { };
 

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -8,13 +8,7 @@
 
 let
   inherit (import ../lib/writeconfig.nix { inherit lib pkgs config; }) writeConfig;
-  inherit
-    (import ../lib/types.nix {
-      inherit lib;
-      inherit config;
-    })
-    coercedSettingsType
-    ;
+  inherit (import ../lib/types.nix { inherit config lib; }) coercedSettingsType;
 
   # Helper function to prepend the appropriate path prefix (e.g. XDG_CONFIG_HOME) to file
   prependPath =

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -8,7 +8,7 @@
 
 let
   inherit (import ../lib/writeconfig.nix { inherit lib pkgs config; }) writeConfig;
-  inherit (import ../lib/types.nix { inherit config lib; }) coercedSettingsType;
+  inherit (import ../lib/types.nix { inherit config lib; }) coercedSettingsType attrsWith';
 
   # Helper function to prepend the appropriate path prefix (e.g. XDG_CONFIG_HOME) to file
   prependPath =
@@ -23,7 +23,12 @@ let
     // (prependPath config.xdg.configHome plasmaCfg.configFile)
     // (prependPath config.xdg.dataHome plasmaCfg.dataFile);
 
-  fileSettingsType = with lib.types; attrsOf (attrsOf (attrsOf coercedSettingsType));
+  fileSettingsType = lib.pipe coercedSettingsType [
+    (attrsWith' "section")
+    (attrsWith' "path")
+    (attrsWith' "setting")
+  ]
+  ;
 
   ##############################################################################
   # Generate a script that will use write_config.py to update all

--- a/modules/panels.nix
+++ b/modules/panels.nix
@@ -239,19 +239,14 @@ in
       programs.plasma.startup.desktopScript."panels" = (
         lib.mkIf anyPanelSet (
           let
-            anyNonDefaultScreens = ((builtins.any (panel: panel.screen != null)) cfg.panels);
+            anyNonDefaultScreens = builtins.any (panel: panel.screen != null) cfg.panels;
             panelPreCMD = ''
               # We delete plasma-org.kde.plasma.desktop-appletsrc to hinder it
               # growing indefinitely. See:
               # https://github.com/nix-community/plasma-manager/issues/76
               [ -f ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc ] && rm ${config.xdg.configHome}/plasma-org.kde.plasma.desktop-appletsrc
             '';
-            panelLayoutStr = (
-              import ../lib/panel.nix {
-                inherit lib;
-                inherit config;
-              }
-            );
+            panelLayoutStr = import ../lib/panel.nix { inherit config lib; };
             panelPostCMD = (
               if anyNonDefaultScreens then
                 ''

--- a/modules/search-plugins/web-search-keywords.nix
+++ b/modules/search-plugins/web-search-keywords.nix
@@ -103,7 +103,7 @@ in
         };
       };
       default = { };
-      type = with lib.types; attrsOf webSearchKeyword;
+      type = lib.types.attrsOf webSearchKeyword;
     };
 
   };

--- a/modules/shortcuts.nix
+++ b/modules/shortcuts.nix
@@ -8,11 +8,7 @@
 {
   options.programs.plasma =
     let
-      attrsWith' =
-        placeholder: elemType:
-        lib.types.attrsWith {
-          inherit elemType placeholder;
-        };
+      inherit (import ../lib/types.nix { inherit config lib; }) attrsWith';
       keys = with lib.types; either str (listOf str);
     in
     {

--- a/modules/widgets/system-monitor.nix
+++ b/modules/widgets/system-monitor.nix
@@ -188,8 +188,7 @@ in
         config = lib.filterAttrsRecursive (_: v: v != null) (
           lib.recursiveUpdate {
             Appearance = {
-              inherit title;
-              inherit showTitle;
+              inherit showTitle title;
               chartFace = displayStyle;
             };
             Sensors = {


### PR DESCRIPTION
## Description

This PR streamlines the Konsole module:

- Remove `profiles.*.font.name` null checks since this is already caught by the option type.
- Remove redundant `lib.mkMerge`s.
- Set the `profiles.<name>.name` option default to `<name>`.
- Use the submodule to merge `profiles.*.extraConfig` with settings derived from `profiles.*.(colorScheme|command|font|name)`.
- Rename `profiles.*.extraConfig` to `profiles.*.settings` to match the typical naming of RFC42-style options.

While at it, I also did two small treewide refactorings:
- Combine adjacent `inherit`s.
- Customize the `attrsOf` placeholder texts.

## Backwards Compatibility

To the best of my knowledge, these changes are backwards-compatible with one exception.

Merging `profiles.*.settings` with the other `profiles.*` options may result into conflicting definitions if `profiles.*.settings` contains definitions that are derived from the other options, e.g. `General.Name`, which requires the user to explicitly override those. However, I personally prefer explicit overrides to implicit overrides.

## Testing

I successfully build my own configuration against these changes.
