### PR TITLE
feat(kwin): add per-output virtual desktop option

### DIFF
--- a/modules/kwin.nix
+++ b/modules/kwin.nix
@@ -411,6 +411,15 @@ in
     };
 
     virtualDesktops = {
+      switchIndependentlyPerScreen = lib.mkOption {
+        type = with lib.types; nullOr bool;
+        default = null;
+        description = ''
+          Whether to switch virtual desktops independently for each screen.
+
+          Available in Plasma 6.7 and later.
+        '';
+      };
       rows = lib.mkOption {
         type = with lib.types; nullOr ints.positive;
         default = null;
@@ -879,6 +888,9 @@ in
           })
 
           # Virtual Desktops
+          (lib.mkIf (cfg.kwin.virtualDesktops.switchIndependentlyPerScreen != null) {
+            Windows.PerOutputVirtualDesktops = cfg.kwin.virtualDesktops.switchIndependentlyPerScreen;
+          })
           (lib.mkIf (cfg.kwin.virtualDesktops.number != null) {
             Desktops = lib.mkMerge [
               { Number = cfg.kwin.virtualDesktops.number; }

--- a/test/basic.nix
+++ b/test/basic.nix
@@ -52,6 +52,7 @@ let
                                                   Wayland                       InputMethod        #
     assert  kwinrc              true              Plugins                       somePluginEnabled  #
     assert  kwinrc              A                 org.kde.kdecoration2          ButtonsOnRight     # Set with kwin option
+    assert  kwinrc              true              Windows                       PerOutputVirtualDesktops # Set with kwin option
     assert  kwinrc              MMM               org.kde.kdecoration2          ButtonsOnLeft      # Set with configFile option
     assert  kwinrc              testvalue         testgroup                     testkey            #
   '';
@@ -83,6 +84,7 @@ testers.nixosTest {
           enable = true;
           workspace.clickItemTo = "select";
           kwin.titlebarButtons.right = [ "maximize" ];
+          kwin.virtualDesktops.switchIndependentlyPerScreen = true;
           configFile.kwinrc = {
             testgroup.testkey = "testvalue";
             Plugins.somePluginEnabled = true;


### PR DESCRIPTION
This PR is for introducing an option to plasma manager to switch desktops independently of screen.

- Introduced in Plasma 6.7

<img width="1110" height="810" alt="image" src="https://github.com/user-attachments/assets/f76053eb-1916-494d-8d4b-bbb5a8edd9b2" />
