### PR TITLE
konsole: fix passing store path to customColorSchemes

### DIFF
--- a/modules/apps/konsole.nix
+++ b/modules/apps/konsole.nix
@@ -239,7 +239,10 @@ in
         name: value:
         lib.attrsets.nameValuePair "konsole/${name}.colorscheme" {
           source =
-            if builtins.isPath value then value else iniFormat.generate "konsole-${name}.colorscheme" value;
+            if lib.types.path.check value then
+              value
+            else
+              iniFormat.generate "konsole-${name}.colorscheme" value;
         }
       ) cfg.customColorSchemes)
     ];


### PR DESCRIPTION
Regression from #564 passing store paths for
programs.konsole.customColorSchemes no longer works. builtins.isPath is only true for primitive types and not string interpolated nix store paths (eg. "${pkgs.foo}/bar.colorscheme"). this causes iniFormat.generate to be called for store paths. Instead use lib.types.path.check which uses the same check as lib.types.path (primitive path or strings starting with /)